### PR TITLE
Provide a client facing DTO version of BoundMonitor entity

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -16,7 +16,7 @@
 
 package com.rackspace.salus.monitor_management.web.client;
 
-import com.rackspace.salus.monitor_management.entities.BoundMonitor;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import java.util.List;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
@@ -50,7 +50,7 @@ import org.springframework.web.client.RestTemplate;
  */
 public class MonitorApiClient implements MonitorApi {
 
-  private static final ParameterizedTypeReference<List<BoundMonitor>> LIST_OF_BOUND_MONITOR = new ParameterizedTypeReference<List<BoundMonitor>>() {
+  private static final ParameterizedTypeReference<List<BoundMonitorDTO>> LIST_OF_BOUND_MONITOR = new ParameterizedTypeReference<List<BoundMonitorDTO>>() {
   };
   private final RestTemplate restTemplate;
 
@@ -59,7 +59,7 @@ public class MonitorApiClient implements MonitorApi {
   }
 
   @Override
-  public List<BoundMonitor> getBoundMonitors(String envoyId) {
+  public List<BoundMonitorDTO> getBoundMonitors(String envoyId) {
     return restTemplate.exchange(
         "/api/boundMonitors/{envoyId}",
         HttpMethod.GET,

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.monitor_management.web.client;
+package com.rackspace.salus.monitor_management.web.model;
 
-import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
-import java.util.List;
+import com.rackspace.salus.telemetry.model.AgentType;
+import java.util.UUID;
+import lombok.Data;
 
-public interface MonitorApi {
-
-  List<BoundMonitorDTO> getBoundMonitors(String envoyId);
+@Data
+public class BoundMonitorDTO {
+  UUID monitorId;
+  String zone;
+  String targetTenant;
+  String resourceId;
+  AgentType agentType;
+  String renderedContent;
+  String envoyId;
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClientTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rackspace.salus.monitor_management.entities.BoundMonitor;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -67,14 +67,14 @@ public class MonitorApiClientTest {
     final UUID id2 = UUID.fromString("16caf730-48e8-47ba-0002-aa9babba8953");
     final UUID id3 = UUID.fromString("16caf730-48e8-47ba-0003-aa9babba8953");
 
-    final List<BoundMonitor> givenBoundMonitors = Arrays.asList(
-        new BoundMonitor()
+    final List<BoundMonitorDTO> givenBoundMonitors = Arrays.asList(
+        new BoundMonitorDTO()
             .setMonitorId(id1)
             .setRenderedContent("{\"instance\":1, \"state\":1}"),
-        new BoundMonitor()
+        new BoundMonitorDTO()
             .setMonitorId(id2)
             .setRenderedContent("{\"instance\":2, \"state\":1}"),
-        new BoundMonitor()
+        new BoundMonitorDTO()
             .setMonitorId(id3)
             .setRenderedContent("{\"instance\":3, \"state\":1}")
     );
@@ -82,7 +82,7 @@ public class MonitorApiClientTest {
     mockServer.expect(requestTo("/api/boundMonitors/e-1"))
         .andRespond(withSuccess(objectMapper.writeValueAsString(givenBoundMonitors), MediaType.APPLICATION_JSON));
 
-    final List<BoundMonitor> boundMonitors = monitorApiClient.getBoundMonitors("e-1");
+    final List<BoundMonitorDTO> boundMonitors = monitorApiClient.getBoundMonitors("e-1");
     assertThat(boundMonitors, equalTo(givenBoundMonitors));
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.monitor_management.entities.BoundMonitor;
+import org.junit.Test;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+public class BoundMonitorDTOTest {
+  final PodamFactory podamFactory = new PodamFactoryImpl();
+
+  /**
+   * Tests that we can do a round-trip conversion using {@link ObjectMapper#convertValue(Object, Class)}
+   */
+  @Test
+  public void testFieldsCovered() {
+    final ObjectMapper objectMapper = new ObjectMapper();
+
+    final BoundMonitor boundMonitor = podamFactory.manufacturePojo(BoundMonitor.class);
+
+    final BoundMonitorDTO dto = objectMapper
+        .convertValue(boundMonitor, BoundMonitorDTO.class);
+
+    final BoundMonitor result = objectMapper.convertValue(dto, BoundMonitor.class);
+
+    assertThat(result, equalTo(boundMonitor));
+  }
+}


### PR DESCRIPTION
# Resolves

Fixes a bug introduced in https://github.com/racker/salus-telemetry-monitor-management/pull/14

# What

Clients of the `MonitorApi` interface could not compile since it referenced `BoundMonitor`, which is purposely not included in the client jar.

# How

Introduces a Data Transfer Object (DTO) version of `BoundMonitor` to decouple the REST API clients from the "private" JPA entity. This approach deviates from [what we currently do in model](https://github.com/racker/salus-telemetry-model/tree/master/src/main/java/com/rackspace/salus/telemetry/model) since it is an experiment to see if this is a better and feasible coding practice.

## How to test

A test was added to confirm the likeness of the DTO.