### PR TITLE
Use resource mgmt query for resource IDs given Envoy labels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,23 @@
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
+          <execution>
+            <id>client-jar</id>
+            <goals><goal>jar</goal></goals>
+            <configuration>
+              <classifier>client</classifier>
+              <includes>
+                <include>**/web/model/**</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -24,8 +24,27 @@ import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.messaging.MonitorEvent;
 import com.rackspace.salus.telemetry.messaging.OperationType;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
-import com.rackspace.salus.telemetry.model.*;
+import com.rackspace.salus.telemetry.model.Monitor;
+import com.rackspace.salus.telemetry.model.Monitor_;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.Resource;
+import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.PropertyMapper;
@@ -40,16 +59,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import javax.persistence.EntityManager;
-import javax.persistence.NoResultException;
-import javax.persistence.PersistenceContext;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
-import javax.validation.Valid;
-import java.util.*;
-import java.util.stream.Stream;
 
 
 @Slf4j
@@ -171,22 +180,22 @@ public class MonitorManagement {
     }
 
     /**
-     * Get a list of resources for the tenant that match the given labels
+     * Get a list of resource IDs for the tenant that match the given labels
      *
      * @param tenantId tenant whose resources are to be found
      * @param labels   labels to be matched
      * @return The list found
      */
-    private List<Resource> getResourcesWithLabels(String tenantId, Map<String, String> labels) {
-        List<Resource> emptyList = new ArrayList<>();
-        String endpoint = "/api/tenant/{tenantId}/resourceLabels";
+    private List<String> getResourcesWithEnvoyLabels(String tenantId, Map<String, String> labels) {
+        List<String> emptyList = new ArrayList<>();
+        String endpoint = "/api/tenant/{tenantId}/resourceIds/withEnvoyLabels";
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(endpoint);
         for (Map.Entry<String, String> e : labels.entrySet()) {
             uriComponentsBuilder.queryParam(e.getKey(), e.getValue());
         }
         String uriString = uriComponentsBuilder.buildAndExpand(tenantId).toUriString();
-        ResponseEntity<List<Resource>> resp = restTemplate.exchange(uriString, HttpMethod.GET, null,
-                new ParameterizedTypeReference<List<Resource>>() {
+        ResponseEntity<List<String>> resp = restTemplate.exchange(uriString, HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<String>>() {
                 });
         if (resp.getStatusCode() != HttpStatus.OK) {
             log.error("get failed on: " + uriString, resp.getStatusCode());
@@ -204,21 +213,18 @@ public class MonitorManagement {
      * @param oldLabels     the old labels that were on the monitor before if this is an update operation
      */
     public void publishMonitor(Monitor monitor, OperationType operationType, Map<String, String> oldLabels) {
-        List<Resource> resources = getResourcesWithLabels(monitor.getTenantId(), monitor.getLabels());
-        List<Resource> oldResources = new ArrayList<>();
+        List<String> resources = getResourcesWithEnvoyLabels(monitor.getTenantId(), monitor.getLabels());
+        List<String> oldResources = new ArrayList<>();
         if (oldLabels != null && !oldLabels.equals(monitor.getLabels())) {
-            oldResources = getResourcesWithLabels(monitor.getTenantId(), oldLabels);
+            oldResources = getResourcesWithEnvoyLabels(monitor.getTenantId(), oldLabels);
         }
         resources.addAll(oldResources);
-        Map<String, Resource> resourceMap = new HashMap<>();
-        // Eliminate duplicate resources
-        for (Resource r : resources) {
-            resourceMap.put(r.getResourceId(), r);
-        }
-        for (String id : resourceMap.keySet()) {
-            Resource r = resourceMap.get(id);
+
+        final Set<String> deduped = new HashSet<>(resources);
+
+        for (String resourceId : deduped) {
             ResourceInfo resourceInfo = envoyResourceManagement
-                    .getOne(monitor.getTenantId(), r.getResourceId()).join().get(0);
+                    .getOne(monitor.getTenantId(), resourceId).join().get(0);
             if (resourceInfo != null) {
                 MonitorEvent monitorEvent = new MonitorEvent()
                         .setFromMonitor(monitor)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ services:
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL5Dialect
     properties:
       hibernate:

--- a/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
@@ -41,7 +41,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.MockBeans;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
@@ -133,14 +132,14 @@ public class MonitorManagementTest {
         monitorList.add(currentMonitor);
         List<ResourceInfo> infoList = new ArrayList<>();
         infoList.add(resourceInfo);
-        List<Resource> resourceList = new ArrayList<>();
-        resourceList.add(resourceEvent.getResource());
+        List<String> resourceIdList = new ArrayList<>();
+        resourceIdList.add(resourceEvent.getResource().getResourceId());
 
         doReturn(restTemplateBuilder).when(restTemplateBuilder).rootUri(anyString());
         doReturn(restTemplate).when(restTemplateBuilder).build();
         doReturn(resp).when(restTemplate).exchange(anyString(), eq(HttpMethod.GET), eq(null), (ParameterizedTypeReference<List<Resource>>) any());
         doReturn(HttpStatus.OK).when(resp).getStatusCode();
-        doReturn(resourceList).when(resp).getBody();
+        doReturn(resourceIdList).when(resp).getBody();
         doReturn("dummyUrl").when(servicesProperties).getResourceManagementUrl();
         when(envoyResourceManagement.getOne(anyString(), anyString()))
                 .thenReturn(CompletableFuture.completedFuture(infoList));


### PR DESCRIPTION
## Resolves

For end to end integration of https://jira.rax.io/browse/SALUS-205

## What

Narrows the Envoy computation to use the resource management query focused on providing just the resource IDs for the given Envoy advertised labels. I originally added the query to temporarily simplify/avoid the object deserialization of a `Resource` via the JDBC query; however, I later realized that monitors should really only use the Envoy advertised labels, which the resource management app takes care of namespacing.

Also for integration of the public API, I added an attached Maven artifact with the `client` qualifier. That will expose just the REST model classes for use by the public API application.