### PR TITLE
Support tenant query of bound monitors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,23 @@
 # Resolves
 
-    <Jira or Github issue reference(s)>
+<Jira or Github issue reference(s)>
 
 # What
 
-    <What is this PR is trying to accomplish?>
+<What is this PR is trying to accomplish?>
 
 # How
 
-    <How is the PR designed to solve the problem?>
+<How is the PR designed to solve the problem?>
 
 ## How to test
 
-    <instructions for verifying the changes specific to this PR>
+<instructions for verifying the changes specific to this PR>
 
 # Why
 
-    <Why was the final approach taken? Were alternatives considered?>
+<Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-    <outstanding tasks before this PR is considered 'ready'>
+<outstanding tasks before this PR is considered 'ready'>

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
@@ -19,6 +19,8 @@ package com.rackspace.salus.monitor_management.repositories;
 import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
@@ -33,4 +35,6 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
   List<BoundMonitor> findAllWithEnvoy(String zoneTenantId, String zoneId, String envoyId);
 
   List<BoundMonitor> findAllByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
+
+  Page<BoundMonitor> findAllByMonitor_TenantId(String tenantId, Pageable pageable);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -27,6 +27,7 @@ import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.telemetry.model.Monitor;
 import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.PagedContent;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -117,6 +119,15 @@ public class MonitorApiController implements MonitorApi {
                     uuid, tenantId));
         }
         return monitorConversionService.convertToOutput(monitor);
+    }
+
+    @GetMapping("/tenant/{tenantId}/boundMonitors")
+    public PagedContent<BoundMonitorDTO> getBoundMonitorsForTenant(@PathVariable String tenantId,
+                                                           Pageable pageable) {
+        return PagedContent.fromPage(
+            boundMonitorRepository.findAllByMonitor_TenantId(tenantId, pageable)
+            .map(BoundMonitor::toDTO)
+        );
     }
 
     @GetMapping("/tenant/{tenantId}/monitors")


### PR DESCRIPTION
# What

Add a REST API for a tenant to query their bound monitors. Later we can add query parameters to support further narrowing by resource and/or monitor ID.

## How to test

Added repository test.

# TODO

I'll update the public API to add a request proxy for the new API.