### PR TITLE
Add zone management services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <description>Service for managing monitors</description>
 
   <properties>
-    <java.version>12</java.version>
+    <java.version>1.8</java.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <description>Service for managing monitors</description>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>12</java.version>
   </properties>
 
   <dependencies>

--- a/src/main/java/com/rackspace/salus/monitor_management/entities/Zone.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/entities/Zone.java
@@ -1,21 +1,41 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.rackspace.salus.monitor_management.entities;
 
+import com.rackspace.salus.monitor_management.types.ZoneState;
 import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
 import lombok.Data;
 import org.hibernate.annotations.Type;
 import org.springframework.boot.convert.DurationUnit;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
 import org.hibernate.validator.constraints.NotBlank;
 
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
 @Table(name = "zones", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"tenant_id", "name"})})
+
 @Data
 public class Zone implements Serializable {
     @Id
@@ -23,22 +43,80 @@ public class Zone implements Serializable {
     @Type(type="uuid-char")
     UUID id;
 
+    /**
+     * Contains the unique name/label for the zone.
+     * Public zones should have a "public/" prefix and then a trailing region descriptor.
+     * e.g. "public/us-central-1"
+     */
     @NotBlank
     @Column(name="name")
     String name;
 
+    /**
+     * Contains an optional hosting provider of the zone.
+     * e.g. Rackspace, Google, Amazon
+     */
+    @Column(name="provider")
+    String provider;
+
+    /**
+     * Contains an optional region to more precisely define where the zone is running.
+     * e.g. for Rackspace, dfw3 may be used; for Google, europe-west3.
+     */
+    @Column(name="provider_region")
+    String providerRegion;
+
+    /**
+     * Defines whether a zone is public or private.
+     */
+    @NotNull
+    @Column(name="is_public")
+    boolean isPublic;
+
+    /**
+     * Contains an optional list of ipv4 and ipv6 ranges that the pollers in this zone reside in.
+     * This can be used to whitelist ranges to allow for remote polling.
+     */
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Column(name="source_ips")
+    List<String> sourceIpRanges;
+
+    /**
+     * Defines whether the zone is available or not.
+     * This helps determine whether new monitors can be added to the zone.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name="state")
+    ZoneState state;
+
+    /**
+     * Contains the tenant that owns the private zone or "_PUBLIC_" for public zones.
+     */
     @NotBlank
     @Column(name="tenant_id")
     String tenantId;
 
+    /**
+     * Contains a timeout value which begins to countdown after an envoy/poller has disconnected.
+     * If the timeout is met, the monitors bound to it will be distributed to other available pollers.
+     */
     @DurationUnit(ChronoUnit.SECONDS)
     @Column(name="envoy_timeout")
     Duration envoyTimeout = Duration.ofSeconds(120);
 
+    /**
+     * Converts the Zone object to a ZoneDTO which is a stripped down version to be used
+     * as output in the APIs.
+     *
+     * @return A ZoneDTO with fields mapped from the Zone.
+     */
     public ZoneDTO toDTO() {
         return new ZoneDTO()
                 .setName(name)
-                .setTenantId(tenantId)
-                .setEnvoyTimeout(envoyTimeout.getSeconds());
+                .setEnvoyTimeout(envoyTimeout.getSeconds())
+                .setProvider(provider)
+                .setProviderRegion(providerRegion)
+                .setPublic(isPublic)
+                .setSourceIpRanges(sourceIpRanges);
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/entities/Zone.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/entities/Zone.java
@@ -1,0 +1,44 @@
+package com.rackspace.salus.monitor_management.entities;
+
+import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
+import lombok.Data;
+import org.hibernate.annotations.Type;
+import org.springframework.boot.convert.DurationUnit;
+
+import javax.persistence.*;
+import org.hibernate.validator.constraints.NotBlank;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+@Entity
+@Table(name = "zones", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"tenant_id", "name"})})
+@Data
+public class Zone implements Serializable {
+    @Id
+    @GeneratedValue
+    @Type(type="uuid-char")
+    UUID id;
+
+    @NotBlank
+    @Column(name="name")
+    String name;
+
+    @NotBlank
+    @Column(name="tenant_id")
+    String tenantId;
+
+    @DurationUnit(ChronoUnit.SECONDS)
+    @Column(name="envoy_timeout")
+    Duration envoyTimeout = Duration.ofSeconds(120);
+
+    public ZoneDTO toDTO() {
+        return new ZoneDTO()
+                .setName(name)
+                .setTenantId(tenantId)
+                .setEnvoyTimeout(envoyTimeout.getSeconds());
+    }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/errors/ZoneAlreadyExists.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/errors/ZoneAlreadyExists.java
@@ -18,7 +18,7 @@ package com.rackspace.salus.monitor_management.errors;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(HttpStatus.BAD_REQUEST)
+@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
 public class ZoneAlreadyExists extends RuntimeException {
     public ZoneAlreadyExists(String message) { super(message);}
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/errors/ZoneAlreadyExists.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/errors/ZoneAlreadyExists.java
@@ -13,16 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.rackspace.salus.monitor_management.errors;
 
-package com.rackspace.salus.monitor_management.config;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-import lombok.Data;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
-
-@ConfigurationProperties("services")
-@Component
-@Data
-public class ServicesProperties {
-    String resourceManagementUrl;
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class ZoneAlreadyExists extends RuntimeException {
+    public ZoneAlreadyExists(String message) { super(message);}
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
@@ -18,9 +18,11 @@ package com.rackspace.salus.monitor_management.repositories;
 
 import com.rackspace.salus.telemetry.model.Monitor;
 
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.stereotype.Repository;
 
@@ -28,4 +30,10 @@ import org.springframework.stereotype.Repository;
 public interface MonitorRepository extends PagingAndSortingRepository<Monitor, UUID> {
 
     Page<Monitor> findByTenantId(String tenantId, Pageable pageable);
+
+    // this works in tests but not in reality.
+    List<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone);
+
+    @Query("select m from Monitor m where m.tenantId = :tenantId and :zone member of m.zones")
+    List<Monitor> customFindByTenantIdAndZonesContains(String tenantId, String zone);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/ZoneRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/ZoneRepository.java
@@ -13,16 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.rackspace.salus.monitor_management.repositories;
 
-package com.rackspace.salus.monitor_management.config;
+import com.rackspace.salus.monitor_management.entities.Zone;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
-import lombok.Data;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
-@ConfigurationProperties("services")
-@Component
-@Data
-public class ServicesProperties {
-    String resourceManagementUrl;
+public interface ZoneRepository extends PagingAndSortingRepository<Zone, UUID> {
+    Optional<Zone> findByTenantIdAndName(String tenantId, String name);
+
+    List<Zone> findAllByTenantId(String tenantId);
+
+    boolean existsByTenantIdAndName(String tenantId, String name);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -18,7 +18,6 @@ package com.rackspace.salus.monitor_management.services;
 
 import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPrivateZone;
 import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPublicZone;
-import static java.util.function.Predicate.not;
 
 import com.google.common.collect.Streams;
 import com.rackspace.salus.monitor_management.config.ZonesProperties;
@@ -51,15 +50,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.validation.Valid;
-
-import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.PropertyMapper;
@@ -190,7 +186,7 @@ public class MonitorManagement {
                 .stream().map(Zone::getName).collect(Collectors.toList());
 
         List<String> invalidZones = providedZones.stream()
-                .filter(not(availableZones::contains))
+                .filter(z -> !availableZones.contains(z))
                 .collect(Collectors.toList());
 
         if (!invalidZones.isEmpty()) {
@@ -683,9 +679,5 @@ public class MonitorManagement {
             monitors.add(monitor);
         }
         return monitors;
-    }
-
-    public List<Monitor> getMonitorsForZone(String tenantId, String zone) {
-        return monitorRepository.customFindByTenantIdAndZonesContains(tenantId, zone);
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
@@ -1,0 +1,137 @@
+package com.rackspace.salus.monitor_management.services;
+
+import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.monitor_management.errors.ZoneAlreadyExists;
+import com.rackspace.salus.monitor_management.entities.Zone;
+import com.rackspace.salus.monitor_management.web.model.ZoneCreate;
+import com.rackspace.salus.monitor_management.web.model.ZoneUpdate;
+import com.rackspace.salus.monitor_management.repositories.ZoneRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+import javax.validation.Valid;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+public class ZoneManagement {
+    private final ZoneRepository zoneRepository;
+    private final ZoneStorage zoneStorage;
+    private final MonitorManagement monitorManagement;
+
+    static final String PUBLIC = "_PUBLIC_";
+
+    @Autowired
+    public ZoneManagement(ZoneRepository zoneRepository, ZoneStorage zoneStorage, @Lazy MonitorManagement monitorManagement) {
+        this.zoneRepository = zoneRepository;
+        this.zoneStorage = zoneStorage;
+        this.monitorManagement = monitorManagement;
+    }
+
+    public Optional<Zone> getZone(String tenantId, String name) {
+        return zoneRepository.findByTenantIdAndName(tenantId, name);
+    }
+
+    /**
+     * Store a new zone in the database.
+     * @param tenantId The tenant to create the zone for.
+     * @param newZone The zone parameters to store.
+     * @return The newly created resource.
+     * @throws ZoneAlreadyExists If the zone name already exists for the tenant.
+     */
+    public Zone createZone(String tenantId, @Valid ZoneCreate newZone) throws ZoneAlreadyExists {
+        if (exists(tenantId, newZone.getName())) {
+            throw new ZoneAlreadyExists(String.format("Zone already exists with name %s on tenant %s",
+                    newZone.getName(), tenantId));
+        }
+
+        Zone zone = new Zone()
+                .setTenantId(tenantId)
+                .setName(newZone.getName())
+                .setEnvoyTimeout(Duration.ofSeconds(newZone.getPollerTimeout()));
+
+        zoneRepository.save(zone);
+
+        return zone;
+    }
+
+    public Zone updateZone(String tenantId, String name, @Valid ZoneUpdate updatedZone) {
+        Zone zone = getZone(tenantId, name).orElseThrow(() ->
+                new NotFoundException(String.format("No zone found named %s on tenant %s",
+                        name, tenantId)));
+
+        zone.setEnvoyTimeout(Duration.ofSeconds(updatedZone.getPollerTimeout()));
+        zoneRepository.save(zone);
+
+        // TBD: need to restart watchers?
+
+        return zone;
+    }
+
+    public void removeZone(String tenantId, String name) {
+        Zone zone = getZone(tenantId, name).orElseThrow(() ->
+                new NotFoundException(String.format("No zone found named %s on tenant %s",
+                        name, tenantId)));
+
+        int monitors = monitorManagement.getMonitorsForZone(tenantId, name).size();
+        if(monitors > 0) {
+            throw new IllegalArgumentException(
+                    String.format("Cannot remove zone with configured monitors. Found %s.", monitors));
+        }
+
+        long activeEnvoys = getActiveEnvoyCountForZone(zone);
+        log.debug("Found {} active envoys for zone {}", activeEnvoys, name);
+        if (activeEnvoys > 0) {
+            throw new IllegalArgumentException(
+                    String.format("Cannot remove zone with connected pollers. Found %d.", activeEnvoys));
+        }
+
+        zoneRepository.deleteById(zone.getId());
+
+        // TBD: remove expected entries in etcd?
+    }
+
+    private long getActiveEnvoyCountForZone(Zone zone) {
+        ResolvedZone resolvedZone;
+        if (zone.getTenantId().equals(PUBLIC)) {
+            resolvedZone = ResolvedZone.createPublicZone(zone.getName());
+        } else {
+            resolvedZone = ResolvedZone.createPrivateZone(zone.getTenantId(), zone.getName());
+        }
+
+        return zoneStorage.getActiveEnvoyCountForZone(resolvedZone).join();
+    }
+
+    private List<Zone> getZonesByTenant(String tenantId) {
+        return zoneRepository.findAllByTenantId(tenantId);
+    }
+
+    private List<Zone> getAllPublicZones() {
+        return getZonesByTenant(PUBLIC);
+    }
+
+    public List<Zone> getAvailableZonesForTenant(String tenantId) {
+        List<Zone> availableZones = new ArrayList<>();
+        availableZones.addAll(getAllPublicZones());
+        availableZones.addAll(getZonesByTenant(tenantId));
+
+        return availableZones;
+    }
+
+    /**
+     * Tests whether the zone exists on the given tenant.
+     * @param tenantId The tenant owning the zone.
+     * @param zoneName The unique value representing the zone.
+     * @return True if the zone exists on the tenant, otherwise false.
+     */
+    private boolean exists(String tenantId, String zoneName) {
+        return zoneRepository.existsByTenantIdAndName(tenantId, zoneName);
+    }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/types/ZoneState.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/types/ZoneState.java
@@ -13,18 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.rackspace.salus.monitor_management.web.model;
+package com.rackspace.salus.monitor_management.types;
 
-import lombok.Data;
-
-import java.util.List;
-
-@Data
-public class ZoneDTO {
-    String name;
-    long envoyTimeout;
-    String provider;
-    String providerRegion;
-    boolean isPublic;
-    List<String> sourceIpRanges;
+public enum ZoneState {
+    ACTIVE, // running and accepting new checks
+    INACTIVE, // not running
+    MAINTENANCE // running but not accepting new checks
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
@@ -17,9 +17,13 @@
 package com.rackspace.salus.monitor_management.web.client;
 
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
+import com.rackspace.salus.telemetry.model.Monitor;
+
 import java.util.List;
 
 public interface MonitorApi {
 
   List<BoundMonitorDTO> getBoundMonitors(String envoyId);
+
+  List<Monitor> getMonitorsForZone(String tenantId, String zone);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
@@ -24,6 +24,4 @@ import java.util.List;
 public interface MonitorApi {
 
   List<BoundMonitorDTO> getBoundMonitors(String envoyId);
-
-  List<Monitor> getMonitorsForZone(String tenantId, String zone);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -18,6 +18,8 @@ package com.rackspace.salus.monitor_management.web.client;
 
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import java.util.List;
+
+import com.rackspace.salus.telemetry.model.Monitor;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
@@ -52,6 +54,8 @@ public class MonitorApiClient implements MonitorApi {
 
   private static final ParameterizedTypeReference<List<BoundMonitorDTO>> LIST_OF_BOUND_MONITOR = new ParameterizedTypeReference<List<BoundMonitorDTO>>() {
   };
+  private static final ParameterizedTypeReference<List<Monitor>> LIST_OF_MONITOR = new ParameterizedTypeReference<List<Monitor>>() {
+  };
   private final RestTemplate restTemplate;
 
   public MonitorApiClient(RestTemplate restTemplate) {
@@ -66,7 +70,18 @@ public class MonitorApiClient implements MonitorApi {
         null,
         LIST_OF_BOUND_MONITOR,
         envoyId
-    )
-        .getBody();
+    ).getBody();
+  }
+
+  @Override
+  public List<Monitor> getMonitorsForZone(String tenantId, String zone) {
+    return restTemplate.exchange(
+        "/api/tenant/{tenantId}/monitorsByZone/{zone}",
+        HttpMethod.GET,
+        null,
+        LIST_OF_MONITOR,
+        tenantId,
+        zone
+    ).getBody();
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -54,8 +54,6 @@ public class MonitorApiClient implements MonitorApi {
 
   private static final ParameterizedTypeReference<List<BoundMonitorDTO>> LIST_OF_BOUND_MONITOR = new ParameterizedTypeReference<List<BoundMonitorDTO>>() {
   };
-  private static final ParameterizedTypeReference<List<Monitor>> LIST_OF_MONITOR = new ParameterizedTypeReference<List<Monitor>>() {
-  };
   private final RestTemplate restTemplate;
 
   public MonitorApiClient(RestTemplate restTemplate) {
@@ -70,18 +68,6 @@ public class MonitorApiClient implements MonitorApi {
         null,
         LIST_OF_BOUND_MONITOR,
         envoyId
-    ).getBody();
-  }
-
-  @Override
-  public List<Monitor> getMonitorsForZone(String tenantId, String zone) {
-    return restTemplate.exchange(
-        "/api/tenant/{tenantId}/monitorsByZone/{zone}",
-        HttpMethod.GET,
-        null,
-        LIST_OF_MONITOR,
-        tenantId,
-        zone
     ).getBody();
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApi.java
@@ -1,6 +1,23 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.rackspace.salus.monitor_management.web.client;
 
 import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
+import com.rackspace.salus.telemetry.model.Monitor;
+
 import java.util.List;
 
 /**
@@ -14,4 +31,6 @@ public interface ZoneApi {
     ZoneDTO getByZoneName(String tenantId, String name);
 
     List<ZoneDTO> getAvailableZones(String tenantId);
+
+    List<Monitor> getMonitorsForZone(String tenantId, String zone);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApi.java
@@ -1,0 +1,17 @@
+package com.rackspace.salus.monitor_management.web.client;
+
+import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
+import java.util.List;
+
+/**
+ * This interface declares a subset of internal REST API calls exposed by the Zone Management
+ * service.
+ *
+ * @see ZoneApiClient
+ */
+public interface ZoneApi {
+
+    ZoneDTO getByZoneName(String tenantId, String name);
+
+    List<ZoneDTO> getAvailableZones(String tenantId);
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClient.java
@@ -1,0 +1,79 @@
+package com.rackspace.salus.monitor_management.web.client;
+
+import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import java.util.List;
+
+/**
+ * This client component provides a small subset of Zone Management REST operations that
+ * can be called internally by other microservices in Salus.
+ *
+ * <p>
+ *   It is required that the {@link RestTemplate} provided to this instance has been
+ *   configured with the appropriate root URI for locating the zone management service.
+ *   The following is an example of a configuration bean that does that:
+ * </p>
+ *
+ * <pre>
+ {@literal @}Configuration
+ public class RestClientsConfig {
+
+   {@literal @}Bean
+   public ZoneApi zoneApi(RestTemplateBuilder restTemplateBuilder) {
+     return new ZoneApiClient(
+       restTemplateBuilder
+       .rootUri("http://localhost:8089")
+       .build()
+     );
+   }
+ }
+ * </pre>
+ *
+ */
+@Slf4j
+public class ZoneApiClient implements ZoneApi {
+
+    private static final ParameterizedTypeReference<List<ZoneDTO>> LIST_OF_ZONES = new ParameterizedTypeReference<List<ZoneDTO>>() {
+    };
+
+    private final RestTemplate restTemplate;
+
+
+    public ZoneApiClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+    @Override
+    public ZoneDTO getByZoneName(String tenantId, String name) {
+        try {
+            return restTemplate.getForObject(
+                    "/api/tenant/{tenantId}/zones/{name}",
+                    ZoneDTO.class,
+                    tenantId, name
+            );
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+                return null;
+                // what happens if this isn't here?
+            }
+            else {
+                throw new IllegalArgumentException(e);
+            }
+        }
+    }
+
+    public List<ZoneDTO> getAvailableZones(String tenantId) {
+
+        return restTemplate.exchange(
+                "/api/tenant/{tenantId}/zones",
+                HttpMethod.GET,
+                null,
+                LIST_OF_ZONES,
+                tenantId
+        ).getBody();
+    }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClient.java
@@ -1,10 +1,28 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.rackspace.salus.monitor_management.web.client;
 
 import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
+import com.rackspace.salus.telemetry.model.Monitor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import java.util.List;
@@ -40,6 +58,8 @@ public class ZoneApiClient implements ZoneApi {
 
     private static final ParameterizedTypeReference<List<ZoneDTO>> LIST_OF_ZONES = new ParameterizedTypeReference<List<ZoneDTO>>() {
     };
+    private static final ParameterizedTypeReference<List<Monitor>> LIST_OF_MONITOR = new ParameterizedTypeReference<List<Monitor>>() {
+    };
 
     private final RestTemplate restTemplate;
 
@@ -66,6 +86,7 @@ public class ZoneApiClient implements ZoneApi {
         }
     }
 
+    @Override
     public List<ZoneDTO> getAvailableZones(String tenantId) {
 
         return restTemplate.exchange(
@@ -74,6 +95,18 @@ public class ZoneApiClient implements ZoneApi {
                 null,
                 LIST_OF_ZONES,
                 tenantId
+        ).getBody();
+    }
+
+    @Override
+    public List<Monitor> getMonitorsForZone(String tenantId, String zone) {
+        return restTemplate.exchange(
+                "/api/tenant/{tenantId}/monitorsByZone/{zone}",
+                HttpMethod.GET,
+                null,
+                LIST_OF_MONITOR,
+                tenantId,
+                zone
         ).getBody();
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -189,9 +189,4 @@ public class MonitorApiController implements MonitorApi {
         return monitorManagement.getMonitorsFromLabels(labels, tenantId);
 
     }
-
-    @GetMapping("/tenant/{tenantId}/monitorsByZone/{zone}")
-    public List<Monitor> getMonitorsForZone(@PathVariable String tenantId, @PathVariable String zone) {
-        return monitorManagement.getMonitorsForZone(tenantId, zone);
-    }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -16,7 +16,6 @@
 
 package com.rackspace.salus.monitor_management.web.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import com.rackspace.salus.monitor_management.repositories.BoundMonitorRepository;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
@@ -72,17 +71,14 @@ public class MonitorApiController implements MonitorApi {
     private final BoundMonitorRepository boundMonitorRepository;
     private TaskExecutor taskExecutor;
     private MonitorConversionService monitorConversionService;
-    private final ObjectMapper objectMapper;
 
     @Autowired
     public MonitorApiController(MonitorManagement monitorManagement, BoundMonitorRepository boundMonitorRepository,
-                                TaskExecutor taskExecutor, MonitorConversionService monitorConversionService,
-                                ObjectMapper objectMapper) {
+                                TaskExecutor taskExecutor, MonitorConversionService monitorConversionService) {
         this.monitorManagement = monitorManagement;
         this.boundMonitorRepository = boundMonitorRepository;
         this.taskExecutor = taskExecutor;
         this.monitorConversionService = monitorConversionService;
-        this.objectMapper = objectMapper;
     }
 
     @GetMapping("/monitors")
@@ -192,5 +188,10 @@ public class MonitorApiController implements MonitorApi {
                                                  @RequestBody Map<String, String> labels) {
         return monitorManagement.getMonitorsFromLabels(labels, tenantId);
 
+    }
+
+    @GetMapping("/tenant/{tenantId}/monitorsByZone/{zone}")
+    public List<Monitor> getMonitorsForZone(@PathVariable String tenantId, @PathVariable String zone) {
+        return monitorManagement.getMonitorsForZone(tenantId, zone);
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -1,0 +1,64 @@
+package com.rackspace.salus.monitor_management.web.controller;
+
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.monitor_management.errors.ZoneAlreadyExists;
+import com.rackspace.salus.monitor_management.entities.Zone;
+import com.rackspace.salus.monitor_management.services.ZoneManagement;
+import com.rackspace.salus.monitor_management.web.client.ZoneApi;
+import com.rackspace.salus.monitor_management.web.model.ZoneCreate;
+import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
+import com.rackspace.salus.monitor_management.web.model.ZoneUpdate;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+public class ZoneApiController implements ZoneApi {
+    private ZoneManagement zoneManagement;
+
+    public ZoneApiController(ZoneManagement zoneManagement) {
+        this.zoneManagement = zoneManagement;
+    }
+
+    @Override
+    @GetMapping("/tenant/{tenantId}/zones/{name}")
+    public ZoneDTO getByZoneName(@PathVariable String tenantId, @PathVariable String name) {
+        Optional<Zone> zone = zoneManagement.getZone(tenantId, name);
+        return zone.orElseThrow(() -> new NotFoundException(String.format("No zone found for %s on tenant %s",
+                name, tenantId)))
+                .toDTO();
+    }
+
+    @PostMapping("/tenant/{tenantId}/zones")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ZoneDTO create(@PathVariable String tenantId, @Valid @RequestBody ZoneCreate zone)
+            throws ZoneAlreadyExists {
+        return zoneManagement.createZone(tenantId, zone).toDTO();
+    }
+
+    @PutMapping("/tenant/{tenantId}/zones/{name}")
+    public ZoneDTO update(@PathVariable String tenantId, @PathVariable String name, @Valid @RequestBody ZoneUpdate zone) {
+        return zoneManagement.updateZone(tenantId, name, zone).toDTO();
+    }
+
+    @DeleteMapping("/tenant/{tenantId}/zones/{name}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable String tenantId, @PathVariable String name) {
+        zoneManagement.removeZone(tenantId, name);
+    }
+
+    @GetMapping("/tenant/{tenantId}/zones")
+    public List<ZoneDTO> getAvailableZones(@PathVariable String tenantId) {
+        return zoneManagement.getAvailableZonesForTenant(tenantId)
+                .stream()
+                .map(Zone::toDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -1,5 +1,21 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.rackspace.salus.monitor_management.web.controller;
 
+import com.rackspace.salus.telemetry.model.Monitor;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.monitor_management.errors.ZoneAlreadyExists;
 import com.rackspace.salus.monitor_management.entities.Zone;
@@ -60,5 +76,10 @@ public class ZoneApiController implements ZoneApi {
                 .stream()
                 .map(Zone::toDTO)
                 .collect(Collectors.toList());
+    }
+
+    @GetMapping("/tenant/{tenantId}/monitorsByZone/{zone}")
+    public List<Monitor> getMonitorsForZone(@PathVariable String tenantId, @PathVariable String zone) {
+        return zoneManagement.getMonitorsForZone(tenantId, zone);
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreate.java
@@ -1,0 +1,20 @@
+package com.rackspace.salus.monitor_management.web.model;
+
+import lombok.Data;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+import org.hibernate.validator.constraints.NotBlank;
+import java.io.Serializable;
+
+@Data
+public class ZoneCreate implements Serializable {
+
+    @NotBlank
+    @Pattern(regexp = "^[\\p{Alnum}]+$", message = "Only alphanumeric characters can be used")
+    String name;
+
+    @Min(value = 30, message = "The timeout must not be less than 30s")
+    @Max(value = 1800, message = "The timeout must not be more than 1800s (30m)")
+    long pollerTimeout = 120;
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreate.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.rackspace.salus.monitor_management.web.model;
 
 import lombok.Data;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneDTO.java
@@ -1,0 +1,10 @@
+package com.rackspace.salus.monitor_management.web.model;
+
+import lombok.Data;
+
+@Data
+public class ZoneDTO {
+    String name;
+    String tenantId;
+    long envoyTimeout;
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneUpdate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneUpdate.java
@@ -1,0 +1,15 @@
+package com.rackspace.salus.monitor_management.web.model;
+
+import lombok.Data;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import java.io.Serializable;
+
+@Data
+public class ZoneUpdate implements Serializable {
+
+    @Min(value = 30, message = "The timeout must not be less than 30s")
+    @Max(value = 1800, message = "The timeout must not be more than 1800s (30m)")
+    long pollerTimeout;
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneUpdate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneUpdate.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.rackspace.salus.monitor_management.web.model;
 
 import lombok.Data;

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -1453,17 +1453,4 @@ public class MonitorManagementTest {
         verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement,
             zoneStorage, monitorEventProducer, resourceApi);
     }
-
-    @Test
-    public void testGetMonitorsForZone() {
-        int count = 0;
-        String tenant = RandomStringUtils.randomAlphabetic(10);
-        String zone = RandomStringUtils.randomAlphabetic(10);
-        assertThat(monitorManagement.getMonitorsForZone(tenant, zone), hasSize(0));
-
-        createRemoteMonitorsForTenant(count, tenant, zone);
-        createRemoteMonitorsForTenant(count, tenant, "notMyZone");
-
-        assertThat(monitorManagement.getMonitorsForZone(tenant, zone), hasSize(count));
-    }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
@@ -1,0 +1,157 @@
+package com.rackspace.salus.monitor_management.services;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.monitor_management.entities.Zone;
+import com.rackspace.salus.monitor_management.repositories.ZoneRepository;
+import com.rackspace.salus.monitor_management.web.model.ZoneCreate;
+import com.rackspace.salus.monitor_management.web.model.ZoneUpdate;
+import com.rackspace.salus.telemetry.etcd.services.AgentsCatalogService;
+import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Random;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest(showSql = false)
+@Import({ZoneManagement.class, ObjectMapper.class})
+public class ZoneManagementTest {
+
+    @MockBean
+    MonitorManagement monitorManagement;
+
+    @MockBean
+    ZoneStorage zoneStorage;
+
+    @MockBean
+    AgentsCatalogService agentsCatalogService;
+
+    @Autowired
+    ZoneRepository zoneRepository;
+
+    @Autowired
+    ZoneManagement zoneManagement;
+
+    private final String DEFAULT_ZONE = "public/default";
+
+    private PodamFactory podamFactory = new PodamFactoryImpl();
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() {
+        // create a default public zone
+        Zone zone = new Zone()
+                .setTenantId(ZoneManagement.PUBLIC)
+                .setName(DEFAULT_ZONE)
+                .setEnvoyTimeout(Duration.ofSeconds(100));
+        zoneRepository.save(zone);
+    }
+
+    private void createZonesForTenant(int count, String tenantId) {
+        for (int i = 0; i < count; i++) {
+            ZoneCreate create = podamFactory.manufacturePojo(ZoneCreate.class);
+            create.setName(RandomStringUtils.randomAlphanumeric(10));
+            zoneManagement.createZone(tenantId, create);
+        }
+    }
+
+    @Test
+    public void testGetZone() {
+        Optional<Zone> zone = zoneManagement.getZone(ZoneManagement.PUBLIC, DEFAULT_ZONE);
+        assertTrue(zone.isPresent());
+        assertThat(zone.get().getId(), notNullValue());
+        assertThat(zone.get().getTenantId(), equalTo(ZoneManagement.PUBLIC));
+        assertThat(zone.get().getName(), equalTo(DEFAULT_ZONE));
+    }
+
+    @Test
+    public void testCreateZone() {
+        ZoneCreate create = podamFactory.manufacturePojo(ZoneCreate.class);
+        create.setName(RandomStringUtils.randomAlphanumeric(10));
+        String tenant = RandomStringUtils.randomAlphabetic(10);
+        Zone zone = zoneManagement.createZone(tenant, create);
+        assertThat(zone.getId(), notNullValue());
+        assertThat(zone.getTenantId(), equalTo(tenant));
+        assertThat(zone.getName(), equalTo(create.getName()));
+        assertThat(zone.getEnvoyTimeout(), equalTo(Duration.ofSeconds(create.getPollerTimeout())));
+
+        Optional<Zone> z = zoneManagement.getZone(tenant, create.getName());
+        assertTrue(z.isPresent());
+        assertThat(z.get().getName(), equalTo(create.getName()));
+    }
+
+    @Test
+    public void testCreateZoneNonAlphanumericName() {
+        // This should be successful because the alphanumeric validation only happens via Spring MVC.
+        ZoneCreate create = podamFactory.manufacturePojo(ZoneCreate.class);
+        create.setName("onlyAlphaNumericAreAllowed!!!");
+        String tenant = RandomStringUtils.randomAlphabetic(10);
+        Zone zone = zoneManagement.createZone(tenant, create);
+        assertThat(zone.getId(), notNullValue());
+        assertThat(zone.getTenantId(), equalTo(tenant));
+        assertThat(zone.getName(), equalTo(create.getName()));
+        assertThat(zone.getEnvoyTimeout(), equalTo(Duration.ofSeconds(create.getPollerTimeout())));
+
+        Optional<Zone> z = zoneManagement.getZone(tenant, create.getName());
+        assertTrue(z.isPresent());
+        assertThat(z.get().getName(), equalTo(create.getName()));
+    }
+
+    @Test
+    public void testUpdateZone() {
+        Zone original = zoneManagement.getAvailableZonesForTenant(ZoneManagement.PUBLIC).get(0);
+
+        assertThat(original, notNullValue());
+
+        ZoneUpdate update = new ZoneUpdate().setPollerTimeout(original.getEnvoyTimeout().getSeconds() + 100);
+
+        Zone zone = zoneManagement.updateZone(ZoneManagement.PUBLIC, original.getName(), update);
+        assertThat(zone.getId(), equalTo(original.getId()));
+        assertThat(zone.getTenantId(), equalTo(original.getTenantId()));
+        assertThat(zone.getName(), equalTo(original.getName()));
+        assertThat(zone.getEnvoyTimeout(), equalTo(Duration.ofSeconds(update.getPollerTimeout())));
+
+        Optional<Zone> z = zoneManagement.getZone(ZoneManagement.PUBLIC, zone.getName());
+        assertTrue(z.isPresent());
+        assertThat(z.get().getEnvoyTimeout().getSeconds(), equalTo(update.getPollerTimeout()));
+    }
+
+    @Test
+    public void testGetAvailableZonesForTenant() {
+        Random random = new Random();
+        int privateCount = random.nextInt(20);
+        int publicCount = random.nextInt(5);
+        String tenant = RandomStringUtils.randomAlphabetic(10);
+        String unrelatedTenant = RandomStringUtils.randomAlphabetic(10);
+
+        // there is one default zone in these tests
+        assertThat(zoneManagement.getAvailableZonesForTenant(tenant), hasSize(1));
+
+        // any new private zone for the tenant should be visible
+        createZonesForTenant(privateCount, tenant);
+        assertThat(zoneManagement.getAvailableZonesForTenant(tenant), hasSize(1 + privateCount));
+
+        // new public zones should be visible too
+        createZonesForTenant(publicCount, ZoneManagement.PUBLIC);
+        assertThat(zoneManagement.getAvailableZonesForTenant(tenant), hasSize(1 + privateCount + publicCount));
+
+        // Another tenant can only see public zones
+        assertThat(zoneManagement.getAvailableZonesForTenant(unrelatedTenant), hasSize(1 + publicCount));
+    }
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClientTest.java
@@ -1,0 +1,57 @@
+package com.rackspace.salus.monitor_management.web.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.monitor_management.web.client.ZoneApiClient;
+import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@RunWith(SpringRunner.class)
+@RestClientTest
+public class ZoneApiClientTest {
+    @TestConfiguration
+    public static class ExtraTestConfig {
+        @Bean
+        public ZoneApiClient zoneApiClient(RestTemplateBuilder restTemplateBuilder) {
+            return new ZoneApiClient(restTemplateBuilder.build());
+        }
+    }
+    @Autowired
+    MockRestServiceServer mockServer;
+
+    @Autowired
+    ZoneApiClient zoneApiClient;
+
+    private PodamFactory podamFactory = new PodamFactoryImpl();
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testGetByZoneName() throws JsonProcessingException {
+        ZoneDTO expectedZone = podamFactory.manufacturePojo(ZoneDTO.class);
+        mockServer.expect(requestTo("/api/tenant/t-1/zones/r-1"))
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(expectedZone), MediaType.APPLICATION_JSON
+                ));
+
+        final ZoneDTO zone = zoneApiClient.getByZoneName("t-1", "r-1");
+
+        assertThat(zone, equalTo(expectedZone));
+    }
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClientTest.java
@@ -45,12 +45,12 @@ public class ZoneApiClientTest {
     @Test
     public void testGetByZoneName() throws JsonProcessingException {
         ZoneDTO expectedZone = podamFactory.manufacturePojo(ZoneDTO.class);
-        mockServer.expect(requestTo("/api/tenant/t-1/zones/r-1"))
+        mockServer.expect(requestTo("/api/tenant/t-1/zones/z-1"))
                 .andRespond(withSuccess(
                         objectMapper.writeValueAsString(expectedZone), MediaType.APPLICATION_JSON
                 ));
 
-        final ZoneDTO zone = zoneApiClient.getByZoneName("t-1", "r-1");
+        final ZoneDTO zone = zoneApiClient.getByZoneName("t-1", "z-1");
 
         assertThat(zone, equalTo(expectedZone));
     }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -5,6 +5,7 @@ import com.rackspace.salus.monitor_management.web.controller.ZoneApiController;
 import com.rackspace.salus.monitor_management.entities.Zone;
 import com.rackspace.salus.monitor_management.services.ZoneManagement;
 import com.rackspace.salus.monitor_management.web.model.ZoneCreate;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +19,7 @@ import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.Random;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.when;
@@ -44,6 +46,13 @@ public class ZoneApiControllerTest {
 
     private PodamFactory podamFactory = new PodamFactoryImpl();
 
+    private ZoneCreate newZoneCreate() {
+        Random random = new Random();
+        return new ZoneCreate()
+                .setName(RandomStringUtils.randomAlphanumeric(10))
+                .setPollerTimeout(random.nextInt(1000) + 30);
+    }
+
     @Test
     public void testGetByZoneName() throws Exception {
         final Zone expectedZone = podamFactory.manufacturePojo(Zone.class);
@@ -52,7 +61,7 @@ public class ZoneApiControllerTest {
 
         mvc.perform(get(
                 "/api/tenant/{tenantId}/zones/{name}",
-                "t-1", "r-1")
+                "t-1", "z-1")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -67,7 +76,7 @@ public class ZoneApiControllerTest {
         when(zoneManagement.createZone(any(), any()))
                 .thenReturn(zone);
 
-        ZoneCreate create = podamFactory.manufacturePojo(ZoneCreate.class);
+        ZoneCreate create = newZoneCreate();
 
         mvc.perform(post(
                     "/api/tenant/{tenantId}/zones", "t-1")
@@ -82,7 +91,7 @@ public class ZoneApiControllerTest {
 
     @Test
     public void testCreateZoneInvalidName() throws Exception {
-        ZoneCreate create = podamFactory.manufacturePojo(ZoneCreate.class);
+        ZoneCreate create = newZoneCreate();
         create.setName("Cant use non-alphanumeric!!!");
 
         String errorMsg = "\"name\" Only alphanumeric characters can be used";
@@ -102,7 +111,7 @@ public class ZoneApiControllerTest {
     public void testDeleteZone() throws Exception {
         mvc.perform(delete(
                 "/api/tenant/{tenantId}/zones/{name}",
-                "t-1", "r-1"))
+                "t-1", "z-1"))
                 .andDo(print())
                 .andExpect(status().isNoContent());
     }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -1,0 +1,109 @@
+package com.rackspace.salus.monitor_management.web.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.monitor_management.web.controller.ZoneApiController;
+import com.rackspace.salus.monitor_management.entities.Zone;
+import com.rackspace.salus.monitor_management.services.ZoneManagement;
+import com.rackspace.salus.monitor_management.web.model.ZoneCreate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(ZoneApiController.class)
+public class ZoneApiControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    ZoneManagement zoneManagement;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+
+    private PodamFactory podamFactory = new PodamFactoryImpl();
+
+    @Test
+    public void testGetByZoneName() throws Exception {
+        final Zone expectedZone = podamFactory.manufacturePojo(Zone.class);
+        when(zoneManagement.getZone(any(), any()))
+                .thenReturn(Optional.of(expectedZone));
+
+        mvc.perform(get(
+                "/api/tenant/{tenantId}/zones/{name}",
+                "t-1", "r-1")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(objectMapper.writeValueAsString(expectedZone.toDTO())));
+    }
+
+    @Test
+    public void testCreateZone() throws Exception {
+        Zone zone = podamFactory.manufacturePojo(Zone.class);
+        when(zoneManagement.createZone(any(), any()))
+                .thenReturn(zone);
+
+        ZoneCreate create = podamFactory.manufacturePojo(ZoneCreate.class);
+
+        mvc.perform(post(
+                    "/api/tenant/{tenantId}/zones", "t-1")
+                .content(objectMapper.writeValueAsString(create))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8.name()))
+                .andExpect(status().isCreated())
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(objectMapper.writeValueAsString(zone.toDTO())));
+    }
+
+    @Test
+    public void testCreateZoneInvalidName() throws Exception {
+        ZoneCreate create = podamFactory.manufacturePojo(ZoneCreate.class);
+        create.setName("Cant use non-alphanumeric!!!");
+
+        String errorMsg = "\"name\" Only alphanumeric characters can be used";
+
+        mvc.perform(post(
+                "/api/tenant/{tenantId}/zones", "t-1")
+                .content(objectMapper.writeValueAsString(create))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8.name()))
+                .andExpect(status().isBadRequest())
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message", is(errorMsg)));
+    }
+
+    @Test
+    public void testDeleteZone() throws Exception {
+        mvc.perform(delete(
+                "/api/tenant/{tenantId}/zones/{name}",
+                "t-1", "r-1"))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+}


### PR DESCRIPTION
# What

This felt like a good place to push a PR without it getting too big.

 * Bumps to Java 12
 * Adds zone repository, entity, models, and management service
 * Adds checks to monitor create to verify the provided zone can be used

# How
Mostly similar to every other service we've created.  A lot of filling in all the generic methods etc.

## How to test

Run included tests or try things manually.

# Why

This allows us to do more validation around zones for monitor creation and envoy attachment.  It is also the first step towards having users create their own zones and implementing the redistribution of monitors if an envoy/poller disconnects for too long.

Cyclical dependencies become a bigger problem if zone management is in a separate repo.

# TODO

 * There are a couple `// TBD` comments that will be removed/replaced when the use of timeouts is implemented.
 * More javadoc will be added in another pr too
 * Look into why `findByTenantIdAndZonesContains` only worked in tests?
 * Add public zone creation api