### PR TITLE
Create MonitorManagement label matching query

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -1,0 +1,92 @@
+substitutions:
+  _GCS_CACHE_BUCKET: salus-cache
+  _SALUS_PROJECT: salus-telemetry-monitor-management
+
+steps:
+
+    # This is ugly because of
+    # https://github.com/GoogleContainerTools/jib/issues/1500#issuecomment-466207421
+  - id: FIX_DOCKER
+    name: gcr.io/cloud-builders/mvn
+    waitFor: ['-']
+    dir: /root
+    entrypoint: bash
+    args:
+    - -c
+    - # Links the Docker config to /root/.docker/config.json so that Jib picks it up.
+      # Note that this is only a temporary workaround.
+      # See https://github.com/GoogleContainerTools/jib/pull/1479.
+      |
+      mkdir .docker &&
+      ln -vs $$HOME/.docker/config.json .docker/config.json
+    volumes:
+    - name: user.home
+      path: /root
+
+  # Pull down settings file for Artifactory settings
+  - id: GET_SETTINGS
+    name: 'gcr.io/cloud-builders/gsutil'
+    waitFor: ['-']
+    args: ['cp', 'gs://salus-mavenrepository/m2-settings.xml', '.mvn/settings.xml']
+
+  # Load the cached files from GCS if they exist.
+  - id: PULL_DOWN_CACHE
+    waitFor: ['-']
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    args:
+    - -c
+    - |
+      (
+        gsutil cp gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz /tmp/m2-cache.tar.gz &&
+        tar -xzf /tmp/m2-cache.tar.gz
+      ) || echo 'Cache not found'
+    volumes:
+    - name: user.home
+      path: /root
+
+  - id: DEPLOY
+    name: 'gcr.io/cloud-builders/mvn'
+    args: ['deploy', '-s', '.mvn/settings.xml']
+    volumes:
+    - name: user.home
+      path: /root
+
+  - id: COMPILE_AND_PUSH_CONTAINER
+    name: 'gcr.io/cloud-builders/mvn'
+    env:
+    - 'SHORT_SHA=$SHORT_SHA'
+    args:
+    - compile
+    # Runs the Jib build by using the latest version of the plugin.
+    # To use a specific version, configure the plugin in the pom.xml.
+    - jib:build
+    # Skip Tests since it happened in the previous test
+    - "-Dmaven.test.skip=true"
+    # Ensure we name the image correctly since its not in pom.xml
+    - "-Ddocker.image.prefix=gcr.io/$PROJECT_ID"
+    - "-s"
+    - .mvn/settings.xml
+    volumes:
+    - name: user.home
+      path: /root
+
+  # Saves the files to the GCS cache.
+  - id: PUSH_UP_CACHE
+    waitFor:
+    - COMPILE_AND_PUSH_CONTAINER
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    # Caches the local Maven repository.
+    args:
+    - -c
+    - |
+      set -ex
+      tar -czf /tmp/m2-cache.tar.gz .m2 &&
+      gsutil cp /tmp/m2-cache.tar.gz gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz
+    volumes:
+    - name: user.home
+      path: /root
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,54 @@
+substitutions:
+  _GCS_CACHE_BUCKET: salus-cache
+  _SALUS_PROJECT: salus-telemetry-monitor-management
+
+steps:
+
+  # Pull down settings file for Artifactory settings
+  - id: GET_SETTINGS
+    name: 'gcr.io/cloud-builders/gsutil'
+    waitFor: ['-']
+    args: ['cp', 'gs://salus-mavenrepository/m2-settings.xml', '.mvn/settings.xml']
+
+  # Load the cached files from GCS if they exist.
+  - id: PULL_DOWN_CACHE
+    waitFor: ['-']
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    args:
+    - -c
+    - |
+      (
+        gsutil cp gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz /tmp/m2-cache.tar.gz &&
+        tar -xzf /tmp/m2-cache.tar.gz
+      ) || echo 'Cache not found'
+    volumes:
+    - name: user.home
+      path: /root
+
+  - id: DEPLOY
+    name: 'gcr.io/cloud-builders/mvn'
+    args: ['deploy', '-s', '.mvn/settings.xml']
+    volumes:
+    - name: user.home
+      path: /root
+
+  # Saves the files to the GCS cache.
+  - id: PUSH_UP_CACHE
+    waitFor:
+    - DEPLOY
+    name: gcr.io/cloud-builders/gsutil
+    dir: /root
+    entrypoint: bash
+    # Caches the local Maven repository.
+    args:
+    - -c
+    - |
+      set -ex
+      tar -czf /tmp/m2-cache.tar.gz .m2 &&
+      gsutil cp /tmp/m2-cache.tar.gz gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz
+    volumes:
+    - name: user.home
+      path: /root
+

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,23 @@
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
+          <execution>
+            <id>client-jar</id>
+            <goals><goal>jar</goal></goals>
+            <configuration>
+              <classifier>client</classifier>
+              <includes>
+                <include>**/web/model/**</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -341,19 +341,7 @@ public class MonitorManagement {
      * @param tenantId The tenant associated to the resource
      * @return the list of Monitor's that match the labels
      */
