### PR TITLE
Support new zone events and modified resource event structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,18 @@
         <artifactId>salus-telemetry-etcd-adapter</artifactId>
         <version>0.1.0-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-resource-management</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <classifier>client</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-protocol</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>

--- a/src/main/java/com/rackspace/salus/monitor_management/config/MonitorContentProperties.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/MonitorContentProperties.java
@@ -29,5 +29,5 @@ public class MonitorContentProperties {
    * Allows configuration of the delimiters used by jmustache for monitor content template
    * rendering. The default avoids conflicting with "{{ }}" used by Insomnia for its templating.
    */
-  String placeholderDelimiters = "<< >>";
+  String placeholderDelimiters = "${ }";
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/config/RestClientsConfig.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/RestClientsConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.config;
+
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.client.ResourceApiClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RestClientsConfig {
+
+  private final ServicesProperties servicesProperties;
+
+  @Autowired
+  public RestClientsConfig(ServicesProperties servicesProperties) {
+    this.servicesProperties = servicesProperties;
+  }
+
+  @Bean
+  public ResourceApi resourceApi(RestTemplateBuilder restTemplateBuilder) {
+    return new ResourceApiClient(
+        restTemplateBuilder.rootUri(servicesProperties.getResourceManagementUrl())
+        .build()
+    );
+  }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/config/ServicesProperties.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/ServicesProperties.java
@@ -20,6 +20,7 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+@SuppressWarnings("ConfigurationProperties")
 @ConfigurationProperties("services")
 @Component
 @Data

--- a/src/main/java/com/rackspace/salus/monitor_management/entities/BoundMonitor.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/entities/BoundMonitor.java
@@ -70,6 +70,7 @@ public class BoundMonitor implements Serializable {
   /**
    * Contains the tenant that owns the private zone or an empty string for public zones.
    */
+  @NotNull
   @Column(length = 100)
   String zoneTenantId;
 
@@ -78,6 +79,7 @@ public class BoundMonitor implements Serializable {
    * For local monitors, this field is an empty string.
    */
   @Id
+  @NotNull
   @Column(length = 100)
   String zoneId;
 

--- a/src/main/java/com/rackspace/salus/monitor_management/entities/BoundMonitor.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/entities/BoundMonitor.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.entities;
 
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.Monitor;
 import java.io.Serializable;
 import java.util.UUID;
 import javax.persistence.Column;
@@ -40,7 +41,8 @@ import org.hibernate.annotations.Type;
 @IdClass(BoundMonitor.PrimaryKey.class)
 @Table(name = "bound_monitors",
 indexes = {
-    @Index(name = "by_envoy_id", columnList = "envoyId")
+    @Index(name = "by_envoy_id", columnList = "envoyId"),
+    @Index(name = "by_zone_envoy", columnList = "zoneTenantId,zoneId,envoyId")
 })
 @Data
 public class BoundMonitor implements Serializable {
@@ -48,33 +50,49 @@ public class BoundMonitor implements Serializable {
   @Data
   public static class PrimaryKey implements Serializable {
 
-    // NOTE the ordering of the following is important since potentially null values need to be
-    // last in the primary key
-
     UUID monitorId;
     String resourceId;
-    // agent monitors will have null zone and zoneTenantId
-    String zone;
+    String zoneId;
+
+    // zoneTenantId does not need to be part of the primary key since the Monitor, via monitorId,
+    // effectively scopes private zone IDs by tenant
   }
 
+  /**
+   * This is an informal foreign key reference to <code>id</code> of {@link Monitor}
+   */
   @Id
   @NotNull
   @Type(type = "uuid-char")
   @Column(length = 100)
   UUID monitorId;
 
+  /**
+   * Contains the tenant that owns the private zone or an empty string for public zones.
+   */
+  @Column(length = 100)
+  String zoneTenantId;
+
+  /**
+   * For remote monitors, contains the binding of a specific monitoring zone.
+   * For local monitors, this field is an empty string.
+   */
   @Id
   @Column(length = 100)
-  String zone;
+  String zoneId;
 
   /**
    * For remote monitors, this field must be non-empty to indicate to the assigned Envoy that
-   * the measurements are being collected on behalf of the target tenant rather than the tenant
-   * of the Envoy.
+   * the measurements are being collected on behalf of the target tenant rather than the Envoy's
+   * tenant.
    */
   @NotNull
   String targetTenant;
 
+  /**
+   * Contains the binding of the {@link Monitor} (via <code>monitorId</code>) to a specific
+   * resource to be monitored.
+   */
   @Id
   @NotNull
   @Column(length = 100)

--- a/src/main/java/com/rackspace/salus/monitor_management/entities/BoundMonitor.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/entities/BoundMonitor.java
@@ -16,33 +16,51 @@
 
 package com.rackspace.salus.monitor_management.entities;
 
-import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.telemetry.model.Monitor;
 import java.io.Serializable;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.Index;
 import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
-import org.hibernate.annotations.Type;
 
 // Using the old validation exceptions for podam support
 // Will move to the newer ones once they're supported.
 //import javax.validation.constraints.NotBlank;
 
+/**
+ * This entity tracks the three-way binding of
+ * <ul>
+ *   <li>monitor</li>
+ *   <li>resource</li>
+ *   <li>zone (empty string for local/agent monitors)</li>
+ * </ul>
+ *
+ * <p>
+ * As part of the binding, the agent configuration content of the monitor is stored in its
+ * rendered form with all context placeholders replaced with their per-binding values.
+ * </p>
+ *
+ * <p>
+ *   This entity has a corresponding DTO at
+ *   {@link com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO}
+ *   where the fields of that class must be maintained to align with the fields of this entity.
+ * </p>
+ */
 @Entity
 @IdClass(BoundMonitor.PrimaryKey.class)
 @Table(name = "bound_monitors",
 indexes = {
     @Index(name = "by_envoy_id", columnList = "envoyId"),
-    @Index(name = "by_zone_envoy", columnList = "zoneTenantId,zoneId,envoyId")
+    @Index(name = "by_zone_envoy", columnList = "zoneTenantId,zoneId,envoyId"),
+    @Index(name = "by_resource", columnList = "resourceId")
 })
 @Data
 public class BoundMonitor implements Serializable {
@@ -50,22 +68,22 @@ public class BoundMonitor implements Serializable {
   @Data
   public static class PrimaryKey implements Serializable {
 
-    UUID monitorId;
+    /**
+     * The Java and Hibernate type of <code>monitor</code> needs to match the primary key
+     * of {@link Monitor}
+     */
+    @org.hibernate.annotations.Type(type="uuid-char")
+    UUID monitor;
     String resourceId;
     String zoneId;
 
-    // zoneTenantId does not need to be part of the primary key since the Monitor, via monitorId,
-    // effectively scopes private zone IDs by tenant
+    // zoneTenantId and resourceTenant do not need to be part of the primary key
+    // since the Monitor, via monitorId, already scopes this binding to a tenant
   }
 
-  /**
-   * This is an informal foreign key reference to <code>id</code> of {@link Monitor}
-   */
   @Id
-  @NotNull
-  @Type(type = "uuid-char")
-  @Column(length = 100)
-  UUID monitorId;
+  @ManyToOne
+  Monitor monitor;
 
   /**
    * Contains the tenant that owns the private zone or an empty string for public zones.
@@ -84,14 +102,6 @@ public class BoundMonitor implements Serializable {
   String zoneId;
 
   /**
-   * For remote monitors, this field must be non-empty to indicate to the assigned Envoy that
-   * the measurements are being collected on behalf of the target tenant rather than the Envoy's
-   * tenant.
-   */
-  @NotNull
-  String targetTenant;
-
-  /**
    * Contains the binding of the {@link Monitor} (via <code>monitorId</code>) to a specific
    * resource to be monitored.
    */
@@ -100,13 +110,21 @@ public class BoundMonitor implements Serializable {
   @Column(length = 100)
   String resourceId;
 
-  @Enumerated(EnumType.STRING)
-  @NotNull
-  AgentType agentType;
-
   @Lob
   String renderedContent;
 
   @Column(length = 100)
   String envoyId;
+
+  public BoundMonitorDTO toDTO() {
+    return new BoundMonitorDTO()
+        .setMonitorId(monitor.getId())
+        .setZoneTenantId(zoneTenantId)
+        .setZoneId(zoneId)
+        .setResourceTenant(monitor.getTenantId())
+        .setResourceId(resourceId)
+        .setAgentType(monitor.getAgentType())
+        .setRenderedContent(renderedContent)
+        .setEnvoyId(envoyId);
+  }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
@@ -25,6 +25,9 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
 
   List<BoundMonitor> findByEnvoyId(String envoyId);
 
-  @Query("select b from BoundMonitor b where b.zoneTenantId = :zoneTenantId and b.zone = :zone and envoyId is null")
-  List<BoundMonitor> findOnesWithoutEnvoy(String zoneTenantId, String zone);
+  @Query("select b from BoundMonitor b where b.zoneTenantId = :zoneTenantId and b.zoneId = :zoneId and b.envoyId is null")
+  List<BoundMonitor> findOnesWithoutEnvoy(String zoneTenantId, String zoneId);
+
+  @Query("select b from BoundMonitor b where b.zoneTenantId = :zoneTenantId and b.zoneId = :zoneId and b.envoyId = :envoyId")
+  List<BoundMonitor> findOnesWithEnvoy(String zoneTenantId, String zoneId, String envoyId);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.monitor_management.repositories;
 
 import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
@@ -30,4 +31,6 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
 
   @Query("select b from BoundMonitor b where b.zoneTenantId = :zoneTenantId and b.zoneId = :zoneId and b.envoyId = :envoyId")
   List<BoundMonitor> findOnesWithEnvoy(String zoneTenantId, String zoneId, String envoyId);
+
+  List<BoundMonitor> findByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
@@ -24,13 +24,13 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, BoundMonitor.PrimaryKey> {
 
-  List<BoundMonitor> findByEnvoyId(String envoyId);
+  List<BoundMonitor> findAllByEnvoyId(String envoyId);
 
   @Query("select b from BoundMonitor b where b.zoneTenantId = :zoneTenantId and b.zoneId = :zoneId and b.envoyId is null")
-  List<BoundMonitor> findOnesWithoutEnvoy(String zoneTenantId, String zoneId);
+  List<BoundMonitor> findAllWithoutEnvoy(String zoneTenantId, String zoneId);
 
   @Query("select b from BoundMonitor b where b.zoneTenantId = :zoneTenantId and b.zoneId = :zoneId and b.envoyId = :envoyId")
-  List<BoundMonitor> findOnesWithEnvoy(String zoneTenantId, String zoneId, String envoyId);
+  List<BoundMonitor> findAllWithEnvoy(String zoneTenantId, String zoneId, String envoyId);
 
-  List<BoundMonitor> findByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
+  List<BoundMonitor> findAllByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
@@ -18,9 +18,13 @@ package com.rackspace.salus.monitor_management.repositories;
 
 import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, BoundMonitor.PrimaryKey> {
 
   List<BoundMonitor> findByEnvoyId(String envoyId);
+
+  @Query("select b from BoundMonitor b where b.zoneTenantId = :zoneTenantId and b.zone = :zone and envoyId is null")
+  List<BoundMonitor> findOnesWithoutEnvoy(String zoneTenantId, String zone);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -16,12 +16,12 @@
 
 package com.rackspace.salus.monitor_management.services;
 
-import com.rackspace.salus.monitor_management.config.ServicesProperties;
 import com.rackspace.salus.monitor_management.config.ZonesProperties;
 import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import com.rackspace.salus.monitor_management.repositories.BoundMonitorRepository;
 import com.rackspace.salus.monitor_management.repositories.MonitorRepository;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
@@ -37,11 +37,12 @@ import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.Resource;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -57,20 +58,13 @@ import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.PropertyMapper;
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
 
 @Slf4j
@@ -81,11 +75,10 @@ public class MonitorManagement {
     private final ZoneStorage zoneStorage;
     private final MonitorEventProducer monitorEventProducer;
     private final MonitorContentRenderer monitorContentRenderer;
+    private final ResourceApi resourceApi;
     private final ZonesProperties zonesProperties;
 
     private final MonitorRepository monitorRepository;
-
-    private final RestTemplate restTemplate;
 
     @PersistenceContext
     private final EntityManager entityManager;
@@ -101,8 +94,7 @@ public class MonitorManagement {
                              ZoneStorage zoneStorage,
                              MonitorEventProducer monitorEventProducer,
                              MonitorContentRenderer monitorContentRenderer,
-                             RestTemplateBuilder restTemplateBuilder,
-                             ServicesProperties servicesProperties,
+                             ResourceApi resourceApi,
                              ZonesProperties zonesProperties,
                              JdbcTemplate jdbcTemplate) {
         this.monitorRepository = monitorRepository;
@@ -112,8 +104,8 @@ public class MonitorManagement {
         this.zoneStorage = zoneStorage;
         this.monitorEventProducer = monitorEventProducer;
         this.monitorContentRenderer = monitorContentRenderer;
+        this.resourceApi = resourceApi;
         this.zonesProperties = zonesProperties;
-        this.restTemplate = restTemplateBuilder.rootUri(servicesProperties.getResourceManagementUrl()).build();
         this.jdbcTemplate = jdbcTemplate;
     }
 
@@ -209,7 +201,7 @@ public class MonitorManagement {
     }
 
     void distributeNewMonitor(Monitor monitor) {
-        final List<Resource> resources = getResourcesWithLabels(
+        final List<Resource> resources = resourceApi.getResourcesWithLabels(
             monitor.getTenantId(), monitor.getLabelSelector());
 
         log.debug("Distributing new monitor={} to resources={}", monitor, resources);
@@ -417,30 +409,6 @@ public class MonitorManagement {
     }
 
     /**
-     * Get a list of resource IDs for the tenant that match the given labels
-     *
-     * @param tenantId tenant whose resources are to be found
-     * @param labels   labels to be matched
-     * @return The list found
-     */
-    private List<Resource> getResourcesWithLabels(String tenantId, Map<String, String> labels) {
-        String endpoint = "/api/tenant/{tenantId}/resourceLabels";
-        UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(endpoint);
-        for (Map.Entry<String, String> e : labels.entrySet()) {
-            uriComponentsBuilder.queryParam(e.getKey(), e.getValue());
-        }
-        String uriString = uriComponentsBuilder.buildAndExpand(tenantId).toUriString();
-        ResponseEntity<List<Resource>> resp = restTemplate.exchange(uriString, HttpMethod.GET, null,
-                new ParameterizedTypeReference<List<Resource>>() {
-                });
-        if (resp.getStatusCode() != HttpStatus.OK || resp.getBody() == null) {
-            log.error("get failed on: " + uriString, resp.getStatusCode());
-            return Collections.emptyList();
-        }
-        return resp.getBody();
-    }
-
-    /**
      * Send a kafka event announcing the monitor operation.  Finds the envoys that match labels in the
      * current monitor as well as the ones that match the old labels, and sends and event to each envoy.
      *
@@ -448,11 +416,12 @@ public class MonitorManagement {
      * @param operationType the crud operation that occurred on the monitor
      * @param oldLabels     the old labels that were on the monitor before if this is an update operation
      */
-    void publishMonitor(Monitor monitor, OperationType operationType, Map<String, String> oldLabels) {
-        List<String> resources = extractResourceIds(getResourcesWithLabels(monitor.getTenantId(), monitor.getLabelSelector()));
+    private void publishMonitor(Monitor monitor, OperationType operationType,
+                                Map<String, String> oldLabels) {
+        List<String> resources = extractResourceIds(resourceApi.getResourcesWithLabels(monitor.getTenantId(), monitor.getLabelSelector()));
         List<String> oldResources = new ArrayList<>();
         if (oldLabels != null && !oldLabels.equals(monitor.getLabelSelector())) {
-            oldResources = extractResourceIds(getResourcesWithLabels(monitor.getTenantId(), oldLabels));
+            oldResources = extractResourceIds(resourceApi.getResourcesWithLabels(monitor.getTenantId(), oldLabels));
         }
         resources.addAll(oldResources);
 
@@ -538,36 +507,135 @@ public class MonitorManagement {
      *
      * @param event the new resource event.
      */
-    public void handleResourceEvent(ResourceEvent event) {
-        Resource r = event.getResource();
-        ResourceInfo resourceInfo = envoyResourceManagement
-                .getOne(r.getTenantId(), r.getResourceId()).join();
-        if (resourceInfo == null) {
-            return;
+    void handleResourceEvent(ResourceEvent event) {
+        final String tenantId = event.getTenantId();
+        final String resourceId = event.getResourceId();
+
+        final List<UUID> boundMonitorIds = findMonitorsBoundToResource(tenantId, resourceId);
+
+        // monitorIdsToUnbind := boundMonitorIds \setminus selectedMonitorIds
+        // ...so start with populating with boundMonitorIds
+        final Set<UUID> monitorIdsToUnbind = new HashSet<>(boundMonitorIds);
+
+        final List<Monitor> selectedMonitors;
+        final Resource resource = resourceApi.getByResourceId(tenantId, resourceId);
+        if (resource != null) {
+            // resource created or updated
+
+            selectedMonitors = getMonitorsFromLabels(resource.getLabels(), tenantId);
+
+            final List<UUID> selectedMonitorIds = selectedMonitors.stream()
+                .map(Monitor::getId)
+                .collect(Collectors.toList());
+
+            // ...the setminus operation upon monitorIdsToUnbind
+            monitorIdsToUnbind.removeAll(selectedMonitorIds);
+        }
+        else {
+            // resource deleted
+
+            selectedMonitors = Collections.emptyList();
+            // ...and monitorIdsToUnbind remains ALL of the currently bound
         }
 
-        List<Monitor> oldMonitors = null;
-        List<Monitor> monitors = getMonitorsFromLabels(event.getResource().getLabels(), event.getResource().getTenantId());
-        if (monitors == null) {
-            monitors = new ArrayList<>();
-        }
-        if (event.getOldLabels() != null && !event.getOldLabels().equals(event.getResource().getLabels())) {
-            oldMonitors = getMonitorsFromLabels(event.getOldLabels(), event.getResource().getTenantId());
-        }
-        if (oldMonitors != null) {
-            monitors.addAll(oldMonitors);
-        }
-        Map<UUID, Monitor> monitorMap = new HashMap<>();
-        // Eliminate duplicate monitors
-        for (Monitor m : monitors) {
-            monitorMap.put(m.getId(), m);
-        }
-        for (UUID id : monitorMap.keySet()) {
-            Monitor m = monitorMap.get(id);
 
-            // Make sure to send the event to Kafka
-            sendMonitorEvent(m, event.getOperation(), resourceInfo.getEnvoyId());
+
+        List<BoundMonitor> unbound = unbindByMonitorId(monitorIdsToUnbind);
+
+        final List<Monitor> monitorsToUpsert = selectedMonitors.stream()
+            .filter(monitor -> !monitorIdsToUnbind.contains(monitor.getId()))
+            .collect(Collectors.toList());
+
+        final List<BoundMonitor> bound;
+        if (!monitorsToUpsert.isEmpty()) {
+            //noinspection ConstantConditions since monitorsToUpsert and selectedMonitors would be empty
+            bound = upsertBindingToResource(monitorsToUpsert, resource);
         }
+        else {
+            bound = Collections.emptyList();
+        }
+
+        // Send MonitorBoundEvents to the distinct set of envoys affected by unbind and bind
+        // changes collected above.
+        Stream.concat(
+            unbound.stream(),
+            bound.stream()
+        )
+            .map(BoundMonitor::getEnvoyId)
+            .filter(Objects::nonNull)
+            .distinct()
+            .forEach(this::sendMonitorBoundEvent);
+    }
+
+    List<BoundMonitor> upsertBindingToResource(List<Monitor> monitors,
+                                                       Resource resource) {
+
+        final ResourceInfo resourceInfo = envoyResourceManagement
+            .getOne(resource.getTenantId(), resource.getResourceId())
+            .join();
+
+        final List<BoundMonitor> boundMonitors = new ArrayList<>();
+
+        for (Monitor monitor : monitors) {
+            final List<BoundMonitor> existing = boundMonitorRepository
+                .findByMonitor_IdAndResourceId(monitor.getId(), resourceInfo.getResourceId());
+
+            if (existing.isEmpty()) {
+                // need to create new bindings
+
+                if (monitor.getSelectorScope() == ConfigSelectorScope.ALL_OF) {
+                    // agent/local monitor
+                    boundMonitors.add(
+                        bindAgentMonitor(monitor, resource, resourceInfo.getEnvoyId())
+                    );
+                } else {
+                    // remote monitor
+                    final List<String> zones = determineMonitoringZones(monitor);
+
+                    for (String zone : zones) {
+                        boundMonitors.add(
+                            bindRemoteMonitor(monitor, resource, zone)
+                        );
+                    }
+                }
+            } else {
+                // existing bindings need to be tested and updated for rendered content changes
+
+                final String newRenderedContent = renderMonitorContent(monitor, resource);
+
+                boundMonitors.addAll(
+                    existing.stream()
+                        // rendered content change?
+                        .filter(existingBind ->
+                            !existingBind.getRenderedContent().equals(newRenderedContent))
+                        // for those that changed, modify entity
+                        .peek(existingBind -> existingBind.setRenderedContent(newRenderedContent))
+                        // and add all of these to list to save and return
+                        .collect(Collectors.toList())
+                );
+            }
+        }
+
+        boundMonitorRepository.saveAll(boundMonitors);
+
+        return boundMonitors;
+    }
+
+    List<BoundMonitor> unbindByMonitorId(Collection<UUID> monitorIdsToUnbind) {
+        if (monitorIdsToUnbind.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final List<BoundMonitor> boundMonitors = entityManager.createQuery(
+            "select b from BoundMonitor b where b.monitor.id in :monitorIds",
+            BoundMonitor.class
+        )
+            .setParameter("monitorIds", monitorIdsToUnbind)
+            .getResultList();
+
+        boundMonitorRepository.deleteAll(boundMonitors);
+
+        return boundMonitors;
     }
 
     /**

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -578,7 +578,7 @@ public class MonitorManagement {
 
         for (Monitor monitor : monitors) {
             final List<BoundMonitor> existing = boundMonitorRepository
-                .findByMonitor_IdAndResourceId(monitor.getId(), resourceInfo.getResourceId());
+                .findByMonitor_IdAndResourceId(monitor.getId(), resource.getResourceId());
 
             if (existing.isEmpty()) {
                 // need to create new bindings
@@ -586,7 +586,8 @@ public class MonitorManagement {
                 if (monitor.getSelectorScope() == ConfigSelectorScope.ALL_OF) {
                     // agent/local monitor
                     boundMonitors.add(
-                        bindAgentMonitor(monitor, resource, resourceInfo.getEnvoyId())
+                        bindAgentMonitor(monitor, resource,
+                            resourceInfo != null ? resourceInfo.getEnvoyId() : null)
                     );
                 } else {
                     // remote monitor

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -334,7 +334,7 @@ public class MonitorManagement {
         final ResolvedZone resolvedZone = resolveZone(zoneTenantId, zoneId);
 
         final List<BoundMonitor> onesWithoutEnvoy = boundMonitorRepository
-            .findOnesWithoutEnvoy(emptyStringForNull(zoneTenantId),  zoneId);
+            .findAllWithoutEnvoy(emptyStringForNull(zoneTenantId),  zoneId);
 
         log.debug("Found bound monitors without envoy: {}", onesWithoutEnvoy);
 
@@ -361,7 +361,7 @@ public class MonitorManagement {
     public void handleEnvoyResourceChangedInZone(String tenantId, String zoneId, String fromEnvoyId,
                                                  String toEnvoyId) {
 
-        final List<BoundMonitor> boundToPrev = boundMonitorRepository.findOnesWithEnvoy(
+        final List<BoundMonitor> boundToPrev = boundMonitorRepository.findAllWithEnvoy(
             emptyStringForNull(tenantId),
             zoneId,
             fromEnvoyId
@@ -541,14 +541,9 @@ public class MonitorManagement {
 
         List<BoundMonitor> unbound = unbindByMonitorId(monitorIdsToUnbind);
 
-        final List<Monitor> monitorsToUpsert = selectedMonitors.stream()
-            .filter(monitor -> !monitorIdsToUnbind.contains(monitor.getId()))
-            .collect(Collectors.toList());
-
         final List<BoundMonitor> bound;
-        if (!monitorsToUpsert.isEmpty()) {
-            //noinspection ConstantConditions since monitorsToUpsert and selectedMonitors would be empty
-            bound = upsertBindingToResource(monitorsToUpsert, resource);
+        if (!selectedMonitors.isEmpty()) {
+            bound = upsertBindingToResource(selectedMonitors, resource);
         }
         else {
             bound = Collections.emptyList();
@@ -577,7 +572,7 @@ public class MonitorManagement {
 
         for (Monitor monitor : monitors) {
             final List<BoundMonitor> existing = boundMonitorRepository
-                .findByMonitor_IdAndResourceId(monitor.getId(), resource.getResourceId());
+                .findAllByMonitor_IdAndResourceId(monitor.getId(), resource.getResourceId());
 
             if (existing.isEmpty()) {
                 // need to create new bindings

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -284,12 +284,10 @@ public class MonitorManagement {
 
     private BoundMonitor bindAgentMonitor(Monitor monitor, Resource resource, String envoyId) {
         return new BoundMonitor()
-            .setMonitorId(monitor.getId())
+            .setMonitor(monitor)
             .setResourceId(resource.getResourceId())
             .setEnvoyId(envoyId)
-            .setAgentType(monitor.getAgentType())
             .setRenderedContent(renderMonitorContent(monitor, resource))
-            .setTargetTenant("")
             .setZoneTenantId("")
             .setZoneId("");
     }
@@ -312,11 +310,9 @@ public class MonitorManagement {
         return new BoundMonitor()
             .setZoneTenantId(emptyStringForNull(resolvedZone.getTenantId()))
             .setZoneId(zone)
-            .setMonitorId(monitor.getId())
+            .setMonitor(monitor)
             .setResourceId(resource.getResourceId())
             .setEnvoyId(envoyId)
-            .setAgentType(monitor.getAgentType())
-            .setTargetTenant(monitor.getTenantId())
             .setRenderedContent(renderMonitorContent(monitor, resource));
     }
 
@@ -324,7 +320,7 @@ public class MonitorManagement {
         return input == null ? "" : input;
     }
 
-    public void handleNewResourceInZone(String zoneTenantId, String zoneId) {
+    public void handleNewEnvoyInZone(String zoneTenantId, String zoneId) {
         log.debug("Locating bound monitors without assigned envoy with zoneId={} and zoneTenantId={}",
             zoneId, zoneTenantId);
 
@@ -353,8 +349,8 @@ public class MonitorManagement {
         }
     }
 
-    public void handleZoneResourceChanged(String tenantId, String zoneId, String fromEnvoyId,
-                                          String toEnvoyId) {
+    public void handleEnvoyResourceChangedInZone(String tenantId, String zoneId, String fromEnvoyId,
+                                                 String toEnvoyId) {
 
         final List<BoundMonitor> boundToPrev = boundMonitorRepository.findOnesWithEnvoy(
             emptyStringForNull(tenantId),

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -16,6 +16,9 @@
 
 package com.rackspace.salus.monitor_management.services;
 
+import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPrivateZone;
+import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPublicZone;
+
 import com.rackspace.salus.monitor_management.config.ZonesProperties;
 import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import com.rackspace.salus.monitor_management.repositories.BoundMonitorRepository;
@@ -373,8 +376,7 @@ public class MonitorManagement {
             boundMonitorRepository.saveAll(boundToPrev);
 
             zoneStorage.incrementBoundCount(
-                new ResolvedZone().setTenantId(tenantId)
-                .setId(zoneId),
+                createPrivateZone(tenantId, zoneId),
                 toEnvoyId,
                 boundToPrev.size()
             );
@@ -393,15 +395,10 @@ public class MonitorManagement {
 
     private ResolvedZone resolveZone(String tenantId, String zone) {
         if (zone.startsWith(zonesProperties.getPublicZonePrefix())) {
-            return new ResolvedZone()
-                .setPublicZone(true)
-                .setId(zone);
+            return createPublicZone(zone);
         }
         else {
-            return new ResolvedZone()
-                .setPublicZone(false)
-                .setTenantId(tenantId)
-                .setId(zone);
+            return createPrivateZone(tenantId, zone);
         }
     }
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -316,6 +316,16 @@ public class MonitorManagement {
             .setRenderedContent(renderMonitorContent(monitor, resource));
     }
 
+    List<UUID> findMonitorsBoundToResource(String tenantId, String resourceId) {
+      return entityManager
+          .createQuery("select distinct b.monitor.id from BoundMonitor b"
+              + " where b.resourceId = :resourceId"
+              + " and b.monitor.tenantId = :tenantId", UUID.class)
+          .setParameter("tenantId", tenantId)
+          .setParameter("resourceId", resourceId)
+          .getResultList();
+    }
+
     private static String emptyStringForNull(String input) {
         return input == null ? "" : input;
     }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ResourceEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ResourceEventListener.java
@@ -32,16 +32,6 @@ public class ResourceEventListener {
         return this.topic;
     }
 
-
-    /*
-    So basically what I need to do is this:
-    identify what events will be coming in.
-    Create functions for each of those events. They might all be under the same topic so I will need to filter somehow.
-     */
-
-
-
-
     /**
      * This receives a resource event from Kafka and passes it to the monitor manager to do whatever is needed.
      * @param resourceEvent The ResourceEvent read from Kafka.

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
@@ -17,14 +17,18 @@
 package com.rackspace.salus.monitor_management.services;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
-import com.rackspace.salus.telemetry.messaging.ZoneEnvoyOfResourceChangedEvent;
+import com.rackspace.salus.telemetry.messaging.NewResourceZoneEvent;
+import com.rackspace.salus.telemetry.messaging.ReattachedResourceZoneEvent;
 import com.rackspace.salus.telemetry.messaging.ZoneEvent;
-import com.rackspace.salus.telemetry.messaging.ZoneNewResourceEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
+/**
+ * This services consumes zone events from Kafka and interacts with the internal services of
+ * monitor management to adapt to the changes conveyed by those events.
+ */
 @Service
 @Slf4j
 public class ZoneEventListener {
@@ -46,14 +50,14 @@ public class ZoneEventListener {
   public void handleEvent(ZoneEvent zoneEvent) {
     log.debug("Handling zone event={}", zoneEvent);
 
-    if (zoneEvent instanceof ZoneNewResourceEvent) {
-      final ZoneNewResourceEvent event = (ZoneNewResourceEvent) zoneEvent;
+    if (zoneEvent instanceof NewResourceZoneEvent) {
+      final NewResourceZoneEvent event = (NewResourceZoneEvent) zoneEvent;
       monitorManagement.handleNewEnvoyInZone(
           event.getTenantId(),
           event.getZoneId()
       );
-    } else if (zoneEvent instanceof ZoneEnvoyOfResourceChangedEvent) {
-      final ZoneEnvoyOfResourceChangedEvent event = (ZoneEnvoyOfResourceChangedEvent) zoneEvent;
+    } else if (zoneEvent instanceof ReattachedResourceZoneEvent) {
+      final ReattachedResourceZoneEvent event = (ReattachedResourceZoneEvent) zoneEvent;
 
       monitorManagement.handleEnvoyResourceChangedInZone(
           event.getTenantId(),

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.services;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.ZoneEnvoyOfResourceChangedEvent;
 import com.rackspace.salus.telemetry.messaging.ZoneEvent;
 import com.rackspace.salus.telemetry.messaging.ZoneNewResourceEvent;
 import lombok.extern.slf4j.Slf4j;
@@ -43,6 +44,7 @@ public class ZoneEventListener {
 
   @KafkaListener(topics = "#{__listener.topic}")
   public void handleEvent(ZoneEvent zoneEvent) {
+    log.debug("Handling zone event={}", zoneEvent);
 
     if (zoneEvent instanceof ZoneNewResourceEvent) {
       final ZoneNewResourceEvent event = (ZoneNewResourceEvent) zoneEvent;
@@ -50,9 +52,16 @@ public class ZoneEventListener {
           event.getTenantId(),
           event.getZoneId()
       );
-    }
-    else {
-      //TODO implement conditions are new event types are added
+    } else if (zoneEvent instanceof ZoneEnvoyOfResourceChangedEvent) {
+      final ZoneEnvoyOfResourceChangedEvent event = (ZoneEnvoyOfResourceChangedEvent) zoneEvent;
+
+      monitorManagement.handleZoneResourceChanged(
+          event.getTenantId(),
+          event.getZoneId(),
+          event.getFromEnvoyId(),
+          event.getToEnvoyId()
+      );
+    } else {
       log.warn("Discarding unknown ZoneEvent={}", zoneEvent);
     }
   }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
@@ -48,14 +48,14 @@ public class ZoneEventListener {
 
     if (zoneEvent instanceof ZoneNewResourceEvent) {
       final ZoneNewResourceEvent event = (ZoneNewResourceEvent) zoneEvent;
-      monitorManagement.handleNewResourceInZone(
+      monitorManagement.handleNewEnvoyInZone(
           event.getTenantId(),
           event.getZoneId()
       );
     } else if (zoneEvent instanceof ZoneEnvoyOfResourceChangedEvent) {
       final ZoneEnvoyOfResourceChangedEvent event = (ZoneEnvoyOfResourceChangedEvent) zoneEvent;
 
-      monitorManagement.handleZoneResourceChanged(
+      monitorManagement.handleEnvoyResourceChangedInZone(
           event.getTenantId(),
           event.getZoneId(),
           event.getFromEnvoyId(),

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.services;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.ZoneEvent;
+import com.rackspace.salus.telemetry.messaging.ZoneNewResourceEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class ZoneEventListener {
+
+  private final String topic;
+  private final MonitorManagement monitorManagement;
+
+  @Autowired
+  public ZoneEventListener(KafkaTopicProperties topicProperties, MonitorManagement monitorManagement) {
+    this.topic = topicProperties.getZones();
+    this.monitorManagement = monitorManagement;
+  }
+
+  public String getTopic() {
+    return topic;
+  }
+
+  @KafkaListener(topics = "#{__listener.topic}")
+  public void handleEvent(ZoneEvent zoneEvent) {
+
+    if (zoneEvent instanceof ZoneNewResourceEvent) {
+      final ZoneNewResourceEvent event = (ZoneNewResourceEvent) zoneEvent;
+      monitorManagement.handleNewResourceInZone(
+          event.getTenantId(),
+          event.getZoneId()
+      );
+    }
+    else {
+      //TODO implement conditions are new event types are added
+      log.warn("Discarding unknown ZoneEvent={}", zoneEvent);
+    }
+  }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -103,7 +103,7 @@ public class MonitorApiController implements MonitorApi {
     @Override
     @GetMapping("/boundMonitors/{envoyId}")
     public List<BoundMonitorDTO> getBoundMonitors(@PathVariable String envoyId) {
-        return boundMonitorRepository.findByEnvoyId(envoyId).stream()
+        return boundMonitorRepository.findAllByEnvoyId(envoyId).stream()
             .map(BoundMonitor::toDTO)
             .collect(Collectors.toList());
     }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.web.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import com.rackspace.salus.monitor_management.repositories.BoundMonitorRepository;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.services.MonitorManagement;
@@ -103,8 +104,7 @@ public class MonitorApiController implements MonitorApi {
     @GetMapping("/boundMonitors/{envoyId}")
     public List<BoundMonitorDTO> getBoundMonitors(@PathVariable String envoyId) {
         return boundMonitorRepository.findByEnvoyId(envoyId).stream()
-            .map(boundMonitor ->
-                objectMapper.convertValue(boundMonitor, BoundMonitorDTO.class))
+            .map(BoundMonitor::toDTO)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
@@ -25,7 +25,7 @@ public class BoundMonitorDTO {
   UUID monitorId;
   String zoneTenantId;
   String zoneId;
-  String targetTenant;
+  String resourceTenant;
   String resourceId;
   AgentType agentType;
   String renderedContent;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
@@ -23,7 +23,8 @@ import lombok.Data;
 @Data
 public class BoundMonitorDTO {
   UUID monitorId;
-  String zone;
+  String zoneTenantId;
+  String zoneId;
   String targetTenant;
   String resourceId;
   AgentType agentType;

--- a/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.repositories;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import com.rackspace.salus.monitor_management.entities.BoundMonitor;
+import com.rackspace.salus.telemetry.model.AgentType;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest(showSql = true)
+@AutoConfigureJson
+public class BoundMonitorRepositoryTest {
+
+  @Autowired
+  private TestEntityManager entityManager;
+
+  @Autowired
+  private BoundMonitorRepository repository;
+
+  @Test
+  public void testFindOnesWithoutEnvoy() {
+    final UUID m1 = UUID.randomUUID();
+
+    save(m1, "t-1", "z-1", "r-1", null, "t-1");
+    save(m1, "t-1", "z-1", "r-2", "e-1", "t-2");
+    save(m1, "", "pz-1", "r-3", null, "t-3");
+    save(m1, "", "pz-1", "r-4", "e-2", "t-4");
+
+    final List<BoundMonitor> t1z1 = repository.findOnesWithoutEnvoy("t-1", "z-1");
+    assertThat(t1z1, hasSize(1));
+    assertThat(t1z1.get(0).getResourceId(), equalTo("r-1"));
+  }
+
+  private void save(UUID monitorId, String tenant, String zone, String resource, String envoyId,
+                    String targetTenantId) {
+    entityManager.persist(new BoundMonitor()
+        .setMonitorId(monitorId)
+        .setZoneTenantId(tenant)
+        .setZoneId(zone)
+        .setResourceId(resource)
+        .setEnvoyId(envoyId)
+        .setTargetTenant(targetTenantId)
+        .setAgentType(AgentType.TELEGRAF)
+    );
+  }
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
@@ -34,7 +34,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@DataJpaTest(showSql = true)
+@DataJpaTest(showSql = false)
 @AutoConfigureJson
 public class BoundMonitorRepositoryTest {
 

--- a/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
@@ -53,11 +53,11 @@ public class BoundMonitorRepositoryTest {
     save(monitor, "", "public/1", "r-3", null);
     save(monitor, "", "public/1", "r-4", "e-2");
 
-    final List<BoundMonitor> t1z1 = repository.findOnesWithoutEnvoy("t-1", "z-1");
+    final List<BoundMonitor> t1z1 = repository.findAllWithoutEnvoy("t-1", "z-1");
     assertThat(t1z1, hasSize(1));
     assertThat(t1z1.get(0).getResourceId(), equalTo("r-1"));
 
-    final List<BoundMonitor> publicResults = repository.findOnesWithoutEnvoy("", "public/1");
+    final List<BoundMonitor> publicResults = repository.findAllWithoutEnvoy("", "public/1");
     assertThat(publicResults, hasSize(1));
     assertThat(publicResults.get(0).getResourceId(), equalTo("r-3"));
   }
@@ -81,12 +81,12 @@ public class BoundMonitorRepositoryTest {
     save(monitor, "", "public/1", "r-5", "e-1");
     save(monitor, "", "public/2", "r-6", "e-1");
 
-    final List<BoundMonitor> t1z1 = repository.findOnesWithEnvoy("t-1", "z-1", "e-1");
+    final List<BoundMonitor> t1z1 = repository.findAllWithEnvoy("t-1", "z-1", "e-1");
     assertThat(t1z1, hasSize(2));
     assertThat(t1z1.get(0).getResourceId(), equalTo("r-2"));
     assertThat(t1z1.get(1).getResourceId(), equalTo("r-3"));
 
-    final List<BoundMonitor> publicResults = repository.findOnesWithEnvoy("", "public/1", "e-1");
+    final List<BoundMonitor> publicResults = repository.findAllWithEnvoy("", "public/1", "e-1");
     assertThat(publicResults, hasSize(1));
     assertThat(publicResults.get(0).getResourceId(), equalTo("r-5"));
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
@@ -49,12 +49,37 @@ public class BoundMonitorRepositoryTest {
 
     save(m1, "t-1", "z-1", "r-1", null, "t-1");
     save(m1, "t-1", "z-1", "r-2", "e-1", "t-2");
-    save(m1, "", "pz-1", "r-3", null, "t-3");
-    save(m1, "", "pz-1", "r-4", "e-2", "t-4");
+    save(m1, "", "public/1", "r-3", null, "t-3");
+    save(m1, "", "public/1", "r-4", "e-2", "t-4");
 
     final List<BoundMonitor> t1z1 = repository.findOnesWithoutEnvoy("t-1", "z-1");
     assertThat(t1z1, hasSize(1));
     assertThat(t1z1.get(0).getResourceId(), equalTo("r-1"));
+
+    final List<BoundMonitor> publicResults = repository.findOnesWithoutEnvoy("", "public/1");
+    assertThat(publicResults, hasSize(1));
+    assertThat(publicResults.get(0).getResourceId(), equalTo("r-3"));
+  }
+
+  @Test
+  public void testFindOnesWithEnvoy() {
+    final UUID m1 = UUID.randomUUID();
+
+    save(m1, "t-1", "z-1", "r-1", null, "t-1");
+    save(m1, "t-1", "z-1", "r-2", "e-1", "t-1");
+    save(m1, "t-1", "z-1", "r-3", "e-1", "t-1");
+    save(m1, "", "public/1", "r-4", null, "t-4");
+    save(m1, "", "public/1", "r-5", "e-1", "t-4");
+    save(m1, "", "public/2", "r-6", "e-1", "t-4");
+
+    final List<BoundMonitor> t1z1 = repository.findOnesWithEnvoy("t-1", "z-1", "e-1");
+    assertThat(t1z1, hasSize(2));
+    assertThat(t1z1.get(0).getResourceId(), equalTo("r-2"));
+    assertThat(t1z1.get(1).getResourceId(), equalTo("r-3"));
+
+    final List<BoundMonitor> publicResults = repository.findOnesWithEnvoy("", "public/1", "e-1");
+    assertThat(publicResults, hasSize(1));
+    assertThat(publicResults.get(0).getResourceId(), equalTo("r-5"));
   }
 
   private void save(UUID monitorId, String tenant, String zone, String resource, String envoyId,

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentRendererTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentRendererTest.java
@@ -42,7 +42,7 @@ public class MonitorContentRendererTest {
     final MonitorContentRenderer renderer = new MonitorContentRenderer(properties);
 
     assertThat(renderer.render(
-        "{\"type\": \"ping\", \"urls\": [\"<<resource.metadata.public_ip>>\"]}",
+        "{\"type\": \"ping\", \"urls\": [\"${resource.metadata.public_ip}\"]}",
         resource
     ), equalTo("{\"type\": \"ping\", \"urls\": [\"150.1.2.3\"]}"));
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -592,11 +592,9 @@ public class MonitorManagementTest {
             Collections.singletonList(
                 new BoundMonitor()
                     .setResourceId(DEFAULT_RESOURCE_ID)
-                    .setMonitorId(monitor.getId())
+                    .setMonitor(monitor)
                     .setEnvoyId(DEFAULT_ENVOY_ID)
-                    .setAgentType(AgentType.TELEGRAF)
                     .setRenderedContent("{}")
-                    .setTargetTenant("")
                     .setZoneTenantId("")
                     .setZoneId("")
             )
@@ -661,37 +659,29 @@ public class MonitorManagementTest {
         verify(boundMonitorRepository).saveAll(Arrays.asList(
             new BoundMonitor()
                 .setResourceId("r-1")
-                .setMonitorId(monitor.getId())
+                .setMonitor(monitor)
                 .setEnvoyId("zone1-e-1")
-                .setAgentType(AgentType.TELEGRAF)
-                .setTargetTenant("t-1")
                 .setRenderedContent("{\"type\": \"ping\", \"urls\": [\"151.1.1.1\"]}")
                 .setZoneTenantId("t-1")
                 .setZoneId("zone1"),
             new BoundMonitor()
                 .setResourceId("r-1")
-                .setMonitorId(monitor.getId())
+                .setMonitor(monitor)
                 .setEnvoyId("zoneWest-e-2")
-                .setAgentType(AgentType.TELEGRAF)
-                .setTargetTenant("t-1")
                 .setRenderedContent("{\"type\": \"ping\", \"urls\": [\"151.1.1.1\"]}")
                 .setZoneTenantId("")
                 .setZoneId("public/west"),
             new BoundMonitor()
                 .setResourceId("r-2")
-                .setMonitorId(monitor.getId())
+                .setMonitor(monitor)
                 .setEnvoyId("zone1-e-1")
-                .setAgentType(AgentType.TELEGRAF)
-                .setTargetTenant("t-1")
                 .setRenderedContent("{\"type\": \"ping\", \"urls\": [\"151.2.2.2\"]}")
                 .setZoneTenantId("t-1")
                 .setZoneId("zone1"),
             new BoundMonitor()
                 .setResourceId("r-2")
-                .setMonitorId(monitor.getId())
+                .setMonitor(monitor)
                 .setEnvoyId("zoneWest-e-2")
-                .setAgentType(AgentType.TELEGRAF)
-                .setTargetTenant("t-1")
                 .setRenderedContent("{\"type\": \"ping\", \"urls\": [\"151.2.2.2\"]}")
                 .setZoneTenantId("")
                 .setZoneId("public/west")
@@ -738,9 +728,7 @@ public class MonitorManagementTest {
         verify(boundMonitorRepository).saveAll(Collections.singletonList(
             new BoundMonitor()
                 .setResourceId(DEFAULT_RESOURCE_ID)
-                .setMonitorId(monitor.getId())
-                .setAgentType(AgentType.TELEGRAF)
-                .setTargetTenant("t-1")
+                .setMonitor(monitor)
                 .setRenderedContent("{}")
                 .setZoneTenantId("t-1")
                 .setZoneId("zone1")
@@ -782,7 +770,7 @@ public class MonitorManagementTest {
         when(boundMonitorRepository.findOnesWithoutEnvoy(any(), any()))
             .thenReturn(unassignedOnes);
 
-        monitorManagement.handleNewResourceInZone("t-1", "z-1");
+        monitorManagement.handleNewEnvoyInZone("t-1", "z-1");
 
         verify(zoneStorage, times(3)).findLeastLoadedEnvoy(
             new ResolvedZone()
@@ -825,7 +813,7 @@ public class MonitorManagementTest {
         when(boundMonitorRepository.findOnesWithEnvoy(any(), any(), any()))
             .thenReturn(boundMonitors);
 
-        monitorManagement.handleZoneResourceChanged("t-1", "z-1", "e-1", "e-2");
+        monitorManagement.handleEnvoyResourceChangedInZone("t-1", "z-1", "e-1", "e-2");
 
         verify(boundMonitorRepository).findOnesWithEnvoy("t-1", "z-1", "e-1");
 
@@ -871,7 +859,7 @@ public class MonitorManagementTest {
             .thenReturn(boundMonitors);
 
         // The main thing being tested is that a null zone tenant ID
-        monitorManagement.handleZoneResourceChanged(null, "public/1", "e-1", "e-2");
+        monitorManagement.handleEnvoyResourceChangedInZone(null, "public/1", "e-1", "e-2");
 
         // ...gets normalized into an empty string for the query
         verify(boundMonitorRepository).findOnesWithEnvoy("", "public/1", "e-1");

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -16,6 +16,8 @@
 
 package com.rackspace.salus.monitor_management.services;
 
+import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPrivateZone;
+import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPublicZone;
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -577,11 +579,8 @@ public class MonitorManagementTest {
 
     @Test
     public void testDistributeNewMonitor_remote() throws JsonProcessingException {
-        final ResolvedZone zone1 = new ResolvedZone()
-            .setTenantId("t-1")
-            .setId("zone1");
-        final ResolvedZone zoneWest = new ResolvedZone()
-            .setId("public/west");
+        final ResolvedZone zone1 = createPrivateZone("t-1", "zone1");
+        final ResolvedZone zoneWest = createPublicZone("public/west");
 
         when(zoneStorage.findLeastLoadedEnvoy(zone1))
             .thenReturn(CompletableFuture.completedFuture(
@@ -668,9 +667,7 @@ public class MonitorManagementTest {
 
     @Test
     public void testDistributeNewMonitor_remote_emptyZone() {
-        final ResolvedZone zone1 = new ResolvedZone()
-            .setTenantId("t-1")
-            .setId("zone1");
+        final ResolvedZone zone1 = createPrivateZone("t-1", "zone1");
 
         when(zoneStorage.findLeastLoadedEnvoy(zone1))
             .thenReturn(CompletableFuture.completedFuture(
@@ -743,9 +740,7 @@ public class MonitorManagementTest {
         monitorManagement.handleNewEnvoyInZone("t-1", "z-1");
 
         verify(zoneStorage, times(3)).findLeastLoadedEnvoy(
-            new ResolvedZone()
-                .setTenantId("t-1")
-                .setId("z-1")
+            createPrivateZone("t-1", "z-1")
         );
 
         // two assignments to same envoy, but verify only one event
@@ -814,8 +809,7 @@ public class MonitorManagementTest {
         // VERIFY
 
         verify(zoneStorage, times(3)).findLeastLoadedEnvoy(
-            new ResolvedZone()
-                .setId("public/west")
+            createPublicZone("public/west")
         );
 
         // two assignments to same envoy, but verify only one event
@@ -875,7 +869,7 @@ public class MonitorManagementTest {
         ));
 
         verify(zoneStorage).incrementBoundCount(
-            new ResolvedZone().setTenantId("t-1").setId("z-1"),
+            createPrivateZone("t-1", "z-1"),
             "e-2",
             3
         );
@@ -922,7 +916,7 @@ public class MonitorManagementTest {
         ));
 
         verify(zoneStorage).incrementBoundCount(
-            new ResolvedZone().setId("public/1"),
+            createPublicZone("public/1"),
             "e-2",
             3
         );
@@ -1133,8 +1127,8 @@ public class MonitorManagementTest {
 
         verify(envoyResourceManagement).getOne("t-1", "r-1");
 
-        final ResolvedZone z1 = new ResolvedZone().setTenantId("t-1").setId("z-1");
-        final ResolvedZone z2 = new ResolvedZone().setTenantId("t-1").setId("z-2");
+        final ResolvedZone z1 = createPrivateZone("t-1", "z-1");
+        final ResolvedZone z2 = createPrivateZone("t-1", "z-2");
         verify(zoneStorage).findLeastLoadedEnvoy(z1);
         verify(zoneStorage).findLeastLoadedEnvoy(z2);
         verify(zoneStorage).incrementBoundCount(z1, "e-2");
@@ -1209,7 +1203,7 @@ public class MonitorManagementTest {
 
         verify(envoyResourceManagement).getOne("t-1", "r-1");
 
-        final ResolvedZone z1 = new ResolvedZone().setTenantId("t-1").setId("z-1");
+        final ResolvedZone z1 = createPrivateZone("t-1", "z-1");
         verify(zoneStorage).findLeastLoadedEnvoy(z1);
 
         verify(boundMonitorRepository).findByMonitor_IdAndResourceId(m0, "r-1");

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
@@ -48,7 +48,7 @@ public class ZoneEventListenerTest {
         .setZoneId("z-1")
     );
 
-    verify(monitorManagement).handleNewResourceInZone("t-1", "z-1");
+    verify(monitorManagement).handleNewEnvoyInZone("t-1", "z-1");
   }
 
   @Test
@@ -61,7 +61,7 @@ public class ZoneEventListenerTest {
             .setZoneId("z-1")
     );
 
-    verify(monitorManagement).handleZoneResourceChanged(
+    verify(monitorManagement).handleEnvoyResourceChangedInZone(
         "t-1", "z-1", "e-1", "e-2");
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.services;
+
+import static org.mockito.Mockito.verify;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.ZoneEnvoyOfResourceChangedEvent;
+import com.rackspace.salus.telemetry.messaging.ZoneNewResourceEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ZoneEventListenerTest {
+
+  @Mock
+  MonitorManagement monitorManagement;
+  private ZoneEventListener zoneEventListener;
+
+  @Before
+  public void setUp() throws Exception {
+    KafkaTopicProperties topicProperties = new KafkaTopicProperties();
+    zoneEventListener = new ZoneEventListener(topicProperties, monitorManagement);
+  }
+
+  @Test
+  public void testZoneNewResourceEvent() {
+    zoneEventListener.handleEvent(
+        new ZoneNewResourceEvent()
+        .setTenantId("t-1")
+        .setZoneId("z-1")
+    );
+
+    verify(monitorManagement).handleNewResourceInZone("t-1", "z-1");
+  }
+
+  @Test
+  public void testZoneEnvoyOfResourceChangedEvent() {
+    zoneEventListener.handleEvent(
+        new ZoneEnvoyOfResourceChangedEvent()
+            .setFromEnvoyId("e-1")
+            .setToEnvoyId("e-2")
+            .setTenantId("t-1")
+            .setZoneId("z-1")
+    );
+
+    verify(monitorManagement).handleZoneResourceChanged(
+        "t-1", "z-1", "e-1", "e-2");
+  }
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
@@ -19,8 +19,8 @@ package com.rackspace.salus.monitor_management.services;
 import static org.mockito.Mockito.verify;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
-import com.rackspace.salus.telemetry.messaging.ZoneEnvoyOfResourceChangedEvent;
-import com.rackspace.salus.telemetry.messaging.ZoneNewResourceEvent;
+import com.rackspace.salus.telemetry.messaging.NewResourceZoneEvent;
+import com.rackspace.salus.telemetry.messaging.ReattachedResourceZoneEvent;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,7 +43,7 @@ public class ZoneEventListenerTest {
   @Test
   public void testZoneNewResourceEvent() {
     zoneEventListener.handleEvent(
-        new ZoneNewResourceEvent()
+        new NewResourceZoneEvent()
         .setTenantId("t-1")
         .setZoneId("z-1")
     );
@@ -54,7 +54,7 @@ public class ZoneEventListenerTest {
   @Test
   public void testZoneEnvoyOfResourceChangedEvent() {
     zoneEventListener.handleEvent(
-        new ZoneEnvoyOfResourceChangedEvent()
+        new ReattachedResourceZoneEvent()
             .setFromEnvoyId("e-1")
             .setToEnvoyId("e-2")
             .setTenantId("t-1")


### PR DESCRIPTION
# Resolves

Part of
- https://jira.rax.io/browse/SALUS-263
- https://jira.rax.io/browse/SALUS-311
- https://jira.rax.io/browse/SALUS-316

# What

Referring to the diagram sections starting at 

https://one.rackspace.com/pages/viewpage.action?pageId=577472836#ExplicitPollerPickingDesign-EntityDiagrams 

this PR supports processing of the new zone events introduced in https://github.com/racker/salus-telemetry-zone-management/pull/1 by handling the cases when a new envoy-resource registers in a zone and when a new envoy-resource instance re-registers for the same resource in the expected zones.

It also adjusts the resource event handling code to adapt to the new event structure from https://github.com/racker/salus-telemetry-model/pull/40 by computing corresponding monitoring binding creations, change, and removal based on resource changes.

## How to test

Lots of new unit test cases were added for the new scenarios.

# Depends on
- https://github.com/racker/salus-telemetry-model/pull/43
- https://github.com/racker/salus-common/pull/15