### PR TITLE
Rename the labels field to labelSelector in the monitor DTO

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -52,7 +52,7 @@ public class MonitorConversionService {
     final DetailedMonitorOutput detailedMonitorOutput = new DetailedMonitorOutput()
         .setId(monitor.getId().toString())
         .setName(monitor.getMonitorName())
-        .setLabels(monitor.getLabels());
+        .setLabelSelector(monitor.getLabels());
 
     final ConfigSelectorScope selectorScope = monitor.getSelectorScope();
 
@@ -99,7 +99,7 @@ public class MonitorConversionService {
   public MonitorCU convertFromInput(DetailedMonitorInput input) {
     final MonitorCU monitor = new MonitorCU()
         .setMonitorName(input.getName())
-        .setLabels(input.getLabels());
+        .setLabels(input.getLabelSelector());
 
     final MonitorDetails details = input.getDetails();
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -52,7 +52,7 @@ public class MonitorConversionService {
     final DetailedMonitorOutput detailedMonitorOutput = new DetailedMonitorOutput()
         .setId(monitor.getId().toString())
         .setName(monitor.getMonitorName())
-        .setLabelSelector(monitor.getLabels());
+        .setLabelSelector(monitor.getLabelSelector());
 
     final ConfigSelectorScope selectorScope = monitor.getSelectorScope();
 
@@ -99,7 +99,7 @@ public class MonitorConversionService {
   public MonitorCU convertFromInput(DetailedMonitorInput input) {
     final MonitorCU monitor = new MonitorCU()
         .setMonitorName(input.getName())
-        .setLabels(input.getLabelSelector());
+        .setLabelSelector(input.getLabelSelector());
 
     final MonitorDetails details = input.getDetails();
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -499,7 +499,7 @@ public class MonitorManagement {
 
         MapSqlParameterSource paramSource = new MapSqlParameterSource();
         paramSource.addValue("tenantId", tenantId);
-        StringBuilder builder = new StringBuilder("SELECT * FROM monitors JOIN monitor_label_selectors AS ml WHERE monitors.id = ml.id AND monitors.id IN ");
+        StringBuilder builder = new StringBuilder("SELECT monitors.id FROM monitors JOIN monitor_label_selectors AS ml WHERE monitors.id = ml.id AND monitors.id IN ");
         builder.append("(SELECT id from monitor_label_selectors WHERE monitors.id IN (SELECT id FROM monitors WHERE tenant_id = :tenantId) AND ");
         builder.append("monitors.id IN (SELECT search_labels.id FROM (SELECT id, COUNT(*) AS count FROM monitor_label_selectors GROUP BY id) AS total_labels JOIN (SELECT id, COUNT(*) AS count FROM monitor_label_selectors WHERE ");
         int i = 0;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
@@ -20,15 +20,18 @@ import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-
 import lombok.Data;
 
 @Data
 public class DetailedMonitorInput {
   String name;
 
+  /**
+   * This key-value mapping of labels specifies what resources will be monitored by this monitor.
+   * For a resource to be selected, it must contain at least all of the labels given here.
+   */
   @NotEmpty
-  Map<String,String> labels;
+  Map<String,String> labelSelector;
 
   @NotNull @Valid
   MonitorDetails details;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
@@ -25,6 +25,6 @@ import lombok.Data;
 public class DetailedMonitorOutput {
     String id;
     String name;
-    Map<String,String> labels;
+    Map<String,String> labelSelector;
     MonitorDetails details;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
@@ -39,7 +39,7 @@ public class MonitorCU implements Serializable {
 
     String monitorName;
 
-    Map<String,String> labels;
+    Map<String,String> labelSelector;
 
     String content;
 

--- a/src/test/java/com/rackspace/salus/monitor_management/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/MonitorConversionServiceTest.java
@@ -81,7 +81,7 @@ public class MonitorConversionServiceTest {
         .setMonitorName("name-a")
         .setAgentType(AgentType.TELEGRAF)
         .setSelectorScope(ConfigSelectorScope.ALL_OF)
-        .setLabels(labels)
+        .setLabelSelector(labels)
         .setContent(content);
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
@@ -120,7 +120,7 @@ public class MonitorConversionServiceTest {
     final MonitorCU result = conversionService.convertFromInput(input);
 
     assertThat(result).isNotNull();
-    assertThat(result.getLabels()).isEqualTo(labels);
+    assertThat(result.getLabelSelector()).isEqualTo(labels);
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
     assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.ALL_OF);
@@ -138,7 +138,7 @@ public class MonitorConversionServiceTest {
         .setId(UUID.randomUUID())
         .setAgentType(AgentType.TELEGRAF)
         .setSelectorScope(ConfigSelectorScope.ALL_OF)
-        .setLabels(Collections.singletonMap("os","linux"))
+        .setLabelSelector(Collections.singletonMap("os","linux"))
         .setContent(content);
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
@@ -186,7 +186,7 @@ public class MonitorConversionServiceTest {
         .setId(UUID.randomUUID())
         .setAgentType(AgentType.TELEGRAF)
         .setSelectorScope(ConfigSelectorScope.ALL_OF)
-        .setLabels(Collections.singletonMap("os","linux"))
+        .setLabelSelector(Collections.singletonMap("os","linux"))
         .setContent(content);
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
@@ -240,7 +240,7 @@ public class MonitorConversionServiceTest {
         .setId(UUID.randomUUID())
         .setAgentType(AgentType.TELEGRAF)
         .setSelectorScope(ConfigSelectorScope.ALL_OF)
-        .setLabels(Collections.singletonMap("os","linux"))
+        .setLabelSelector(Collections.singletonMap("os","linux"))
         .setContent(content);
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
@@ -290,7 +290,7 @@ public class MonitorConversionServiceTest {
         .setAgentType(AgentType.TELEGRAF)
         .setSelectorScope(ConfigSelectorScope.REMOTE)
         .setZones(Collections.singletonList("z-1"))
-        .setLabels(labels)
+        .setLabelSelector(labels)
         .setContent(content);
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
@@ -329,7 +329,7 @@ public class MonitorConversionServiceTest {
     final MonitorCU result = conversionService.convertFromInput(input);
 
     assertThat(result).isNotNull();
-    assertThat(result.getLabels()).isEqualTo(labels);
+    assertThat(result.getLabelSelector()).isEqualTo(labels);
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
     assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.REMOTE);

--- a/src/test/java/com/rackspace/salus/monitor_management/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/MonitorConversionServiceTest.java
@@ -89,7 +89,7 @@ public class MonitorConversionServiceTest {
     assertThat(result).isNotNull();
     assertThat(result.getId()).isEqualTo(monitorId.toString());
     assertThat(result.getName()).isEqualTo("name-a");
-    assertThat(result.getLabels()).isEqualTo(labels);
+    assertThat(result.getLabelSelector()).isEqualTo(labels);
     assertThat(result.getDetails()).isInstanceOf(LocalMonitorDetails.class);
 
     final LocalPlugin plugin = ((LocalMonitorDetails) result.getDetails()).getPlugin();
@@ -115,7 +115,7 @@ public class MonitorConversionServiceTest {
 
     DetailedMonitorInput input = new DetailedMonitorInput()
         .setName("name-a")
-        .setLabels(labels)
+        .setLabelSelector(labels)
         .setDetails(details);
     final MonitorCU result = conversionService.convertFromInput(input);
 
@@ -168,7 +168,7 @@ public class MonitorConversionServiceTest {
     details.setPlugin(plugin);
 
     DetailedMonitorInput input = new DetailedMonitorInput()
-        .setLabels(Collections.singletonMap("os","linux"))
+        .setLabelSelector(Collections.singletonMap("os","linux"))
         .setDetails(details);
     final MonitorCU result = conversionService.convertFromInput(input);
 
@@ -222,7 +222,7 @@ public class MonitorConversionServiceTest {
     details.setPlugin(plugin);
 
     DetailedMonitorInput input = new DetailedMonitorInput()
-        .setLabels(Collections.singletonMap("os","linux"))
+        .setLabelSelector(Collections.singletonMap("os","linux"))
         .setDetails(details);
     final MonitorCU result = conversionService.convertFromInput(input);
 
@@ -266,7 +266,7 @@ public class MonitorConversionServiceTest {
     details.setPlugin(plugin);
 
     DetailedMonitorInput input = new DetailedMonitorInput()
-        .setLabels(Collections.singletonMap("os","linux"))
+        .setLabelSelector(Collections.singletonMap("os","linux"))
         .setDetails(details);
     final MonitorCU result = conversionService.convertFromInput(input);
 
@@ -298,7 +298,7 @@ public class MonitorConversionServiceTest {
     assertThat(result).isNotNull();
     assertThat(result.getId()).isEqualTo(monitorId.toString());
     assertThat(result.getName()).isEqualTo("name-a");
-    assertThat(result.getLabels()).isEqualTo(labels);
+    assertThat(result.getLabelSelector()).isEqualTo(labels);
     assertThat(result.getDetails()).isInstanceOf(RemoteMonitorDetails.class);
 
     final RemoteMonitorDetails remoteMonitorDetails = (RemoteMonitorDetails) result.getDetails();
@@ -324,7 +324,7 @@ public class MonitorConversionServiceTest {
 
     DetailedMonitorInput input = new DetailedMonitorInput()
         .setName("name-a")
-        .setLabels(labels)
+        .setLabelSelector(labels)
         .setDetails(details);
     final MonitorCU result = conversionService.convertFromInput(input);
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -162,7 +162,7 @@ public class MonitorManagementTest {
         Monitor monitor = new Monitor()
                 .setTenantId("abcde")
                 .setMonitorName("mon1")
-                .setLabels(Collections.singletonMap("os", "LINUX"))
+                .setLabelSelector(Collections.singletonMap("os", "LINUX"))
                 .setContent("content1")
                 .setAgentType(AgentType.FILEBEAT);
         monitorRepository.save(monitor);
@@ -223,7 +223,7 @@ public class MonitorManagementTest {
         Monitor r = monitorManagement.getMonitor("abcde", currentMonitor.getId());
 
         assertThat(r.getId(), notNullValue());
-        assertThat(r.getLabels(), hasEntry("os", "LINUX"));
+        assertThat(r.getLabelSelector(), hasEntry("os", "LINUX"));
         assertThat(r.getContent(), equalTo(currentMonitor.getContent()));
         assertThat(r.getAgentType(), equalTo(currentMonitor.getAgentType()));
     }
@@ -241,13 +241,13 @@ public class MonitorManagementTest {
         assertThat(returned.getContent(), equalTo(create.getContent()));
         assertThat(returned.getAgentType(), equalTo(create.getAgentType()));
 
-        assertThat(returned.getLabels().size(), greaterThan(0));
-        assertTrue(Maps.difference(create.getLabels(), returned.getLabels()).areEqual());
+        assertThat(returned.getLabelSelector().size(), greaterThan(0));
+        assertTrue(Maps.difference(create.getLabelSelector(), returned.getLabelSelector()).areEqual());
 
         Monitor retrieved = monitorManagement.getMonitor(tenantId, returned.getId());
 
         assertThat(retrieved.getMonitorName(), equalTo(returned.getMonitorName()));
-        assertTrue(Maps.difference(returned.getLabels(), retrieved.getLabels()).areEqual());
+        assertTrue(Maps.difference(returned.getLabelSelector(), retrieved.getLabelSelector()).areEqual());
     }
 
 
@@ -307,11 +307,11 @@ public class MonitorManagementTest {
     @Test
     public void testUpdateExistingMonitor() {
         Monitor monitor = monitorManagement.getAllMonitors(PageRequest.of(0, 1)).getContent().get(0);
-        Map<String, String> newLabels = new HashMap<>(monitor.getLabels());
+        Map<String, String> newLabels = new HashMap<>(monitor.getLabelSelector());
         newLabels.put("newLabel", "newValue");
         MonitorCU update = new MonitorCU();
 
-        update.setLabels(newLabels).setContent("newContent");
+        update.setLabelSelector(newLabels).setContent("newContent");
 
         Monitor newMonitor;
         try {
@@ -324,7 +324,7 @@ public class MonitorManagementTest {
             return;
         }
 
-        assertThat(newMonitor.getLabels(), equalTo(monitor.getLabels()));
+        assertThat(newMonitor.getLabelSelector(), equalTo(monitor.getLabelSelector()));
         assertThat(newMonitor.getId(), equalTo(monitor.getId()));
         assertThat(newMonitor.getContent(), equalTo(monitor.getContent()));
     }
@@ -356,7 +356,7 @@ public class MonitorManagementTest {
 
     @Test
     public void testPublishMonitor() {
-        monitorManagement.publishMonitor(currentMonitor, OperationType.UPDATE, currentMonitor.getLabels());
+        monitorManagement.publishMonitor(currentMonitor, OperationType.UPDATE, currentMonitor.getLabelSelector());
         verify(monitorEventProducer).sendMonitorEvent(monitorEvent);
 
     }
@@ -367,7 +367,7 @@ public class MonitorManagementTest {
         labels.put("os", "DARWIN");
 
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
-        create.setLabels(labels);
+        create.setLabelSelector(labels);
         create.setSelectorScope(ConfigSelectorScope.ALL_OF);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
@@ -385,7 +385,7 @@ public class MonitorManagementTest {
         queryLabels.put("os", "linux");
 
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
-        create.setLabels(labels);
+        create.setLabelSelector(labels);
         create.setSelectorScope(ConfigSelectorScope.ALL_OF);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
@@ -399,7 +399,7 @@ public class MonitorManagementTest {
         final Map<String, String> labels = new HashMap<>();
 
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
-        create.setLabels(labels);
+        create.setLabelSelector(labels);
         create.setSelectorScope(ConfigSelectorScope.ALL_OF);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
@@ -413,7 +413,7 @@ public class MonitorManagementTest {
         labels.put("key", "value");
 
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
-        create.setLabels(labels);
+        create.setLabelSelector(labels);
         create.setSelectorScope(ConfigSelectorScope.ALL_OF);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         String tenantId2 = RandomStringUtils.randomAlphanumeric(10);
@@ -428,7 +428,7 @@ public class MonitorManagementTest {
         assertEquals(create.getContent(), monitors.get(0).getContent());
         assertEquals(create.getMonitorName(), monitors.get(0).getMonitorName());
         assertEquals(create.getSelectorScope(), monitors.get(0).getSelectorScope());
-        assertEquals(create.getLabels(), monitors.get(0).getLabels());
+        assertEquals(create.getLabelSelector(), monitors.get(0).getLabelSelector());
     }
 
     @Test
@@ -438,7 +438,7 @@ public class MonitorManagementTest {
         labels.put("env", "test");
 
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
-        create.setLabels(labels);
+        create.setLabelSelector(labels);
         create.setSelectorScope(ConfigSelectorScope.ALL_OF);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
@@ -451,7 +451,7 @@ public class MonitorManagementTest {
         assertEquals(create.getContent(), monitors.get(0).getContent());
         assertEquals(create.getMonitorName(), monitors.get(0).getMonitorName());
         assertEquals(create.getSelectorScope(), monitors.get(0).getSelectorScope());
-        assertEquals(create.getLabels(), monitors.get(0).getLabels());
+        assertEquals(create.getLabelSelector(), monitors.get(0).getLabelSelector());
     }
 
     @Test
@@ -465,7 +465,7 @@ public class MonitorManagementTest {
         queryLabels.put("env", "test");
 
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
-        create.setLabels(labels);
+        create.setLabelSelector(labels);
         create.setSelectorScope(ConfigSelectorScope.ALL_OF);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
@@ -487,7 +487,7 @@ public class MonitorManagementTest {
         labels.put("env", "test");
 
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
-        create.setLabels(monitorLabels);
+        create.setLabelSelector(monitorLabels);
         create.setSelectorScope(ConfigSelectorScope.ALL_OF);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
@@ -509,7 +509,7 @@ public class MonitorManagementTest {
         labels.put("env", "test");
 
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
-        create.setLabels(monitorLabels);
+        create.setLabelSelector(monitorLabels);
         create.setSelectorScope(ConfigSelectorScope.ALL_OF);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
@@ -532,7 +532,7 @@ public class MonitorManagementTest {
 
 
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
-        create.setLabels(monitorLabels);
+        create.setLabelSelector(monitorLabels);
         create.setSelectorScope(ConfigSelectorScope.ALL_OF);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
@@ -545,7 +545,7 @@ public class MonitorManagementTest {
         assertEquals(create.getContent(), monitors.get(0).getContent());
         assertEquals(create.getMonitorName(), monitors.get(0).getMonitorName());
         assertEquals(create.getSelectorScope(), monitors.get(0).getSelectorScope());
-        assertEquals(create.getLabels(), monitors.get(0).getLabels());
+        assertEquals(create.getLabelSelector(), monitors.get(0).getLabelSelector());
     }
 
     public void testMisMatchResourceWithSubsetOfLabels() {
@@ -560,7 +560,7 @@ public class MonitorManagementTest {
 
 
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
-        create.setLabels(monitorLabels);
+        create.setLabelSelector(monitorLabels);
         create.setSelectorScope(ConfigSelectorScope.ALL_OF);
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         monitorManagement.createMonitor(tenantId, create);
@@ -577,7 +577,7 @@ public class MonitorManagementTest {
             .setTenantId("t-1")
             .setAgentType(AgentType.TELEGRAF)
             .setSelectorScope(ConfigSelectorScope.ALL_OF)
-            .setLabels(Collections.singletonMap("os", "LINUX"))
+            .setLabelSelector(Collections.singletonMap("os", "LINUX"))
             .setAgentType(AgentType.TELEGRAF)
             .setContent("{}");
 
@@ -645,7 +645,7 @@ public class MonitorManagementTest {
             .setTenantId("t-1")
             .setAgentType(AgentType.TELEGRAF)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
-            .setLabels(Collections.singletonMap("os", "LINUX"))
+            .setLabelSelector(Collections.singletonMap("os", "LINUX"))
             .setZones(Arrays.asList("zone1", "zone2"))
             .setAgentType(AgentType.TELEGRAF)
             .setContent("{\"type\": \"ping\", \"urls\": [\"<<resource.metadata.public_ip>>\"]}");
@@ -721,7 +721,7 @@ public class MonitorManagementTest {
             .setTenantId("t-1")
             .setAgentType(AgentType.TELEGRAF)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
-            .setLabels(Collections.singletonMap("os", "LINUX"))
+            .setLabelSelector(Collections.singletonMap("os", "LINUX"))
             // NOTE only one zone used in this test
             .setZones(Collections.singletonList("zone1"))
             .setAgentType(AgentType.TELEGRAF)


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-319

# What

During sprint demo we realized it would be better to rename this user facing field to "labelSelector" emphasize that it selects the labels of the resource and is not itself a set of labels of the monitor.

## How to test

Existing unit tests

# Depends on

- https://github.com/racker/salus-telemetry-model/pull/42