### PR TITLE
Remove CriteriaBuilder and use repository methods instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>21.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-protocol</artifactId>
       <version>0.1.1</version>

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
@@ -17,10 +17,18 @@
 package com.rackspace.salus.monitor_management.repositories;
 
 import com.rackspace.salus.telemetry.model.Monitor;
+
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MonitorRepository extends PagingAndSortingRepository<Monitor, UUID> {
+
+    Page<Monitor> findByTenantId(String tenantId, Pageable pageable);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
@@ -18,10 +18,7 @@ package com.rackspace.salus.monitor_management.repositories;
 
 import com.rackspace.salus.telemetry.model.Monitor;
 
-import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Stream;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.PagingAndSortingRepository;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -113,11 +113,9 @@ public class MonitorApiController implements MonitorApi {
     @GetMapping("/tenant/{tenantId}/monitors/{uuid}")
     public DetailedMonitorOutput getById(@PathVariable String tenantId,
                                          @PathVariable UUID uuid) throws NotFoundException {
-        Monitor monitor = monitorManagement.getMonitor(tenantId, uuid);
-        if (monitor == null) {
-            throw new NotFoundException(String.format("No monitor found for %s on tenant %s",
-                    uuid, tenantId));
-        }
+        Monitor monitor = monitorManagement.getMonitor(tenantId, uuid).orElseThrow(
+                () -> new NotFoundException(String.format("No monitor found for %s on tenant %s",
+                        uuid, tenantId)));
         return monitorConversionService.convertToOutput(monitor);
     }
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -38,7 +38,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import com.rackspace.salus.monitor_management.config.MonitorContentProperties;
@@ -54,11 +53,8 @@ import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
-import com.rackspace.salus.telemetry.model.AgentType;
-import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
-import com.rackspace.salus.telemetry.model.Monitor;
-import com.rackspace.salus.telemetry.model.Resource;
-import com.rackspace.salus.telemetry.model.ResourceInfo;
+import com.rackspace.salus.telemetry.model.*;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -213,12 +209,20 @@ public class MonitorManagementTest {
 
     @Test
     public void testGetMonitor() {
-        Monitor r = monitorManagement.getMonitor("abcde", currentMonitor.getId());
+        Optional<Monitor> m = monitorManagement.getMonitor("abcde", currentMonitor.getId());
 
-        assertThat(r.getId(), notNullValue());
-        assertThat(r.getLabelSelector(), hasEntry("os", "LINUX"));
-        assertThat(r.getContent(), equalTo(currentMonitor.getContent()));
-        assertThat(r.getAgentType(), equalTo(currentMonitor.getAgentType()));
+        assertTrue(m.isPresent());
+        assertThat(m.get().getId(), notNullValue());
+        assertThat(m.get().getLabelSelector(), hasEntry("os", "LINUX"));
+        assertThat(m.get().getContent(), equalTo(currentMonitor.getContent()));
+        assertThat(m.get().getAgentType(), equalTo(currentMonitor.getAgentType()));
+    }
+
+    @Test
+    public void testGetMonitorForUnauthorizedTenant() {
+        String unauthorizedTenantId = RandomStringUtils.randomAlphanumeric(10);
+        Optional<Monitor> monitor = monitorManagement.getMonitor(unauthorizedTenantId, currentMonitor.getId());
+        assertTrue(!monitor.isPresent());
     }
 
     @Test
@@ -237,10 +241,11 @@ public class MonitorManagementTest {
         assertThat(returned.getLabelSelector().size(), greaterThan(0));
         assertTrue(Maps.difference(create.getLabelSelector(), returned.getLabelSelector()).areEqual());
 
-        Monitor retrieved = monitorManagement.getMonitor(tenantId, returned.getId());
+        Optional<Monitor> retrieved = monitorManagement.getMonitor(tenantId, returned.getId());
 
-        assertThat(retrieved.getMonitorName(), equalTo(returned.getMonitorName()));
-        assertTrue(Maps.difference(returned.getLabelSelector(), retrieved.getLabelSelector()).areEqual());
+        assertTrue(retrieved.isPresent());
+        assertThat(retrieved.get().getMonitorName(), equalTo(returned.getMonitorName()));
+        assertTrue(Maps.difference(returned.getLabelSelector(), retrieved.get().getLabelSelector()).areEqual());
     }
 
 
@@ -322,6 +327,18 @@ public class MonitorManagementTest {
         assertThat(newMonitor.getContent(), equalTo(monitor.getContent()));
     }
 
+    @Test(expected = NotFoundException.class)
+    public void testUpdateNonExistentMonitor() {
+        String tenant = RandomStringUtils.randomAlphanumeric(10);
+        UUID uuid = UUID.randomUUID();
+
+        Map<String, String> newLabels = Collections.singletonMap("newLabel", "newValue");
+        MonitorCU update = new MonitorCU();
+        update.setLabelSelector(newLabels).setContent("newContent");
+
+        monitorManagement.updateMonitor(tenant, uuid, update);
+    }
+
     @Test
     public void testRemoveMonitor() {
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
@@ -329,12 +346,20 @@ public class MonitorManagementTest {
         String tenantId = RandomStringUtils.randomAlphanumeric(10);
         Monitor newMon = monitorManagement.createMonitor(tenantId, create);
 
-        Monitor monitor = monitorManagement.getMonitor(tenantId, newMon.getId());
-        assertThat(monitor, notNullValue());
+        Optional<Monitor> monitor = monitorManagement.getMonitor(tenantId, newMon.getId());
+        assertTrue(monitor.isPresent());
+        assertThat(monitor.get(), notNullValue());
 
         monitorManagement.removeMonitor(tenantId, newMon.getId());
         monitor = monitorManagement.getMonitor(tenantId, newMon.getId());
-        assertThat(monitor, nullValue());
+        assertTrue(!monitor.isPresent());
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testRemoveNonExistentMonitor() {
+        String tenant = RandomStringUtils.randomAlphanumeric(10);
+        UUID uuid = UUID.randomUUID();
+        monitorManagement.removeMonitor(tenant, uuid);
     }
 
     @Test
@@ -578,7 +603,7 @@ public class MonitorManagementTest {
     }
 
     @Test
-    public void testDistributeNewMonitor_remote() throws JsonProcessingException {
+    public void testDistributeNewMonitor_remote() {
         final ResolvedZone zone1 = createPrivateZone("t-1", "zone1");
         final ResolvedZone zoneWest = createPublicZone("public/west");
 


### PR DESCRIPTION
# What

Removes all the `CriteriaBuilder` logic for building sql queries and replaces it by using standard repository options.

# How

The "how" is fairly obvious.  The only real decision was to start using `Optional` fields where we are getting at most one returned object.  I like this overall, but the downside is it makes the tests a little more tedious due to having to do various `isPresent()` and `get()` calls.

## How to test

Run all tests.  They still work!

# Why

Cleans up the code and standardizes things across all repos.

# TODO

Incoming PRs for model repo... I think that'll be it.