### PR TITLE
Adam9500/salus 330 add swagger documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,12 @@
       <artifactId>swagger-hibernate-validations</artifactId>
       <version>1.5.6</version>
     </dependency>
-
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-tools</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -165,8 +170,8 @@
             <apiSource>
               <springmvc>true</springmvc>
               <locations>
-                <location>com.rackspace.salus.resource_management.web.model</location>
-                <location>com.rackspace.salus.resource_management.web.controller.ResourceApi</location>
+                <location>com.rackspace.salus.monitor_management.web.model</location>
+                <location>com.rackspace.salus.monitor_management.web.controller.MonitorApiController</location>
               </locations>
               <templatePath>${basedir}/templates/strapdown.html.hbs</templatePath>
               <schemes>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,28 @@
           </dependency>
         </dependencies>
       </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.2.1</version>
+
+        <executions>
+          <execution>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <classpathScope>test</classpathScope>
+          <mainClass>com.rackspace.salus.salus_tools.converter.SwaggerJsonConverter</mainClass>
+          <arguments>
+            <argument>${project.build.directory}/generated/swagger</argument>
+          </arguments>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
       <version>7.2.1.RELEASE</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-hibernate-validations</artifactId>
+      <version>1.5.6</version>
+    </dependency>
 
   </dependencies>
 
@@ -150,6 +155,50 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.github.kongchen</groupId>
+        <artifactId>swagger-maven-plugin</artifactId>
+        <version>3.1.8</version>
+        <configuration>
+          <apiSources>
+            <apiSource>
+              <springmvc>true</springmvc>
+              <locations>
+                <location>com.rackspace.salus.resource_management.web.model</location>
+                <location>com.rackspace.salus.resource_management.web.controller.ResourceApi</location>
+              </locations>
+              <templatePath>${basedir}/templates/strapdown.html.hbs</templatePath>
+              <schemes>
+                <scheme> https </scheme>
+                <scheme> http </scheme>
+              </schemes>
+              <info>
+                <title>Salus Resource Management</title>
+                <version>0.1.0</version>
+              </info>
+              <outputPath>${project.build.directory}/generated/swagger/document.html</outputPath>
+              <swaggerDirectory>${project.build.directory}/generated/swagger</swaggerDirectory>
+              <outputFormats>json</outputFormats>
+            </apiSource>
+          </apiSources>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-hibernate-validations</artifactId>
+            <version>1.5.6</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -171,8 +171,8 @@
               </locations>
               <templatePath>${basedir}/templates/strapdown.html.hbs</templatePath>
               <schemes>
-                <scheme> https </scheme>
-                <scheme> http </scheme>
+                <scheme>https</scheme>
+                <scheme>http</scheme>
               </schemes>
               <info>
                 <title>Salus Resource Management</title>
@@ -205,7 +205,6 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.2.1</version>
-
         <executions>
           <execution>
             <phase>test-compile</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-protocol</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.1.1</version>
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>
@@ -85,6 +85,18 @@
         <groupId>com.rackspace.salus</groupId>
         <artifactId>salus-telemetry-etcd-adapter</artifactId>
         <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-resource-management</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <classifier>client</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
                 <scheme>http</scheme>
               </schemes>
               <info>
-                <title>Salus Resource Management</title>
+                <title>Salus Monitor Management</title>
                 <version>0.1.0</version>
               </info>
               <outputPath>${project.build.directory}/generated/swagger/document.html</outputPath>

