### PR TITLE
Use _PUBLIC_ placeholder when storing bound monitors bound to public zone

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -305,12 +305,22 @@ public class MonitorManagement {
         }
 
         return new BoundMonitor()
-            .setZoneTenantId(emptyStringForNull(resolvedZone.getTenantId()))
+            .setZoneTenantId(normalizeZoneTenant(resolvedZone.getTenantId()))
             .setZoneId(zone)
             .setMonitor(monitor)
             .setResourceId(resource.getResourceId())
             .setEnvoyId(envoyId)
             .setRenderedContent(renderMonitorContent(monitor, resource));
+    }
+
+    /**
+     * Ensures the zone tenant ID is a non-null value by normalizing to {@value ResolvedZone#PUBLIC}
+     * if the given tenant is null.
+     * @param tenantId the resolve zone tenant ID
+     * @return the normalized tenant value to use with {@link BoundMonitor#setZoneTenantId(String)}
+     */
+    private static String normalizeZoneTenant(@Nullable String tenantId) {
+        return tenantId != null ? tenantId : ResolvedZone.PUBLIC;
     }
 
     List<UUID> findMonitorsBoundToResource(String tenantId, String resourceId) {

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -638,7 +638,7 @@ public class MonitorManagementTest {
                 .setMonitor(monitor)
                 .setEnvoyId("zoneWest-e-2")
                 .setRenderedContent("{\"type\": \"ping\", \"urls\": [\"151.1.1.1\"]}")
-                .setZoneTenantId("")
+                .setZoneTenantId(ResolvedZone.PUBLIC)
                 .setZoneId("public/west"),
             new BoundMonitor()
                 .setResourceId("r-2")
@@ -652,7 +652,7 @@ public class MonitorManagementTest {
                 .setMonitor(monitor)
                 .setEnvoyId("zoneWest-e-2")
                 .setRenderedContent("{\"type\": \"ping\", \"urls\": [\"151.2.2.2\"]}")
-                .setZoneTenantId("")
+                .setZoneTenantId(ResolvedZone.PUBLIC)
                 .setZoneId("public/west")
         ));
 


### PR DESCRIPTION
# What

Rather than store BoundMonitor's with an empty string for zone tenant ID of public zones, we'll use the same placeholder from `ResolvedZone` that is used for the etcd key formation.

The query response now looks like the following:

```json
{
  "content": [
    {
      "monitorId": "558d3895-9b66-4f5b-bdb2-235e27c97aa8",
      "zoneTenantId": "_PUBLIC_",
      "zoneId": "public/dev",
      "resourceTenant": "aaaaaa",
      "resourceId": "test1",
      "agentType": "TELEGRAF",
      "renderedContent": "{\"type\":\"ping\",\"urls\":[\"localhost\"]}",
      "envoyId": null
    }
  ],
  "number": 0,
  "totalPages": 1,
  "totalElements": 1,
  "last": true,
  "first": true
}
```

## How to test

Existing unit tests