### PR TITLE
remove hack

### DIFF
--- a/src/test/java/com/rackspace/salus/monitor_management/MonitorApiTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/MonitorApiTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -60,6 +61,7 @@ import java.util.stream.Stream;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(controllers = MonitorApi.class)
+@AutoConfigureDataJpa
 public class MonitorApiTest {
 
     private PodamFactory podamFactory = new PodamFactoryImpl();
@@ -69,16 +71,6 @@ public class MonitorApiTest {
 
     @MockBean
     MonitorManagement monitorManagement;
-
-    @MockBean
-    MonitorRepository monitorRepository;
-
-    // This mock is a hack; it is required because the entityManager
-    //  bean needs to find a bean for all the repositories defined in the telemetery model module
-    //  We need to find a way to filter out the unwanted repos without adding a bean for each of them
-    @MockBean
-    ResourceRepository resourceRepository;
-
 
     @Autowired
     ObjectMapper objectMapper;


### PR DESCRIPTION
Fix a spring bean creation hack.  Because the entityManager bean needs an instance of each repository in the model, I had to create a mock ResourceRepository bean in this test even though the test is for the monitor repo:  https://github.com/racker/salus-telemetry-monitor-management/blob/17e664e81eb2b6c481a93e1b82abd9f264fe218a/src/test/java/com/rackspace/salus/monitor_management/MonitorApiTest.java#L76-L81


The fix is to use the AutoConfigureDataJpa annotation to have spring boot create all necessary beans, without us having to worry about it.