-    public List<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId) throws IllegalArgumentException{
-        /*
-        SELECT * FROM resources where id IN (SELECT id from resource_labels WHERE id IN (select id from resources)
-        AND ((labels = "windows" AND labels_key = "os") OR (labels = "prod" AND labels_key="env")) GROUP BY id
-        HAVING COUNT(id) = 2) AND tenant_id = "aaaad";
-        */
-
-
-        /*
-        two scenarios for testing are envoy comes first or monitor comes first
-
-         */
-
+    public List<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId) throws IllegalArgumentException {
         if(labels.size() == 0) {
             throw new IllegalArgumentException("Labels must be provided for search");
         }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -307,12 +307,12 @@ public class MonitorManagement {
         }
 
         List<Monitor> oldMonitors = null;
-        List<Monitor> monitors = getMonitorsFromLabels(event.getResource().getLabels(), event.getResource().getTenantId(), MatchOptions.MATCH_ALL);
+        List<Monitor> monitors = getMonitorsFromLabels(event.getResource().getLabels(), event.getResource().getTenantId());
         if (monitors == null) {
             monitors = new ArrayList<>();
         }
         if (event.getOldLabels() != null && !event.getOldLabels().equals(event.getResource().getLabels())) {
-            oldMonitors = getMonitorsFromLabels(event.getOldLabels(), event.getResource().getTenantId(), MatchOptions.MATCH_ALL);
+            oldMonitors = getMonitorsFromLabels(event.getOldLabels(), event.getResource().getTenantId());
         }
         if (oldMonitors != null) {
             monitors.addAll(oldMonitors);
@@ -341,7 +341,7 @@ public class MonitorManagement {
      * @param tenantId The tenant associated to the resource
      * @return the list of Monitor's that match the labels
      */
-    public List<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId, MatchOptions option) {
+    public List<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId) throws IllegalArgumentException{
         /*
         SELECT * FROM resources where id IN (SELECT id from resource_labels WHERE id IN (select id from resources)
         AND ((labels = "windows" AND labels_key = "os") OR (labels = "prod" AND labels_key="env")) GROUP BY id
@@ -353,6 +353,10 @@ public class MonitorManagement {
         two scenarios for testing are envoy comes first or monitor comes first
 
          */
+
+        if(labels.size() == 0) {
+            throw new IllegalArgumentException("Labels must be provided for search");
+        }
 
         MapSqlParameterSource paramSource = new MapSqlParameterSource();
         paramSource.addValue("tenantId", tenantId);
@@ -409,9 +413,5 @@ public class MonitorManagement {
         });
 
         return monitors;
-    }
-
-    public static enum MatchOptions {
-        MATCH_SOME, MATCH_ALL;
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -346,7 +346,7 @@ public class MonitorManagement {
      * @param tenantId The tenant associated to the resource
      * @return the list of Monitor's that match the labels
      */
-    public List<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId, MATCH_OPTIONS option) {
+    public List<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId, MatchOptions option) {
         /*
         SELECT * FROM resources where id IN (SELECT id from resource_labels WHERE id IN (select id from resources)
         AND ((labels = "windows" AND labels_key = "os") OR (labels = "prod" AND labels_key="env")) GROUP BY id
@@ -417,7 +417,7 @@ public class MonitorManagement {
         return monitors;
     }
 
-    public static enum MATCH_OPTIONS {
+    public static enum MatchOptions {
         MATCH_SOME, MATCH_ALL;
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -24,11 +24,7 @@ import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.messaging.MonitorEvent;
 import com.rackspace.salus.telemetry.messaging.OperationType;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
-import com.rackspace.salus.telemetry.model.Monitor;
-import com.rackspace.salus.telemetry.model.Monitor_;
-import com.rackspace.salus.telemetry.model.NotFoundException;
-import com.rackspace.salus.telemetry.model.Resource;
-import com.rackspace.salus.telemetry.model.ResourceInfo;
+import com.rackspace.salus.telemetry.model.*;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 
 import java.util.ArrayList;
@@ -379,7 +375,7 @@ public class MonitorManagement {
                             resultSet.getString("labels_key"),
                             resultSet.getString("labels"));
                 }else {
-                    Map<String, String> theseLabels = new HashMap<String, String>();
+                    Map<String, String> theseLabels = new HashMap<>();
                     theseLabels.put(
                             resultSet.getString("labels_key"),
                             resultSet.getString("labels"));
@@ -387,9 +383,9 @@ public class MonitorManagement {
                             .setId(UUID.fromString(resultSet.getString("id")))
                             .setTenantId(resultSet.getString("tenant_id"))
                             .setContent(resultSet.getString("content"))
-                            //.setMonitorName(resultSet.getString("monitor_name"))
-                            //.setSelectorScope(ConfigSelectorScope.valueOf(resultSet.getInt("selector_scope")))
-                            //.setAgentType(AgentType.valueOf(resultSet.getInt("agent_type")))
+                            .setMonitorName(resultSet.getString("monitor_name"))
+                            .setSelectorScope(ConfigSelectorScope.valueOf(resultSet.getString("selector_scope")))
+                            .setAgentType(AgentType.valueOf(resultSet.getString("agent_type")))
                             .setTargetTenant(resultSet.getString("target_tenant"))
                             .setLabels(theseLabels);
                     prevId = resultSet.getString("id");

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -346,7 +346,7 @@ public class MonitorManagement {
      * @param tenantId The tenant associated to the resource
      * @return the list of Monitor's that match the labels
      */
-    public List<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId) {
+    public List<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId, MATCH_OPTIONS option) {
         /*
         SELECT * FROM resources where id IN (SELECT id from resource_labels WHERE id IN (select id from resources)
         AND ((labels = "windows" AND labels_key = "os") OR (labels = "prod" AND labels_key="env")) GROUP BY id
@@ -370,7 +370,14 @@ public class MonitorManagement {
             paramSource.addValue("labelKey"+i, entry.getKey());
             i++;
         }
-        builder.append(" GROUP BY id HAVING COUNT(id) = :i) ORDER BY monitors.id");
+
+        builder.append(" GROUP BY id");
+        //HAVING COUNT(id) = :i)
+        switch(option) {
+            case MATCH_ALL:
+                builder.append("HAVING COUNT(id) = :i");
+        }
+        builder.append(") ORDER BY monitors.id");
         paramSource.addValue("i", i);
 
         NamedParameterJdbcTemplate namedParameterTemplate = new NamedParameterJdbcTemplate(jdbcTemplate.getDataSource());
@@ -379,9 +386,8 @@ public class MonitorManagement {
 
             long prevId = 0;
             Monitor prevMonitor = null;
-            boolean iterate = true;
 
-            while(iterate){
+            do{
                 if(resultSet.getLong("id") == prevId) {
                     prevMonitor.getLabels().put(
                             resultSet.getString("labels_key"),
@@ -405,10 +411,13 @@ public class MonitorManagement {
                     monitors.add(m);
 
                 }
-                iterate = resultSet.next();
-            }
+            } while(resultSet.next());
         });
 
         return monitors;
+    }
+
+    public static enum MATCH_OPTIONS {
+        MATCH_SOME, MATCH_ALL;
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -370,7 +370,7 @@ public class MonitorManagement {
             i++;
         }
 
-        builder.append(" GROUP BY id");
+        builder.append(" GROUP BY id ");
         //HAVING COUNT(id) = :i)
         switch(option) {
             case MATCH_ALL:

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -357,6 +357,7 @@ public class MonitorManagement {
         paramSource.addValue("tenantId", tenantId);//AS r JOIN resource_labels AS rl
         StringBuilder builder = new StringBuilder("SELECT * FROM monitors JOIN monitor_labels AS ml WHERE monitors.id = ml.id AND monitors.id IN ");
         builder.append("(SELECT id from monitor_labels WHERE id IN ( SELECT id FROM monitors WHERE tenant_id = :tenantId) AND ");
+        builder.append(" (SELECT search_labels.id FROM (SELECT id, COUNT(*) AS count FROM monitor_labels GROUP BY id) AS total_labels JOIN (SELECT id, COUNT(*) AS count FROM monitor_labels WHERE ");
 
         int i = 0;
         labels.size();
@@ -369,8 +370,8 @@ public class MonitorManagement {
             paramSource.addValue("labelKey"+i, entry.getKey());
             i++;
         }
-
-        builder.append(" GROUP BY id ");
+        builder.append("GROUP BY id) AS search_labels WHERE total_labels.id = search_labels.id AND (search_labels.count >= total_labels.count OR search_labels.count = :i)");
+        //builder.append(" GROUP BY id ");
         //HAVING COUNT(id) = :i)
         switch(option) {
             case MATCH_ALL:

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -362,7 +362,7 @@ public class MonitorManagement {
             paramSource.addValue("labelKey"+i, entry.getKey());
             i++;
         }
-        builder.append(" GROUP BY id) AS search_labels WHERE total_labels.id = search_labels.id AND (search_labels.count >= total_labels.count OR search_labels.count = :i) GROUP BY search_labels.id)");
+        builder.append(" GROUP BY id) AS search_labels WHERE total_labels.id = search_labels.id AND search_labels.count >= total_labels.count GROUP BY search_labels.id)");
 
         builder.append(") ORDER BY monitors.id");
         paramSource.addValue("i", i);

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -370,15 +370,8 @@ public class MonitorManagement {
             paramSource.addValue("labelKey"+i, entry.getKey());
             i++;
         }
-        builder.append("GROUP BY id) AS search_labels WHERE total_labels.id = search_labels.id AND (search_labels.count >= total_labels.count OR search_labels.count = :i)");
-        //builder.append(" GROUP BY id ");
-        //HAVING COUNT(id) = :i)
-        switch(option) {
-            case MATCH_ALL:
-                builder.append("HAVING COUNT(id) = :i");
-                // AND COUNT(id) >= (SELECT TOTAL(*) FROM monitor_labels WHERE id = m.id)
-                // we need to add something like this to the query to make it work properly
-        }
+        builder.append("GROUP BY id) AS search_labels WHERE total_labels.id = search_labels.id AND (search_labels.count >= total_labels.count OR search_labels.count = :i) GROUP BY search_labels.id)");
+
         builder.append(") ORDER BY monitors.id");
         paramSource.addValue("i", i);
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -24,8 +24,27 @@ import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.messaging.MonitorEvent;
 import com.rackspace.salus.telemetry.messaging.OperationType;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
-import com.rackspace.salus.telemetry.model.*;
+import com.rackspace.salus.telemetry.model.Monitor;
+import com.rackspace.salus.telemetry.model.Monitor_;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.Resource;
+import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.PropertyMapper;
@@ -40,16 +59,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import javax.persistence.EntityManager;
-import javax.persistence.NoResultException;
-import javax.persistence.PersistenceContext;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
-import javax.validation.Valid;
-import java.util.*;
-import java.util.stream.Stream;
 
 
 @Slf4j
@@ -171,22 +180,22 @@ public class MonitorManagement {
     }
 
     /**
-     * Get a list of resources for the tenant that match the given labels
+     * Get a list of resource IDs for the tenant that match the given labels
      *
      * @param tenantId tenant whose resources are to be found
      * @param labels   labels to be matched
      * @return The list found
      */
-    private List<Resource> getResourcesWithLabels(String tenantId, Map<String, String> labels) {
-        List<Resource> emptyList = new ArrayList<>();
-        String endpoint = "/api/tenant/{tenantId}/resourceLabels";
+    private List<String> getResourcesWithEnvoyLabels(String tenantId, Map<String, String> labels) {
+        List<String> emptyList = new ArrayList<>();
+        String endpoint = "/api/tenant/{tenantId}/resourceIds/withEnvoyLabels";
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(endpoint);
         for (Map.Entry<String, String> e : labels.entrySet()) {
             uriComponentsBuilder.queryParam(e.getKey(), e.getValue());
         }
         String uriString = uriComponentsBuilder.buildAndExpand(tenantId).toUriString();
-        ResponseEntity<List<Resource>> resp = restTemplate.exchange(uriString, HttpMethod.GET, null,
-                new ParameterizedTypeReference<List<Resource>>() {
+        ResponseEntity<List<String>> resp = restTemplate.exchange(uriString, HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<String>>() {
                 });
         if (resp.getStatusCode() != HttpStatus.OK) {
             log.error("get failed on: " + uriString, resp.getStatusCode());
@@ -204,21 +213,18 @@ public class MonitorManagement {
      * @param oldLabels     the old labels that were on the monitor before if this is an update operation
      */
     public void publishMonitor(Monitor monitor, OperationType operationType, Map<String, String> oldLabels) {
-        List<Resource> resources = getResourcesWithLabels(monitor.getTenantId(), monitor.getLabels());
-        List<Resource> oldResources = new ArrayList<>();
+        List<String> resources = getResourcesWithEnvoyLabels(monitor.getTenantId(), monitor.getLabels());
+        List<String> oldResources = new ArrayList<>();
         if (oldLabels != null && !oldLabels.equals(monitor.getLabels())) {
-            oldResources = getResourcesWithLabels(monitor.getTenantId(), oldLabels);
+            oldResources = getResourcesWithEnvoyLabels(monitor.getTenantId(), oldLabels);
         }
         resources.addAll(oldResources);
-        Map<String, Resource> resourceMap = new HashMap<>();
-        // Eliminate duplicate resources
-        for (Resource r : resources) {
-            resourceMap.put(r.getResourceId(), r);
-        }
-        for (String id : resourceMap.keySet()) {
-            Resource r = resourceMap.get(id);
+
+        final Set<String> deduped = new HashSet<>(resources);
+
+        for (String resourceId : deduped) {
             ResourceInfo resourceInfo = envoyResourceManagement
-                    .getOne(monitor.getTenantId(), r.getResourceId()).join().get(0);
+                    .getOne(monitor.getTenantId(), resourceId).join().get(0);
             if (resourceInfo != null) {
                 MonitorEvent monitorEvent = new MonitorEvent()
                         .setFromMonitor(monitor)

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApi.java
@@ -119,7 +119,7 @@ public class MonitorApi {
     }
 
     @GetMapping("/tenant/{tenantId}/monitorLabels")
-    public List<Monitor> getResourcesWithLabels(@PathVariable String tenantId,
+    public List<Monitor> getMonitorsWithLabels(@PathVariable String tenantId,
                                                  @RequestBody Map<String, String> labels) {
         return monitorManagement.getMonitorsFromLabels(labels, tenantId);
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApi.java
@@ -121,7 +121,7 @@ public class MonitorApi {
     @GetMapping("/tenant/{tenantId}/monitorLabels")
     public List<Monitor> getResourcesWithLabels(@PathVariable String tenantId,
                                                  @RequestBody Map<String, String> labels) {
-        return monitorManagement.getMonitorsFromLabels(labels, tenantId, MonitorManagement.MatchOptions.MATCH_ALL);
+        return monitorManagement.getMonitorsFromLabels(labels, tenantId);
 
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApi.java
@@ -21,6 +21,7 @@ import com.rackspace.salus.monitor_management.web.model.MonitorCreate;
 import com.rackspace.salus.monitor_management.web.model.MonitorUpdate;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.Monitor;
+import com.rackspace.salus.telemetry.model.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.task.TaskExecutor;
@@ -32,6 +33,8 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import javax.validation.Valid;
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -113,5 +116,12 @@ public class MonitorApi {
     public void delete(@PathVariable String tenantId,
                        @PathVariable UUID uuid) {
         monitorManagement.removeMonitor(tenantId, uuid);
+    }
+
+    @GetMapping("/tenant/{tenantId}/monitorLabels")
+    public List<Resource> getResourcesWithLabels(@PathVariable String tenantId,
+                                                 @RequestBody Map<String, String> labels) {
+        //return monitorManagement.getMonitorsFromLabels(labels, tenantId);
+        return null;
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApi.java
@@ -119,9 +119,9 @@ public class MonitorApi {
     }
 
     @GetMapping("/tenant/{tenantId}/monitorLabels")
-    public List<Resource> getResourcesWithLabels(@PathVariable String tenantId,
+    public List<Monitor> getResourcesWithLabels(@PathVariable String tenantId,
                                                  @RequestBody Map<String, String> labels) {
-        //return monitorManagement.getMonitorsFromLabels(labels, tenantId);
-        return null;
+        return monitorManagement.getMonitorsFromLabels(labels, tenantId, MonitorManagement.MatchOptions.MATCH_ALL);
+
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ services:
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL5Dialect
     properties:
       hibernate:

--- a/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
@@ -380,41 +380,41 @@ public class MonitorManagementTest {
 
     @Test
     public void testMatchMonitorWithSupersetOfLabels() {
-        final Map<String, String> resourceLabels = new HashMap<>();
-        resourceLabels.put("os", "DARWIN");
-        resourceLabels.put("env", "test");
-        resourceLabels.put("architecture", "x86");
-        resourceLabels.put("region", "DFW");
+        final Map<String, String> monitorLabels = new HashMap<>();
+        monitorLabels.put("os", "DARWIN");
+        monitorLabels.put("env", "test");
+        monitorLabels.put("architecture", "x86");
+        monitorLabels.put("region", "DFW");
         final Map<String, String> labels = new HashMap<>();
         labels.put("os", "DARWIN");
         labels.put("env", "test");
 
         MonitorCreate create = podamFactory.manufacturePojo(MonitorCreate.class);
-        create.setLabels(resourceLabels);
+        create.setLabels(monitorLabels);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
         entityManager.flush();
 
-        List<Monitor> resources = monitorManagement.getMonitorsFromLabels(labels, tenantId);
-        assertEquals(1, resources.size()); //make sure we only returned the one value
-        assertEquals(tenantId, resources.get(0).getTenantId());
+        List<Monitor> monitors = monitorManagement.getMonitorsFromLabels(labels, tenantId);
+        assertEquals(1, monitors.size()); //make sure we only returned the one value
+        assertEquals(tenantId, monitors.get(0).getTenantId());
         //assertEquals(create.getResourceId(), resources.get(0).getResourceId());
-        assertEquals(resourceLabels, resources.get(0).getLabels());
+        assertEquals(monitorLabels, monitors.get(0).getLabels());
     }
 
     @Test
     public void testMisMatchMonitorWithSupersetOfLabels() {
-        final Map<String, String> resourceLabels = new HashMap<>();
-        resourceLabels.put("os", "DARWIN");
-        resourceLabels.put("env", "test");
-        resourceLabels.put("architecture", "x86");
-        resourceLabels.put("region", "DFW");
+        final Map<String, String> monitorLabels = new HashMap<>();
+        monitorLabels.put("os", "DARWIN");
+        monitorLabels.put("env", "test");
+        monitorLabels.put("architecture", "x86");
+        monitorLabels.put("region", "DFW");
         final Map<String, String> labels = new HashMap<>();
         labels.put("os", "Windows");
         labels.put("env", "test");
 
         MonitorCreate create = podamFactory.manufacturePojo(MonitorCreate.class);
-        create.setLabels(resourceLabels);
+        create.setLabels(monitorLabels);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
         entityManager.flush();

--- a/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
@@ -328,6 +328,22 @@ public class MonitorManagementTest {
         assertNotNull(monitors);
     }
 
+    @Test
+    public void testMisMatchSpecificCreate() {
+        final Map<String, String> labels = new HashMap<>();
+        labels.put("os", "DARWIN");
+        final Map<String, String> queryLabels = new HashMap<>();
+        queryLabels.put("os", "linux");
+
+        MonitorCreate create = podamFactory.manufacturePojo(MonitorCreate.class);
+        create.setLabels(labels);
+        String tenantId = RandomStringUtils.randomAlphanumeric(10);
+        monitorManagement.createMonitor(tenantId, create);
+        entityManager.flush();
+        List<Monitor> monitors = monitorManagement.getMonitorsFromLabels(queryLabels, tenantId);
+        assertEquals(0, monitors.size());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testEmptyLabelsException() {
         final Map<String, String> labels = new HashMap<>();
@@ -356,7 +372,12 @@ public class MonitorManagementTest {
         List<Monitor> monitors = monitorManagement.getMonitorsFromLabels(labels, tenantId);
         assertEquals(1, monitors.size()); //make sure we only returned the one value
         assertEquals(tenantId, monitors.get(0).getTenantId());
-        //assertEquals(create.get(), resources.get(0).getResourceId());
+        assertEquals(create.getAgentType(), monitors.get(0).getAgentType());
+        assertEquals(create.getContent(), monitors.get(0).getContent());
+        assertEquals(create.getMonitorName(), monitors.get(0).getMonitorName());
+        assertEquals(create.getSelectorScope(), monitors.get(0).getSelectorScope());
+        assertEquals(create.getLabels(), monitors.get(0).getLabels());
+        assertEquals(create.getTargetTenant(), monitors.get(0).getTargetTenant());
     }
 
     @Test
@@ -371,11 +392,35 @@ public class MonitorManagementTest {
         monitorManagement.createMonitor(tenantId, create);
         entityManager.flush();
 
-        List<Monitor> resources = monitorManagement.getMonitorsFromLabels(labels, tenantId);
-        assertEquals(1, resources.size()); //make sure we only returned the one value
-        assertEquals(tenantId, resources.get(0).getTenantId());
-        //assertEquals(create.getResourceId(), resources.get(0).getResourceId());
-        assertEquals(labels, resources.get(0).getLabels());
+        List<Monitor> monitors = monitorManagement.getMonitorsFromLabels(labels, tenantId);
+        assertEquals(1, monitors.size()); //make sure we only returned the one value
+        assertEquals(tenantId, monitors.get(0).getTenantId());
+        assertEquals(create.getAgentType(), monitors.get(0).getAgentType());
+        assertEquals(create.getContent(), monitors.get(0).getContent());
+        assertEquals(create.getMonitorName(), monitors.get(0).getMonitorName());
+        assertEquals(create.getSelectorScope(), monitors.get(0).getSelectorScope());
+        assertEquals(create.getLabels(), monitors.get(0).getLabels());
+        assertEquals(create.getTargetTenant(), monitors.get(0).getTargetTenant());
+    }
+
+    @Test
+    public void testMisMatchMonitorWithMultipleLabels() {
+        final Map<String, String> labels = new HashMap<>();
+        labels.put("os", "DARWIN");
+        labels.put("env", "test");
+
+        final Map<String, String> queryLabels = new HashMap<>();
+        queryLabels.put("os", "linux");
+        queryLabels.put("env", "test");
+
+        MonitorCreate create = podamFactory.manufacturePojo(MonitorCreate.class);
+        create.setLabels(labels);
+        String tenantId = RandomStringUtils.randomAlphanumeric(10);
+        monitorManagement.createMonitor(tenantId, create);
+        entityManager.flush();
+
+        List<Monitor> monitors = monitorManagement.getMonitorsFromLabels(queryLabels, tenantId);
+        assertEquals(0, monitors.size());
     }
 
     @Test
@@ -416,8 +461,8 @@ public class MonitorManagementTest {
         monitorManagement.createMonitor(tenantId, create);
         entityManager.flush();
 
-        List<Monitor> resources = monitorManagement.getMonitorsFromLabels(labels, tenantId);
-        assertEquals(0, resources.size());
+        List<Monitor> monitors = monitorManagement.getMonitorsFromLabels(labels, tenantId);
+        assertEquals(0, monitors.size());
     }
 
     @Test
@@ -438,11 +483,15 @@ public class MonitorManagementTest {
         monitorManagement.createMonitor(tenantId, create);
         entityManager.flush();
 
-        List<Monitor> resources = monitorManagement.getMonitorsFromLabels(labels, tenantId);
-        assertEquals(1, resources.size()); //make sure we only returned the one value
-        assertEquals(tenantId, resources.get(0).getTenantId());
-        //assertEquals(create.getResourceId(), resources.get(0).getResourceId());
-        assertEquals(monitorLabels, resources.get(0).getLabels());
+        List<Monitor> monitors = monitorManagement.getMonitorsFromLabels(labels, tenantId);
+        assertEquals(1, monitors.size()); //make sure we only returned the one value
+        assertEquals(tenantId, monitors.get(0).getTenantId());
+        assertEquals(create.getAgentType(), monitors.get(0).getAgentType());
+        assertEquals(create.getContent(), monitors.get(0).getContent());
+        assertEquals(create.getMonitorName(), monitors.get(0).getMonitorName());
+        assertEquals(create.getSelectorScope(), monitors.get(0).getSelectorScope());
+        assertEquals(create.getLabels(), monitors.get(0).getLabels());
+        assertEquals(create.getTargetTenant(), monitors.get(0).getTargetTenant());
     }
 
     public void testMisMatchResourceWithSubsetOfLabels() {

--- a/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
@@ -41,7 +41,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.MockBeans;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
@@ -134,14 +133,14 @@ public class MonitorManagementTest {
         monitorList.add(currentMonitor);
         List<ResourceInfo> infoList = new ArrayList<>();
         infoList.add(resourceInfo);
-        List<Resource> resourceList = new ArrayList<>();
-        resourceList.add(resourceEvent.getResource());
+        List<String> resourceIdList = new ArrayList<>();
+        resourceIdList.add(resourceEvent.getResource().getResourceId());
 
         doReturn(restTemplateBuilder).when(restTemplateBuilder).rootUri(anyString());
         doReturn(restTemplate).when(restTemplateBuilder).build();
         doReturn(resp).when(restTemplate).exchange(anyString(), eq(HttpMethod.GET), eq(null), (ParameterizedTypeReference<List<Resource>>) any());
         doReturn(HttpStatus.OK).when(resp).getStatusCode();
-        doReturn(resourceList).when(resp).getBody();
+        doReturn(resourceIdList).when(resp).getBody();
         doReturn("dummyUrl").when(servicesProperties).getResourceManagementUrl();
         when(envoyResourceManagement.getOne(anyString(), anyString()))
                 .thenReturn(CompletableFuture.completedFuture(infoList));

--- a/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
@@ -396,10 +396,7 @@ public class MonitorManagementTest {
         entityManager.flush();
 
         List<Monitor> monitors = monitorManagement.getMonitorsFromLabels(labels, tenantId);
-        assertEquals(1, monitors.size()); //make sure we only returned the one value
-        assertEquals(tenantId, monitors.get(0).getTenantId());
-        //assertEquals(create.getResourceId(), resources.get(0).getResourceId());
-        assertEquals(monitorLabels, monitors.get(0).getLabels());
+        assertEquals(0, monitors.size()); //make sure we only returned the one value
     }
 
     @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
@@ -129,6 +129,7 @@ public class MonitorManagementTest {
                 "\"config\":{\"content\":\"content1\"," +
                 "\"labels\":{\"os\":\"LINUX\"}}}";
         monitorEvent = objectMapper.readValue(monitorEventString, MonitorEvent.class);
+        monitorEvent.setMonitorId(currentMonitor.getId().toString());
         monitorList = new ArrayList<>();
         monitorList.add(currentMonitor);
         List<ResourceInfo> infoList = new ArrayList<>();

--- a/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
@@ -39,6 +39,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -95,6 +97,8 @@ public class MonitorManagementTest {
     MonitorRepository monitorRepository;
     @Autowired
     EntityManager entityManager;
+    @Autowired
+    JdbcTemplate jdbcTemplate;
     @MockBean
     ServicesProperties servicesProperties;
     private MonitorManagement monitorManagement;
@@ -148,7 +152,7 @@ public class MonitorManagementTest {
                 .thenReturn(CompletableFuture.completedFuture(infoList));
 
         monitorManagement = new MonitorManagement(monitorRepository, entityManager, envoyResourceManagement,
-                monitorEventProducer, restTemplateBuilder, servicesProperties);
+                monitorEventProducer, restTemplateBuilder, servicesProperties, jdbcTemplate);
 
 
     }
@@ -318,7 +322,7 @@ public class MonitorManagementTest {
         create.setLabels(labels);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
-        //entityManager.flush();
+        entityManager.flush();
         List<Monitor> resources = monitorManagement.getMonitorsFromLabels(labels, tenantId, MonitorManagement.MatchOptions.MATCH_ALL);
         assertEquals(1, resources.size());
         assertNotNull(resources);
@@ -335,6 +339,7 @@ public class MonitorManagementTest {
         String tenantId2 = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
         monitorManagement.createMonitor(tenantId2, create);
+        entityManager.flush();
 
         List<Monitor> resources = monitorManagement.getMonitorsFromLabels(labels, tenantId, MonitorManagement.MatchOptions.MATCH_ALL);
         assertEquals(1, resources.size()); //make sure we only returned the one value
@@ -376,7 +381,7 @@ public class MonitorManagementTest {
         create.setLabels(resourceLabels);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
-        //entityManager.flush();
+        entityManager.flush();
 
         List<Monitor> resources = monitorManagement.getMonitorsFromLabels(labels, tenantId, MonitorManagement.MatchOptions.MATCH_ALL);
         assertEquals(1, resources.size()); //make sure we only returned the one value

--- a/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/MonitorManagementTest.java
@@ -387,9 +387,9 @@ public class MonitorManagementTest {
 
     @Test
     public void testMatchResourceWithSubsetOfLabels() {
-        final Map<String, String> resourceLabels = new HashMap<>();
-        resourceLabels.put("os", "DARWIN");
-        resourceLabels.put("env", "test");
+        final Map<String, String> monitorLabels = new HashMap<>();
+        monitorLabels.put("os", "DARWIN");
+        monitorLabels.put("env", "test");
         final Map<String, String> labels = new HashMap<>();
         labels.put("os", "DARWIN");
         labels.put("env", "test");
@@ -398,7 +398,7 @@ public class MonitorManagementTest {
 
 
         MonitorCreate create = podamFactory.manufacturePojo(MonitorCreate.class);
-        create.setLabels(resourceLabels);
+        create.setLabels(monitorLabels);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
         entityManager.flush();
@@ -407,6 +407,6 @@ public class MonitorManagementTest {
         assertEquals(1, resources.size()); //make sure we only returned the one value
         assertEquals(tenantId, resources.get(0).getTenantId());
         //assertEquals(create.getResourceId(), resources.get(0).getResourceId());
-        assertEquals(labels, resources.get(0).getLabels());
+        assertEquals(monitorLabels, resources.get(0).getLabels());
     }
 }


### PR DESCRIPTION
# Resolves

This is for https://jira.rax.io/browse/SALUS-125

# What

Create a query that will match to all of the labels we have provided

# How

It creates a query function to manually create the SQL query since this is a fairly complex query

# How to test

Run the MonitorManagementTest unit tests

# Why

This query incurs fewer JOIN penalties from the suggested SO approach.

# TODO

Probably a little cleanup
