### PR TITLE
Update API Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ HTTP POST to http://localhost:8089/api/tenant/aaaaa/monitors with body:
 }
 ```
 
-## Update an existing monitor to use wildcards
+## Update an existing monitor to use template placeholders
 
 http PUT localhost:8089/api/tenant/aaaaa/monitors/$MonitorId with body:
 ```

--- a/README.md
+++ b/README.md
@@ -21,9 +21,19 @@ You can trigger these events to be posted by utilizing some of the API operation
 Examples of a subset of the available API operations.
 
 ## Create a new monitor
+
+HTTP POST to http://localhost:8089/api/tenant/aaaaa/monitors with body:
 ```
-echo '{"monitorName":"mon1", "content":"content1", "agentType":"TELEGRAF"}' | http POST 'localhost:8089/api/tenant/aaaaa/monitors' | tee /tmp/newMonitor.txt; 
+{
+	"labelSelector": {"agent.os":"darwin"},
+	"details": {
+		"type": "local",
+		"agentType": "TELEGRAF",
+		"plugin": {"type":"mem"}
+	}
+}
 ```
+
 ## Save the monitor id in a env var
 export MonitorId=`jq -r .id /tmp/newMonitor.txt`
 

--- a/README.md
+++ b/README.md
@@ -20,26 +20,54 @@ You can trigger these events to be posted by utilizing some of the API operation
 # API Operations
 Examples of a subset of the available API operations.
 
-## Create a new monitor
+## Create a new local monitor
 
 HTTP POST to http://localhost:8089/api/tenant/aaaaa/monitors with body:
 ```
 {
-	"labelSelector": {"agent.os":"darwin"},
-	"details": {
-		"type": "local",
-		"agentType": "TELEGRAF",
-		"plugin": {"type":"mem"}
-	}
+  "labelSelector": {
+    "agent_discovered_os": "darwin"
+  },
+  "details": {
+    "type": "local",
+    "plugin": {"type": "mem"}
+  }
 }
 ```
 
-## Save the monitor id in a env var
-export MonitorId=`jq -r .id /tmp/newMonitor.txt`
+## Create a new remote monitor
 
-## Update an existing monitor
+HTTP POST to http://localhost:8089/api/tenant/aaaaa/monitors with body:
 ```
-echo '{"content":"content1xxxxx"}' | http PUT localhost:8089/api/tenant/aaaaa/monitors/$MonitorId
+{
+  "labelSelector": {
+    "agent_environment": "localdev"
+  },
+  "details": {
+    "type": "remote",
+    "monitoringZones": ["dev"],
+    "plugin": {
+      "type": "ping",
+      "urls": ["127.0.0.1"]
+    }
+  }
+}
+```
+
+## Update an existing monitor to use wildcards
+
+http PUT localhost:8089/api/tenant/aaaaa/monitors/$MonitorId with body:
+```
+{
+  "details": {
+    "type": "remote",
+    "monitoringZones": ["dev"],
+    "plugin": {
+      "type": "ping",
+      "urls": ["${resource.labels.agent_discovered_hostname}"]
+    }
+  }
+}
 ```
 
 ## Get all monitors


### PR DESCRIPTION
When trying to get the whole bundle working I realized these API examples are out of date.  I figured out what payload I should be able to provide, but this `POST` example currently returns a `500`.  We need to figure out what's going on here, fix the problem, and then update these examples with whatever is correct.

FYI... the failure is due to `http://localhost:8085/api/tenant/aaaaaa/resourceLabels?agent.os=darwin` returning a `404`.  I'm unable to reproduce this via hitting the reosurce api directly.  It is only failing via the resourceApiClient being used by the monitor mgmt service.

Currently my only thought is that its somehow getting the `rootUri` parameters mixed up and querying the wrong service, but the logs don't back that up, and stepping through the request in debug mode also hasn't helped me identify the problem.