--- a/src/main/java/com/rackspace/salus/monitor_management/config/MonitorContentProperties.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/MonitorContentProperties.java
@@ -29,5 +29,5 @@ public class MonitorContentProperties {
    * Allows configuration of the delimiters used by jmustache for monitor content template
    * rendering. The default avoids conflicting with "{{ }}" used by Insomnia for its templating.
    */
-  String placeholderDelimiters = "<< >>";
+  String placeholderDelimiters = "${ }";
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/config/RestClientsConfig.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/RestClientsConfig.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.monitor_management.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.resource_management.web.client.ResourceApiClient;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,8 +35,8 @@ public class RestClientsConfig {
   }
 
   @Bean
-  public ResourceApi resourceApi(RestTemplateBuilder restTemplateBuilder) {
-    return new ResourceApiClient(
+  public ResourceApi resourceApi(RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper) {
+    return new ResourceApiClient(objectMapper,
         restTemplateBuilder.rootUri(servicesProperties.getResourceManagementUrl())
         .build()
     );

--- a/src/main/java/com/rackspace/salus/monitor_management/config/RestClientsConfig.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/RestClientsConfig.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.config;
+
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.client.ResourceApiClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RestClientsConfig {
+
+  private final ServicesProperties servicesProperties;
+
+  @Autowired
+  public RestClientsConfig(ServicesProperties servicesProperties) {
+    this.servicesProperties = servicesProperties;
+  }
+
+  @Bean
+  public ResourceApi resourceApi(RestTemplateBuilder restTemplateBuilder) {
+    return new ResourceApiClient(
+        restTemplateBuilder.rootUri(servicesProperties.getResourceManagementUrl())
+        .build()
+    );
+  }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/config/ServicesProperties.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/ServicesProperties.java
@@ -20,6 +20,7 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+@SuppressWarnings("ConfigurationProperties")
 @ConfigurationProperties("services")
 @Component
 @Data

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
@@ -18,9 +18,19 @@ package com.rackspace.salus.monitor_management.repositories;
 
 import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, BoundMonitor.PrimaryKey> {
 
-  List<BoundMonitor> findByEnvoyId(String envoyId);
+  List<BoundMonitor> findAllByEnvoyId(String envoyId);
+
+  @Query("select b from BoundMonitor b where b.zoneTenantId = :zoneTenantId and b.zoneId = :zoneId and b.envoyId is null")
+  List<BoundMonitor> findAllWithoutEnvoy(String zoneTenantId, String zoneId);
+
+  @Query("select b from BoundMonitor b where b.zoneTenantId = :zoneTenantId and b.zoneId = :zoneId and b.envoyId = :envoyId")
+  List<BoundMonitor> findAllWithEnvoy(String zoneTenantId, String zoneId, String envoyId);
+
+  List<BoundMonitor> findAllByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ResourceEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ResourceEventListener.java
@@ -32,16 +32,6 @@ public class ResourceEventListener {
         return this.topic;
     }
 
-
-    /*
-    So basically what I need to do is this:
-    identify what events will be coming in.
-    Create functions for each of those events. They might all be under the same topic so I will need to filter somehow.
-     */
-
-
-
-
     /**
      * This receives a resource event from Kafka and passes it to the monitor manager to do whatever is needed.
      * @param resourceEvent The ResourceEvent read from Kafka.

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.services;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.NewResourceZoneEvent;
+import com.rackspace.salus.telemetry.messaging.ReattachedResourceZoneEvent;
+import com.rackspace.salus.telemetry.messaging.ZoneEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+/**
+ * This services consumes zone events from Kafka and interacts with the internal services of
+ * monitor management to adapt to the changes conveyed by those events.
+ */
+@Service
+@Slf4j
+public class ZoneEventListener {
+
+  private final String topic;
+  private final MonitorManagement monitorManagement;
+
+  @Autowired
+  public ZoneEventListener(KafkaTopicProperties topicProperties, MonitorManagement monitorManagement) {
+    this.topic = topicProperties.getZones();
+    this.monitorManagement = monitorManagement;
+  }
+
+  public String getTopic() {
+    return topic;
+  }
+
+  @KafkaListener(topics = "#{__listener.topic}")
+  public void handleEvent(ZoneEvent zoneEvent) {
+    log.debug("Handling zone event={}", zoneEvent);
+
+    if (zoneEvent instanceof NewResourceZoneEvent) {
+      final NewResourceZoneEvent event = (NewResourceZoneEvent) zoneEvent;
+      monitorManagement.handleNewEnvoyInZone(
+          event.getTenantId(),
+          event.getZoneId()
+      );
+    } else if (zoneEvent instanceof ReattachedResourceZoneEvent) {
+      final ReattachedResourceZoneEvent event = (ReattachedResourceZoneEvent) zoneEvent;
+
+      monitorManagement.handleEnvoyResourceChangedInZone(
+          event.getTenantId(),
+          event.getZoneId(),
+          event.getFromEnvoyId(),
+          event.getToEnvoyId()
+      );
+    } else {
+      log.warn("Discarding unknown ZoneEvent={}", zoneEvent);
+    }
+  }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.web.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import com.rackspace.salus.monitor_management.repositories.BoundMonitorRepository;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.services.MonitorManagement;
@@ -102,9 +103,8 @@ public class MonitorApiController implements MonitorApi {
     @Override
     @GetMapping("/boundMonitors/{envoyId}")
     public List<BoundMonitorDTO> getBoundMonitors(@PathVariable String envoyId) {
-        return boundMonitorRepository.findByEnvoyId(envoyId).stream()
-            .map(boundMonitor ->
-                objectMapper.convertValue(boundMonitor, BoundMonitorDTO.class))
+        return boundMonitorRepository.findAllByEnvoyId(envoyId).stream()
+            .map(BoundMonitor::toDTO)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -59,9 +59,9 @@ import io.swagger.annotations.*;
 @Api(description = "Monitor operations", authorizations = {
         @Authorization(value = "repose_auth",
                 scopes = {
-                        @AuthorizationScope(scope = "write:resource", description = "modify Monitors in your account"),
-                        @AuthorizationScope(scope = "read:resource", description = "read your Monitors"),
-                        @AuthorizationScope(scope = "delete:resource", description = "delete your Monitors")
+                        @AuthorizationScope(scope = "write:monitor", description = "modify Monitors in your account"),
+                        @AuthorizationScope(scope = "read:monitor", description = "read your Monitors"),
+                        @AuthorizationScope(scope = "delete:monitor", description = "delete your Monitors")
                 })
 })
 public class MonitorApiController implements MonitorApi {
@@ -144,6 +144,7 @@ public class MonitorApiController implements MonitorApi {
     @PostMapping("/tenant/{tenantId}/monitors")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "Creates new Monitor for Tenant")
+    @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Monitor")})
     public DetailedMonitorOutput create(@PathVariable String tenantId,
                                         @Valid @RequestBody final DetailedMonitorInput input)
             throws IllegalArgumentException {
@@ -170,6 +171,7 @@ public class MonitorApiController implements MonitorApi {
     @DeleteMapping("/tenant/{tenantId}/monitors/{uuid}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @ApiOperation(value = "Deletes specific Monitor for Tenant")
+    @ApiResponses(value = { @ApiResponse(code = 204, message = "Resource Deleted")})
     public void delete(@PathVariable String tenantId,
                        @PathVariable UUID uuid) {
         monitorManagement.removeMonitor(tenantId, uuid);

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -51,10 +51,19 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import io.swagger.annotations.*;
 
 @Slf4j
 @RestController
 @RequestMapping("/api")
+@Api(description = "Monitor operations", authorizations = {
+        @Authorization(value = "repose_auth",
+                scopes = {
+                        @AuthorizationScope(scope = "write:resource", description = "modify Monitors in your account"),
+                        @AuthorizationScope(scope = "read:resource", description = "read your Monitors"),
+                        @AuthorizationScope(scope = "delete:resource", description = "delete your Monitors")
+                })
+})
 public class MonitorApiController implements MonitorApi {
 
     private MonitorManagement monitorManagement;
@@ -75,6 +84,7 @@ public class MonitorApiController implements MonitorApi {
     }
 
     @GetMapping("/monitors")
+    @ApiOperation(value = "Gets all Monitors irrespective of Tenant")
     public Page<DetailedMonitorOutput> getAll(@RequestParam(defaultValue = "100") int size,
                                 @RequestParam(defaultValue = "0") int page) {
 
@@ -102,6 +112,7 @@ public class MonitorApiController implements MonitorApi {
 
     @Override
     @GetMapping("/boundMonitors/{envoyId}")
+    @ApiOperation(value = "Gets all BoundMonitors attached to a particular Envoy")
     public List<BoundMonitorDTO> getBoundMonitors(@PathVariable String envoyId) {
         return boundMonitorRepository.findAllByEnvoyId(envoyId).stream()
             .map(BoundMonitor::toDTO)
@@ -109,6 +120,7 @@ public class MonitorApiController implements MonitorApi {
     }
 
     @GetMapping("/tenant/{tenantId}/monitors/{uuid}")
+    @ApiOperation(value = "Gets specific Monitor for Tenant")
     public DetailedMonitorOutput getById(@PathVariable String tenantId,
                                          @PathVariable UUID uuid) throws NotFoundException {
         Monitor monitor = monitorManagement.getMonitor(tenantId, uuid);
@@ -120,6 +132,7 @@ public class MonitorApiController implements MonitorApi {
     }
 
     @GetMapping("/tenant/{tenantId}/monitors")
+    @ApiOperation(value = "Gets all Monitors for Tenant")
     public Page<DetailedMonitorOutput> getAllForTenant(@PathVariable String tenantId,
                                          @RequestParam(defaultValue = "100") int size,
                                          @RequestParam(defaultValue = "0") int page) {
@@ -130,6 +143,7 @@ public class MonitorApiController implements MonitorApi {
 
     @PostMapping("/tenant/{tenantId}/monitors")
     @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "Creates new Monitor for Tenant")
     public DetailedMonitorOutput create(@PathVariable String tenantId,
                                         @Valid @RequestBody final DetailedMonitorInput input)
             throws IllegalArgumentException {
@@ -141,6 +155,7 @@ public class MonitorApiController implements MonitorApi {
     }
 
     @PutMapping("/tenant/{tenantId}/monitors/{uuid}")
+    @ApiOperation(value = "Updates specific Monitor for Tenant")
     public DetailedMonitorOutput update(@PathVariable String tenantId,
                           @PathVariable UUID uuid,
                           @Valid @RequestBody final DetailedMonitorInput input) throws IllegalArgumentException {
@@ -154,12 +169,14 @@ public class MonitorApiController implements MonitorApi {
 
     @DeleteMapping("/tenant/{tenantId}/monitors/{uuid}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ApiOperation(value = "Deletes specific Monitor for Tenant")
     public void delete(@PathVariable String tenantId,
                        @PathVariable UUID uuid) {
         monitorManagement.removeMonitor(tenantId, uuid);
     }
 
     @GetMapping("/tenant/{tenantId}/monitorLabels")
+    @ApiOperation(value = "Gets all Monitors that match labels. All labels must match to retrieve relevant Monitors.")
     public List<Monitor> getMonitorsWithLabels(@PathVariable String tenantId,
                                                  @RequestBody Map<String, String> labels) {
         return monitorManagement.getMonitorsFromLabels(labels, tenantId);

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
@@ -23,8 +23,9 @@ import lombok.Data;
 @Data
 public class BoundMonitorDTO {
   UUID monitorId;
-  String zone;
-  String targetTenant;
+  String zoneTenantId;
+  String zoneId;
+  String resourceTenant;
   String resourceId;
   AgentType agentType;
   String renderedContent;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
@@ -26,7 +26,6 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 @Data
-@ApiModel(discriminator="details", subTypes={LocalMonitorDetails.class, RemoteMonitorDetails.class})
 public class DetailedMonitorInput {
   String name;
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
@@ -20,9 +20,13 @@ import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 @Data
+@ApiModel(discriminator="details", subTypes={LocalMonitorDetails.class, RemoteMonitorDetails.class})
 public class DetailedMonitorInput {
   String name;
 
@@ -33,6 +37,7 @@ public class DetailedMonitorInput {
   @NotEmpty
   Map<String,String> labelSelector;
 
+  @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\",\"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false,\"reportActive\": false, \"totalcpu\": true}}")
   @NotNull @Valid
   MonitorDetails details;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
@@ -19,12 +19,17 @@ package com.rackspace.salus.monitor_management.web.model;
 
 
 import java.util.Map;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 @Data
+@ApiModel(discriminator="details", subTypes={LocalMonitorDetails.class, RemoteMonitorDetails.class})
 public class DetailedMonitorOutput {
     String id;
     String name;
     Map<String,String> labelSelector;
+    @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\", \"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false, \"reportActive\": false, \"totalcpu\": true} }")
     MonitorDetails details;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 @Data
-@ApiModel(discriminator="details", subTypes={LocalMonitorDetails.class, RemoteMonitorDetails.class})
 public class DetailedMonitorOutput {
     String id;
     String name;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalMonitorDetails.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalMonitorDetails.java
@@ -19,9 +19,11 @@ package com.rackspace.salus.monitor_management.web.model;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import io.swagger.annotations.ApiModel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+@ApiModel(parent=MonitorDetails.class)
 @Data @EqualsAndHashCode(callSuper = false)
 public class LocalMonitorDetails extends MonitorDetails {
   @NotNull @Valid

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDetails.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDetails.java
@@ -20,10 +20,13 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
+@ApiModel(discriminator="type", subTypes={LocalMonitorDetails.class, RemoteMonitorDetails.class})
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonSubTypes({
-    @Type(name = "local", value = LocalMonitorDetails.class),
+    @Type(name = "local", value=LocalMonitorDetails.class),
     @Type(name = "remote", value=RemoteMonitorDetails.class)
 })
 public abstract class MonitorDetails {

--- a/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.repositories;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import com.rackspace.salus.monitor_management.entities.BoundMonitor;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.Monitor;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest(showSql = false)
+@AutoConfigureJson
+public class BoundMonitorRepositoryTest {
+
+  @Autowired
+  private TestEntityManager entityManager;
+
+  @Autowired
+  private BoundMonitorRepository repository;
+
+  @Test
+  public void testFindOnesWithoutEnvoy() {
+    final Monitor monitor = createMonitor();
+
+    save(monitor, "t-1", "z-1", "r-1", null);
+    save(monitor, "t-1", "z-1", "r-2", "e-1");
+    save(monitor, "", "public/1", "r-3", null);
+    save(monitor, "", "public/1", "r-4", "e-2");
+
+    final List<BoundMonitor> t1z1 = repository.findAllWithoutEnvoy("t-1", "z-1");
+    assertThat(t1z1, hasSize(1));
+    assertThat(t1z1.get(0).getResourceId(), equalTo("r-1"));
+
+    final List<BoundMonitor> publicResults = repository.findAllWithoutEnvoy("", "public/1");
+    assertThat(publicResults, hasSize(1));
+    assertThat(publicResults.get(0).getResourceId(), equalTo("r-3"));
+  }
+
+  private Monitor createMonitor() {
+    return entityManager.persist(new Monitor()
+        .setAgentType(AgentType.TELEGRAF)
+        .setContent("{}")
+        .setTenantId("monitor-t-1")
+    );
+  }
+
+  @Test
+  public void testFindOnesWithEnvoy() {
+    final Monitor monitor = createMonitor();
+
+    save(monitor, "t-1", "z-1", "r-1", null);
+    save(monitor, "t-1", "z-1", "r-2", "e-1");
+    save(monitor, "t-1", "z-1", "r-3", "e-1");
+    save(monitor, "", "public/1", "r-4", null);
+    save(monitor, "", "public/1", "r-5", "e-1");
+    save(monitor, "", "public/2", "r-6", "e-1");
+
+    final List<BoundMonitor> t1z1 = repository.findAllWithEnvoy("t-1", "z-1", "e-1");
+    assertThat(t1z1, hasSize(2));
+    assertThat(t1z1.get(0).getResourceId(), equalTo("r-2"));
+    assertThat(t1z1.get(1).getResourceId(), equalTo("r-3"));
+
+    final List<BoundMonitor> publicResults = repository.findAllWithEnvoy("", "public/1", "e-1");
+    assertThat(publicResults, hasSize(1));
+    assertThat(publicResults.get(0).getResourceId(), equalTo("r-5"));
+  }
+
+  private void save(Monitor monitor, String tenant, String zone, String resource, String envoyId) {
+    final Monitor retrievedMonitor = entityManager.find(Monitor.class, monitor.getId());
+    assertThat(retrievedMonitor, notNullValue());
+
+    entityManager.persist(new BoundMonitor()
+        .setMonitor(monitor)
+        .setZoneTenantId(tenant)
+        .setZoneId(zone)
+        .setResourceId(resource)
+        .setEnvoyId(envoyId)
+    );
+    entityManager.flush();
+  }
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentRendererTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentRendererTest.java
@@ -42,7 +42,7 @@ public class MonitorContentRendererTest {
     final MonitorContentRenderer renderer = new MonitorContentRenderer(properties);
 
     assertThat(renderer.render(
-        "{\"type\": \"ping\", \"urls\": [\"<<resource.metadata.public_ip>>\"]}",
+        "{\"type\": \"ping\", \"urls\": [\"${resource.metadata.public_ip}\"]}",
         resource
     ), equalTo("{\"type\": \"ping\", \"urls\": [\"150.1.2.3\"]}"));
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.services;
+
+import static org.mockito.Mockito.verify;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.NewResourceZoneEvent;
+import com.rackspace.salus.telemetry.messaging.ReattachedResourceZoneEvent;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ZoneEventListenerTest {
+
+  @Mock
+  MonitorManagement monitorManagement;
+  private ZoneEventListener zoneEventListener;
+
+  @Before
+  public void setUp() throws Exception {
+    KafkaTopicProperties topicProperties = new KafkaTopicProperties();
+    zoneEventListener = new ZoneEventListener(topicProperties, monitorManagement);
+  }
+
+  @Test
+  public void testZoneNewResourceEvent() {
+    zoneEventListener.handleEvent(
+        new NewResourceZoneEvent()
+        .setTenantId("t-1")
+        .setZoneId("z-1")
+    );
+
+    verify(monitorManagement).handleNewEnvoyInZone("t-1", "z-1");
+  }
+
+  @Test
+  public void testZoneEnvoyOfResourceChangedEvent() {
+    zoneEventListener.handleEvent(
+        new ReattachedResourceZoneEvent()
+            .setFromEnvoyId("e-1")
+            .setToEnvoyId("e-2")
+            .setTenantId("t-1")
+            .setZoneId("z-1")
+    );
+
+    verify(monitorManagement).handleEnvoyResourceChangedInZone(
+        "t-1", "z-1", "e-1", "e-2");
+  }
+}

--- a/templates/markdown.hbs
+++ b/templates/markdown.hbs
@@ -7,7 +7,7 @@
 {{description}}
 
 {{#contact}}
-[**Contact the developer**](mailto:{{email}})
+[**Contact your support team**](mailto:{{email}})
 {{/contact}}
 
 **Version** {{version}}

--- a/templates/markdown.hbs
+++ b/templates/markdown.hbs
@@ -1,0 +1,106 @@
+#{{#info}}{{title}}
+
+
+## {{join schemes " | "}}://{{host}}{{basePath}}
+
+
+{{description}}
+
+{{#contact}}
+[**Contact the developer**](mailto:{{email}})
+{{/contact}}
+
+**Version** {{version}}
+
+{{#license}}[**{{name}}**]({{url}}){{/license}}
+
+{{/info}}
+
+{{#if consumes}}**Consumes:** {{join consumes ", "}}{{/if}}
+
+{{#if produces}}**Produces:** {{join produces ", "}}{{/if}}
+
+{{#if securityDefinitions}}
+# Security Definitions
+{{/if}}
+{{> security}}
+
+# APIs
+
+{{#each paths}}
+## {{@key}}
+{{#this}}
+{{#get}}
+### GET
+{{> operation}}
+{{/get}}
+
+{{#put}}
+### PUT
+{{> operation}}
+{{/put}}
+
+{{#post}}
+### POST
+
+{{> operation}}
+
+{{/post}}
+
+{{#delete}}
+### DELETE
+{{> operation}}
+{{/delete}}
+
+{{#option}}
+### OPTION
+{{> operation}}
+{{/option}}
+
+{{#patch}}
+### PATCH
+{{> operation}}
+{{/patch}}
+
+{{#head}}
+### HEAD
+{{> operation}}
+{{/head}}
+
+{{/this}}
+{{/each}}
+
+# Definitions
+{{#each definitions}}
+## <a name="/definitions/{{key}}">{{@key}}</a>
+
+<table border="1">
+    <tr>
+        <th>name</th>
+        <th>type</th>
+        <th>required</th>
+        <th>description</th>
+        <th>example</th>
+    </tr>
+    {{#each this.properties}}
+        <tr>
+            <td>{{@key}}</td>
+            <td>
+                {{#ifeq type "array"}}
+                {{#items.$ref}}
+                    {{type}}[<a href="{{items.$ref}}">{{basename items.$ref}}</a>]
+                {{/items.$ref}}
+                {{^items.$ref}}{{type}}[{{items.type}}]{{/items.$ref}}
+                {{else}}
+                    {{#$ref}}<a href="{{$ref}}">{{basename $ref}}</a>{{/$ref}}
+                    {{^$ref}}{{type}}{{#format}} ({{format}}){{/format}}{{/$ref}}
+                {{/ifeq}}
+            </td>
+            <td>{{#required}}required{{/required}}{{^required}}optional{{/required}}</td>
+            <td>{{#description}}{{{description}}}{{/description}}{{^description}}-{{/description}}</td>
+            <td>{{example}}</td>
+        </tr>
+    {{/each}}
+</table>
+{{/each}}
+

--- a/templates/markdown.hbs
+++ b/templates/markdown.hbs
@@ -82,25 +82,47 @@
         <th>description</th>
         <th>example</th>
     </tr>
-    {{#each this.properties}}
-        <tr>
-            <td>{{@key}}</td>
-            <td>
-                {{#ifeq type "array"}}
-                {{#items.$ref}}
-                    {{type}}[<a href="{{items.$ref}}">{{basename items.$ref}}</a>]
-                {{/items.$ref}}
-                {{^items.$ref}}{{type}}[{{items.type}}]{{/items.$ref}}
-                {{else}}
-                    {{#$ref}}<a href="{{$ref}}">{{basename $ref}}</a>{{/$ref}}
-                    {{^$ref}}{{type}}{{#format}} ({{format}}){{/format}}{{/$ref}}
-                {{/ifeq}}
-            </td>
-            <td>{{#required}}required{{/required}}{{^required}}optional{{/required}}</td>
-            <td>{{#description}}{{{description}}}{{/description}}{{^description}}-{{/description}}</td>
-            <td>{{example}}</td>
-        </tr>
-    {{/each}}
+    {{#if this.1.properties}}
+        {{#each this.1.properties}}
+            <tr>
+                <td>{{@key}}</td>
+                <td>
+                    {{#ifeq type "array"}}
+                    {{#items.$ref}}
+                        {{type}}[<a href="{{items.$ref}}">{{basename items.$ref}}</a>]
+                    {{/items.$ref}}
+                    {{^items.$ref}}{{type}}[{{items.type}}]{{/items.$ref}}
+                    {{else}}
+                        {{#$ref}}<a href="{{$ref}}">{{basename $ref}}</a>{{/$ref}}
+                        {{^$ref}}{{type}}{{#format}} ({{format}}){{/format}}{{/$ref}}
+                    {{/ifeq}}
+                </td>
+                <td>{{#required}}required{{/required}}{{^required}}optional{{/required}}</td>
+                <td>{{#description}}{{{description}}}{{/description}}{{^description}}-{{/description}}</td>
+                <td>{{example}}</td>
+            </tr>
+        {{/each}}
+    {{else}}
+        {{#each this.properties}}
+            <tr>
+                <td>{{@key}}</td>
+                <td>
+                    {{#ifeq type "array"}}
+                    {{#items.$ref}}
+                        {{type}}[<a href="{{items.$ref}}">{{basename items.$ref}}</a>]
+                    {{/items.$ref}}
+                    {{^items.$ref}}{{type}}[{{items.type}}]{{/items.$ref}}
+                    {{else}}
+                        {{#$ref}}<a href="{{$ref}}">{{basename $ref}}</a>{{/$ref}}
+                        {{^$ref}}{{type}}{{#format}} ({{format}}){{/format}}{{/$ref}}
+                    {{/ifeq}}
+                </td>
+                <td>{{#required}}required{{/required}}{{^required}}optional{{/required}}</td>
+                <td>{{#description}}{{{description}}}{{/description}}{{^description}}-{{/description}}</td>
+                <td>{{example}}</td>
+            </tr>
+        {{/each}}
+    {{/if}}
 </table>
 {{/each}}
 

--- a/templates/markdown.hbs
+++ b/templates/markdown.hbs
@@ -82,8 +82,8 @@
         <th>description</th>
         <th>example</th>
     </tr>
-    {{#if this.1.properties}}
-        {{#each this.1.properties}}
+    {{#if this.allOf.1.properties}}
+        {{#each this.allOf.1.properties}}
             <tr>
                 <td>{{@key}}</td>
                 <td>

--- a/templates/operation.hbs
+++ b/templates/operation.hbs
@@ -1,0 +1,73 @@
+{{#deprecated}}-deprecated-{{/deprecated}}
+<a id="{{operationId}}">{{summary}}</a>
+
+{{description}}
+
+{{#if externalDocs.url}}{{externalDocs.description}}. [See external documents for more details]({{externalDocs.url}})
+{{/if}}
+
+{{#if security}}
+#### Security
+{{/if}}
+
+{{#security}}
+{{#each this}}
+* {{@key}}
+{{#this}}   * {{this}}
+{{/this}}
+{{/each}}
+{{/security}}
+
+#### Request
+
+{{#if consumes}}
+**Content-Type: ** {{join consumes ", "}}{{/if}}
+
+##### Parameters
+{{#if parameters}}
+<table border="1">
+    <tr>
+        <th>Name</th>
+        <th>Located in</th>
+        <th>Required</th>
+        <th>Description</th>
+        <th>Default</th>
+        <th>Schema</th>
+    </tr>
+{{/if}}
+
+{{#parameters}}
+<tr>
+    <th>{{name}}</th>
+    <td>{{in}}</td>
+    <td>{{#if required}}yes{{else}}no{{/if}}</td>
+    <td>{{description}}{{#if pattern}} (**Pattern**: `{{pattern}}`){{/if}}</td>
+    <td> - </td>
+{{#ifeq in "body"}}
+    <td>
+    {{#ifeq schema.type "array"}}Array[<a href="{{schema.items.$ref}}">{{basename schema.items.$ref}}</a>]{{/ifeq}}
+    {{#schema.$ref}}<a href="{{schema.$ref}}">{{basename schema.$ref}}</a> {{/schema.$ref}}
+    </td>
+{{else}}
+    {{#ifeq type "array"}}
+            <td>Array[{{items.type}}] ({{collectionFormat}})</td>
+    {{else}}
+            <td>{{type}} {{#format}}({{format}}){{/format}}</td>
+    {{/ifeq}}
+{{/ifeq}}
+</tr>
+{{/parameters}}
+{{#if parameters}}
+</table>
+{{/if}}
+
+
+#### Response
+
+{{#if produces}}**Content-Type: ** {{join produces ", "}}{{/if}}
+
+
+| Status Code | Reason      | Response Model |
+|-------------|-------------|----------------|
+{{#each responses}}| {{@key}}    | {{description}} | {{#schema.$ref}}<a href="{{schema.$ref}}">{{basename schema.$ref}}</a>{{/schema.$ref}}{{#ifeq schema.type "array"}}Array[<a href="{{schema.items.$ref}}">{{basename schema.items.$ref}}</a>]{{/ifeq}}{{^schema}} - {{/schema}}|
+{{/each}}

--- a/templates/security.hbs
+++ b/templates/security.hbs
@@ -1,0 +1,88 @@
+{{#each securityDefinitions}}
+### {{@key}}
+{{#this}}
+{{#ifeq type "oauth2"}}
+<table>
+    <tr>
+        <th>type</th>
+        <th colspan="2">{{type}}</th>
+    </tr>
+{{#if description}}
+        <tr>
+            <th>description</th>
+            <th colspan="2">{{description}}</th>
+        </tr>
+{{/if}}
+{{#if authorizationUrl}}
+        <tr>
+            <th>authorizationUrl</th>
+            <th colspan="2">{{authorizationUrl}}</th>
+        </tr>
+{{/if}}
+{{#if flow}}
+        <tr>
+            <th>flow</th>
+            <th colspan="2">{{flow}}</th>
+        </tr>
+{{/if}}
+{{#if tokenUrl}}
+        <tr>
+            <th>tokenUrl</th>
+            <th colspan="2">{{tokenUrl}}</th>
+        </tr>
+{{/if}}
+{{#if scopes}}
+    <tr>
+        <td rowspan="3">scopes</td>
+{{#each scopes}}
+            <td>{{@key}}</td>
+            <td>{{this}}</td>
+        </tr>
+        <tr>
+{{/each}}
+    </tr>
+{{/if}}
+</table>
+{{/ifeq}}
+{{#ifeq type "apiKey"}}
+<table>
+    <tr>
+        <th>type</th>
+        <th colspan="2">{{type}}</th>
+    </tr>
+{{#if description}}
+        <tr>
+            <th>description</th>
+            <th colspan="2">{{description}}</th>
+        </tr>
+{{/if}}
+{{#if name}}
+        <tr>
+            <th>name</th>
+            <th colspan="2">{{name}}</th>
+        </tr>
+{{/if}}
+{{#if in}}
+        <tr>
+            <th>in</th>
+            <th colspan="2">{{in}}</th>
+        </tr>
+{{/if}}
+</table>
+{{/ifeq}}
+{{#ifeq type "basic"}}
+<table>
+    <tr>
+        <th>type</th>
+        <th colspan="2">{{type}}</th>
+    </tr>
+{{#if description}}
+        <tr>
+            <th>description</th>
+            <th colspan="2">{{description}}</th>
+        </tr>
+{{/if}}
+</table>
+{{/ifeq}}
+{{/this}}
+{{/each}}

--- a/templates/security.json
+++ b/templates/security.json
@@ -1,0 +1,6 @@
+{
+  "repose_auth": {
+    "name": "x-auth-token",
+    "in": "header"
+  }
+}

--- a/templates/strapdown.html.hbs
+++ b/templates/strapdown.html.hbs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<title>API Document</title>
+
+<xmp theme="united" style="display:none;">
+{{>markdown}}
+</xmp>
+
+<script src="http://strapdownjs.com/v/0.2/strapdown.js"></script>
+</html>


### PR DESCRIPTION
# Resolves

    SALUS-330

# What

    Adds internal and external documentation for Monitor-management

# How

    Generates internal documentation with Swagger then utilizes the SwaggerJsonConverter to export the internal documentation for external use

## How to test

    After Installing (Running the mvn install target) the SwaggerJsonConverter will be in the .m2 folder and then you can run the `test` target here that will generate the internal swagger and run the SwaggerJsonConverter

# TODO

    This should be complete