### PR TITLE
Public Zone Additions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,6 @@
       <version>0.0.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
       <version>0.0.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/rackspace/salus/monitor_management/entities/Zone.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/entities/Zone.java
@@ -34,89 +34,89 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "zones", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"tenant_id", "name"})})
+    @UniqueConstraint(columnNames = {"tenant_id", "name"})})
 
 @Data
 public class Zone implements Serializable {
-    @Id
-    @GeneratedValue
-    @Type(type="uuid-char")
-    UUID id;
+  @Id
+  @GeneratedValue
+  @Type(type="uuid-char")
+  UUID id;
 
-    /**
-     * Contains the unique name/label for the zone.
-     * Public zones should have a "public/" prefix and then a trailing region descriptor.
-     * e.g. "public/us-central-1"
-     */
-    @NotBlank
-    @Column(name="name")
-    String name;
+  /**
+   * Contains the tenant that owns the private zone or "_PUBLIC_" for public zones.
+   */
+  @NotBlank
+  @Column(name="tenant_id")
+  String tenantId;
 
-    /**
-     * Contains an optional hosting provider of the zone.
-     * e.g. Rackspace, Google, Amazon
-     */
-    @Column(name="provider")
-    String provider;
+  /**
+   * Contains the unique name/label for the zone.
+   * Public zones should have a "public/" prefix and then a trailing region descriptor.
+   * e.g. "public/us-central-1"
+   */
+  @NotBlank
+  @Column(name="name")
+  String name;
 
-    /**
-     * Contains an optional region to more precisely define where the zone is running.
-     * e.g. for Rackspace, dfw3 may be used; for Google, europe-west3.
-     */
-    @Column(name="provider_region")
-    String providerRegion;
+  /**
+   * Contains an optional hosting provider of the zone.
+   * e.g. Rackspace, Google, Amazon
+   */
+  @Column(name="provider")
+  String provider;
 
-    /**
-     * Defines whether a zone is public or private.
-     */
-    @NotNull
-    @Column(name="is_public")
-    boolean isPublic;
+  /**
+   * Contains an optional region to more precisely define where the zone is running.
+   * e.g. for Rackspace, dfw3 may be used; for Google, europe-west3.
+   */
+  @Column(name="provider_region")
+  String providerRegion;
 
-    /**
-     * Contains an optional list of ipv4 and ipv6 ranges that the pollers in this zone reside in.
-     * This can be used to whitelist ranges to allow for remote polling.
-     */
-    @ElementCollection(fetch = FetchType.EAGER)
-    @Column(name="source_ips")
-    List<String> sourceIpRanges;
+  /**
+   * Defines whether a zone is public or private.
+   */
+  @NotNull
+  @Column(name="is_public")
+  boolean isPublic;
 
-    /**
-     * Defines whether the zone is available or not.
-     * This helps determine whether new monitors can be added to the zone.
-     */
-    @Enumerated(EnumType.STRING)
-    @Column(name="state")
-    ZoneState state;
+  /**
+   * Contains an optional list of ipv4 and ipv6 ranges that the pollers in this zone reside in.
+   * This can be used to whitelist ranges to allow for remote polling.
+   */
+  @ElementCollection(fetch = FetchType.EAGER)
+  @Column(name="source_ips")
+  List<String> sourceIpAddresses;
 
-    /**
-     * Contains the tenant that owns the private zone or "_PUBLIC_" for public zones.
-     */
-    @NotBlank
-    @Column(name="tenant_id")
-    String tenantId;
+  /**
+   * Defines whether the zone is available or not.
+   * This helps determine whether new monitors can be added to the zone.
+   */
+  @Enumerated(EnumType.STRING)
+  @Column(name="state")
+  ZoneState state;
 
-    /**
-     * Contains a timeout value which begins to countdown after an envoy/poller has disconnected.
-     * If the timeout is met, the monitors bound to it will be distributed to other available pollers.
-     */
-    @DurationUnit(ChronoUnit.SECONDS)
-    @Column(name="envoy_timeout")
-    Duration envoyTimeout = Duration.ofSeconds(120);
+  /**
+   * Contains a timeout value which begins to countdown after an poller has disconnected.
+   * If the timeout is met, the monitors bound to it will be distributed to other available pollers.
+   */
+  @DurationUnit(ChronoUnit.SECONDS)
+  @Column(name="poller_timeout")
+  Duration pollerTimeout = Duration.ofSeconds(120);
 
-    /**
-     * Converts the Zone object to a ZoneDTO which is a stripped down version to be used
-     * as output in the APIs.
-     *
-     * @return A ZoneDTO with fields mapped from the Zone.
-     */
-    public ZoneDTO toDTO() {
-        return new ZoneDTO()
-                .setName(name)
-                .setEnvoyTimeout(envoyTimeout.getSeconds())
-                .setProvider(provider)
-                .setProviderRegion(providerRegion)
-                .setPublic(isPublic)
-                .setSourceIpRanges(sourceIpRanges);
-    }
+  /**
+   * Converts the Zone object to a ZoneDTO which is a stripped down version to be used
+   * as output in the APIs.
+   *
+   * @return A ZoneDTO with fields mapped from the Zone.
+   */
+  public ZoneDTO toDTO() {
+    return new ZoneDTO()
+        .setName(name)
+        .setPollerTimeout(pollerTimeout.getSeconds())
+        .setProvider(provider)
+        .setProviderRegion(providerRegion)
+        .setPublic(isPublic)
+        .setSourceIpAddresses(sourceIpAddresses);
+  }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/entities/Zone.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/entities/Zone.java
@@ -97,7 +97,7 @@ public class Zone implements Serializable {
   ZoneState state;
 
   /**
-   * Contains a timeout value which begins to countdown after an poller has disconnected.
+   * Contains a timeout value which begins to countdown after a poller has disconnected.
    * If the timeout is met, the monitors bound to it will be distributed to other available pollers.
    */
   @DurationUnit(ChronoUnit.SECONDS)

--- a/src/main/java/com/rackspace/salus/monitor_management/entities/Zone.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/entities/Zone.java
@@ -83,6 +83,7 @@ public class Zone implements Serializable {
   /**
    * Contains an optional list of ipv4 and ipv6 ranges that the pollers in this zone reside in.
    * This can be used to whitelist ranges to allow for remote polling.
+   * Entries must be valid CIDR notation.
    */
   @ElementCollection(fetch = FetchType.EAGER)
   @Column(name="source_ips")

--- a/src/main/java/com/rackspace/salus/monitor_management/errors/ZoneDeletionNotAllowed.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/errors/ZoneDeletionNotAllowed.java
@@ -1,0 +1,9 @@
+package com.rackspace.salus.monitor_management.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ZoneDeletionNotAllowed extends RuntimeException {
+  public ZoneDeletionNotAllowed(String message) { super(message);}
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
@@ -30,9 +30,6 @@ public interface MonitorRepository extends PagingAndSortingRepository<Monitor, U
 
     Page<Monitor> findByTenantId(String tenantId, Pageable pageable);
 
-    // this doesn't work in tests but it logs the exact same query as the one below.
-    //List<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone);
-
     @Query("select m from Monitor m where m.tenantId = :tenantId and :zone member of m.zones")
     List<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone);
 

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
@@ -30,9 +30,15 @@ public interface MonitorRepository extends PagingAndSortingRepository<Monitor, U
 
     Page<Monitor> findByTenantId(String tenantId, Pageable pageable);
 
-    // this works in tests but not in reality.
-    List<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone);
+    // this doesn't work in tests but it logs the exact same query as the one below.
+    //List<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone);
 
     @Query("select m from Monitor m where m.tenantId = :tenantId and :zone member of m.zones")
-    List<Monitor> customFindByTenantIdAndZonesContains(String tenantId, String zone);
+    List<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone);
+
+    @Query("select count(m) from Monitor m where :zone member of m.zones")
+    int countAllByZonesContains(String zone);
+
+    @Query("select count(m) from Monitor m where m.tenantId = :tenantId and :zone member of m.zones")
+    int countAllByTenantIdAndZonesContains(String tenantId, String zone);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
@@ -231,7 +231,7 @@ public class ZoneManagement {
     }
 
     /**
-     * Helper method to public private zones by tenant id and zone name.
+     * Helper method to remove public zones by zone name.
      * @param name The name of the zone.
      * @throws NotFoundException
      * @throws IllegalArgumentException

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
@@ -135,9 +135,7 @@ public class ZoneManagement {
           .to(zone::setSourceIpAddresses);
       map.from(updatedZone.getPollerTimeout())
           .whenNonNull()
-          .to(timeout -> {
-            zone.setPollerTimeout(Duration.ofSeconds(updatedZone.getPollerTimeout()));
-          });
+          .to(timeout -> zone.setPollerTimeout(Duration.ofSeconds(updatedZone.getPollerTimeout())));
       map.from(updatedZone.getState())
           .whenNonNull()
           .to(zone::setState);
@@ -224,7 +222,7 @@ public class ZoneManagement {
    * @param zoneName The zone to lookup.
    * @return The count of monitors in the zone.
    */
-  public int getMonitorCountForPublicZone(String zoneName) {
+  int getMonitorCountForPublicZone(String zoneName) {
     return monitorRepository.countAllByZonesContains(zoneName);
   }
 
@@ -236,7 +234,7 @@ public class ZoneManagement {
    * @param zoneName The zone to lookup.
    * @return The count of monitors in the zone.
    */
-  public int getMonitorCountForPrivateZone(String tenantId, String zoneName) {
+  int getMonitorCountForPrivateZone(String tenantId, String zoneName) {
     return monitorRepository.countAllByTenantIdAndZonesContains(tenantId, zoneName);
   }
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
@@ -173,7 +173,7 @@ public class ZoneManagement {
    * @return The newly updated zone.
    */
   public Zone updatePrivateZone(String tenantId, String name, @Valid ZoneUpdate updatedZone) {
-    Zone zone = getZone(tenantId, name).orElseThrow(() ->
+    Zone zone = getPrivateZone(tenantId, name).orElseThrow(() ->
         new NotFoundException(String.format("No zone found named %s on tenant %s",
             name, tenantId)));
     return updateZone(zone, updatedZone);
@@ -186,7 +186,7 @@ public class ZoneManagement {
    * @return The newly updated zone.
    */
   public Zone updatePublicZone(String name, @Valid ZoneUpdate updatedZone) {
-    Zone zone = getZone(ResolvedZone.PUBLIC, name).orElseThrow(() ->
+    Zone zone = getPublicZone(name).orElseThrow(() ->
         new NotFoundException(String.format("No public zone found named %s", name)));
     return updateZone(zone, updatedZone);
   }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
@@ -292,7 +292,7 @@ public class ZoneManagement {
 
   /**
    * Get the number of monitors for a zone on a single tenant.
-   * This should be used when looking up public zones.
+   * This should be used when looking up private zones.
    *
    * @param tenantId The tenant the zone resides on.
    * @param zoneName The zone to lookup.

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -85,7 +85,12 @@ public class ZoneApiController implements ZoneApi {
 
     @PutMapping("/tenant/{tenantId}/zones/{name}")
     public ZoneDTO update(@PathVariable String tenantId, @PathVariable String name, @Valid @RequestBody ZoneUpdate zone) {
-        return zoneManagement.updateZone(tenantId, name, zone).toDTO();
+        return zoneManagement.updatePrivateZone(tenantId, name, zone).toDTO();
+    }
+
+    @PutMapping("/admin/zones/{name}")
+    public ZoneDTO update(@PathVariable String name, @Valid @RequestBody ZoneUpdate zone) {
+        return zoneManagement.updatePublicZone(name, zone).toDTO();
     }
 
     @DeleteMapping("/tenant/{tenantId}/zones/{name}")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -56,9 +56,17 @@ public class ZoneApiController implements ZoneApi {
     @GetMapping("/tenant/{tenantId}/zones/{name}")
     public ZoneDTO getByZoneName(@PathVariable String tenantId, @PathVariable String name) {
         Optional<Zone> zone = zoneManagement.getPrivateZone(tenantId, name);
-        return zone.orElseThrow(() -> new NotFoundException(String.format("No zone found for %s on tenant %s",
+        return zone.orElseThrow(() -> new NotFoundException(String.format("No zone found named %s on tenant %s",
                 name, tenantId)))
                 .toDTO();
+    }
+
+    @GetMapping("/admin/zones/{name}")
+    public ZoneDTO getPublicZone(@PathVariable String name) {
+        Optional<Zone> zone = zoneManagement.getPublicZone(name);
+        return zone.orElseThrow(() -> new NotFoundException(String.format("No public zone found named %s",
+            name)))
+            .toDTO();
     }
 
     @PostMapping("/tenant/{tenantId}/zones")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreate.java
@@ -26,7 +26,7 @@ import java.io.Serializable;
 public class ZoneCreate implements Serializable {
 
     @NotBlank
-    @Pattern(regexp = "^[\\p{Alnum}]+$", message = "Only alphanumeric characters can be used")
+    @Pattern(regexp = "^[A-Za-z0-9_]+$", message = "Only alphanumeric and underscore characters can be used")
     String name;
 
     @Min(value = 30, message = "The timeout must not be less than 30s")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePrivate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePrivate.java
@@ -41,7 +41,7 @@ public class ZoneCreatePrivate implements Serializable {
 
     ZoneState state = ZoneState.ACTIVE; // Can we do active for private, inactive for public?
 
-    @Min(value = 30, message = "The timeout must not be less than 30s")
-    @Max(value = 1800, message = "The timeout must not be more than 1800s (30m)")
-    long pollerTimeout = 120;
+    @Min(value = 30L, message = "The timeout must not be less than 30s")
+    @Max(value = 1800L, message = "The timeout must not be more than 1800s (30m)")
+    Long pollerTimeout = 120L;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePrivate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePrivate.java
@@ -15,6 +15,8 @@
  */
 package com.rackspace.salus.monitor_management.web.model;
 
+import com.rackspace.salus.monitor_management.types.ZoneState;
+import java.util.List;
 import lombok.Data;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -23,11 +25,19 @@ import org.hibernate.validator.constraints.NotBlank;
 import java.io.Serializable;
 
 @Data
-public class ZoneCreate implements Serializable {
+public class ZoneCreatePrivate implements Serializable {
 
     @NotBlank
     @Pattern(regexp = "^[A-Za-z0-9_]+$", message = "Only alphanumeric and underscore characters can be used")
     String name;
+
+    String provider;
+
+    String providerRegion;
+
+    List<String> sourceIpAddresses;
+
+    ZoneState state = ZoneState.ACTIVE; // Can we do active for private, inactive for public?
 
     @Min(value = 30, message = "The timeout must not be less than 30s")
     @Max(value = 1800, message = "The timeout must not be more than 1800s (30m)")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePrivate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePrivate.java
@@ -16,6 +16,7 @@
 package com.rackspace.salus.monitor_management.web.model;
 
 import com.rackspace.salus.monitor_management.types.ZoneState;
+import com.rackspace.salus.monitor_management.web.model.validator.ValidCidrList;
 import java.util.List;
 import lombok.Data;
 import javax.validation.constraints.Max;
@@ -35,6 +36,7 @@ public class ZoneCreatePrivate implements Serializable {
 
     String providerRegion;
 
+    @ValidCidrList
     List<String> sourceIpAddresses;
 
     ZoneState state = ZoneState.ACTIVE; // Can we do active for private, inactive for public?

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePublic.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePublic.java
@@ -16,8 +16,10 @@
 package com.rackspace.salus.monitor_management.web.model;
 
 import com.rackspace.salus.monitor_management.types.ZoneState;
+import com.rackspace.salus.monitor_management.web.model.validator.ValidCidrList;
 import java.util.List;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
 import lombok.Data;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -28,6 +30,7 @@ import java.io.Serializable;
 public class ZoneCreatePublic implements Serializable {
 
   @NotBlank
+  @Pattern(regexp = "^[A-Za-z0-9_/]+$", message = "Only alphanumeric, underscores, and slashes can be used")
   String name;
 
   @NotBlank
@@ -37,6 +40,7 @@ public class ZoneCreatePublic implements Serializable {
   String providerRegion;
 
   @NotEmpty
+  @ValidCidrList
   List<String> sourceIpAddresses;
 
   ZoneState state = ZoneState.INACTIVE;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePublic.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePublic.java
@@ -45,7 +45,7 @@ public class ZoneCreatePublic implements Serializable {
 
   ZoneState state = ZoneState.INACTIVE;
 
-  @Min(value = 30, message = "The timeout must not be less than 30s")
-  @Max(value = 1800, message = "The timeout must not be more than 1800s (30m)")
-  long pollerTimeout = 300;
+  @Min(value = 30L, message = "The timeout must not be less than 30s")
+  @Max(value = 1800L, message = "The timeout must not be more than 1800s (30m)")
+  Long pollerTimeout = 300L;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePublic.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePublic.java
@@ -16,18 +16,32 @@
 package com.rackspace.salus.monitor_management.web.model;
 
 import com.rackspace.salus.monitor_management.types.ZoneState;
-import lombok.Data;
-
 import java.util.List;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import org.hibernate.validator.constraints.NotBlank;
+import java.io.Serializable;
 
 @Data
-public class ZoneDTO {
-    String name;
-    long pollerTimeout;
-    String provider;
-    String providerRegion;
-    boolean isPublic;
-    List<String> sourceIpAddresses;
+public class ZoneCreatePublic implements Serializable {
 
-    ZoneState state; // we want to filter this from public api responses
+  @NotBlank
+  String name;
+
+  @NotBlank
+  String provider;
+
+  @NotBlank
+  String providerRegion;
+
+  @NotEmpty
+  List<String> sourceIpAddresses;
+
+  ZoneState state = ZoneState.INACTIVE;
+
+  @Min(value = 30, message = "The timeout must not be less than 30s")
+  @Max(value = 1800, message = "The timeout must not be more than 1800s (30m)")
+  long pollerTimeout = 300;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneUpdate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneUpdate.java
@@ -15,6 +15,8 @@
  */
 package com.rackspace.salus.monitor_management.web.model;
 
+import com.rackspace.salus.monitor_management.types.ZoneState;
+import java.util.List;
 import lombok.Data;
 
 import javax.validation.constraints.Max;
@@ -23,6 +25,14 @@ import java.io.Serializable;
 
 @Data
 public class ZoneUpdate implements Serializable {
+
+    String provider;
+
+    String providerRegion;
+
+    List<String> sourceIpAddresses;
+
+    ZoneState state;
 
     @Min(value = 30, message = "The timeout must not be less than 30s")
     @Max(value = 1800, message = "The timeout must not be more than 1800s (30m)")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneUpdate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneUpdate.java
@@ -16,6 +16,7 @@
 package com.rackspace.salus.monitor_management.web.model;
 
 import com.rackspace.salus.monitor_management.types.ZoneState;
+import com.rackspace.salus.monitor_management.web.model.validator.ValidCidrList;
 import java.util.List;
 import lombok.Data;
 
@@ -30,6 +31,7 @@ public class ZoneUpdate implements Serializable {
 
     String providerRegion;
 
+    @ValidCidrList
     List<String> sourceIpAddresses;
 
     ZoneState state;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneUpdate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneUpdate.java
@@ -36,7 +36,7 @@ public class ZoneUpdate implements Serializable {
 
     ZoneState state;
 
-    @Min(value = 30, message = "The timeout must not be less than 30s")
-    @Max(value = 1800, message = "The timeout must not be more than 1800s (30m)")
-    long pollerTimeout;
+    @Min(value = 30L, message = "The timeout must not be less than 30s")
+    @Max(value = 1800L, message = "The timeout must not be more than 1800s (30m)")
+    Long pollerTimeout;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidCidrList.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidCidrList.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.validator;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Indicates that an annotated <code>List</code> must only contain <code>String</code>
+ * values that match valid CIDR notation.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Documented
+@Constraint(validatedBy = ValidCidrListValidator.class)
+public @interface ValidCidrList {
+  String message() default "All values must be valid CIDR notation";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidCidrListValidator.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidCidrListValidator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.validator;
+
+import com.rackspace.salus.common.util.CIDRUtils;
+import java.util.List;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Validates the annotated list only contains strings that are valid CIDR notation.
+ * A null list is also valid.
+ */
+public class ValidCidrListValidator implements ConstraintValidator<ValidCidrList, List<String>> {
+  public void initialize(ValidCidrList constraint) {}
+
+  public boolean isValid(List<String> obj, ConstraintValidatorContext context) {
+    if (obj == null) {
+      return true;
+    }
+
+    return obj.stream().allMatch(this::isValidSubnet);
+  }
+
+  /**
+   * Verify if a given string is valid cidr notation.
+   * @param input The string to validate.
+   * @return True if it's valid, otherwise false.
+   */
+  private boolean isValidSubnet(String input) {
+    try {
+      new CIDRUtils(input);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
@@ -81,6 +81,14 @@ public class ZoneManagementTest {
         return zoneManagement.createPublicZone(create);
     }
 
+    private List<Zone> createPublicZones(int count) {
+        List<Zone> zones = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            zones.add(createPublicZone());
+        }
+        return zones;
+    }
+
     private Zone createPrivateZoneForTenant(String tenantId) {
         ZoneCreatePrivate create = podamFactory.manufacturePojo(ZoneCreatePrivate.class);
         create.setName(RandomStringUtils.randomAlphanumeric(10));
@@ -234,7 +242,7 @@ public class ZoneManagementTest {
         assertThat(zoneManagement.getAvailableZonesForTenant(tenant), hasSize(1 + privateCount));
 
         // new public zones should be visible too
-        createPrivateZonesForTenant(publicCount, ResolvedZone.PUBLIC);
+        createPublicZones(publicCount);
         assertThat(zoneManagement.getAvailableZonesForTenant(tenant), hasSize(1 + privateCount + publicCount));
 
         // Another tenant can only see public zones
@@ -326,7 +334,7 @@ public class ZoneManagementTest {
         assertThat(zoneManagement.getMonitorCountForPublicZone(publicZone), equalTo(0));
 
         createRemoteMonitorsForTenant(privateCount, tenant, privateZone);
-        createRemoteMonitorsForTenant(privateCount, tenant, "anotherPrivateZone");
+        createRemoteMonitorsForTenant(privateCount + 2, tenant, "anotherPrivateZone");
         createRemoteMonitorsForTenant(publicCount, tenant, publicZone);
 
         assertThat(zoneManagement.getMonitorCountForPrivateZone(tenant, privateZone), equalTo(privateCount));

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
@@ -1,25 +1,35 @@
 package com.rackspace.salus.monitor_management.services;
 
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.monitor_management.entities.Zone;
+import com.rackspace.salus.monitor_management.repositories.MonitorRepository;
 import com.rackspace.salus.monitor_management.repositories.ZoneRepository;
+import com.rackspace.salus.monitor_management.types.ZoneState;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
-import com.rackspace.salus.monitor_management.web.model.ZoneCreate;
+import com.rackspace.salus.monitor_management.web.model.ZoneCreatePrivate;
+import com.rackspace.salus.monitor_management.web.model.ZoneCreatePublic;
 import com.rackspace.salus.monitor_management.web.model.ZoneUpdate;
-import com.rackspace.salus.telemetry.etcd.services.AgentsCatalogService;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.Monitor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -31,7 +41,7 @@ import java.util.Optional;
 import java.util.Random;
 
 @RunWith(SpringRunner.class)
-@DataJpaTest(showSql = false)
+@DataJpaTest(showSql = true)
 @Import({ZoneManagement.class, ObjectMapper.class})
 public class ZoneManagementTest {
 
@@ -43,6 +53,9 @@ public class ZoneManagementTest {
 
     @Autowired
     ZoneRepository zoneRepository;
+
+    @Autowired
+    MonitorRepository monitorRepository;
 
     @Autowired
     ZoneManagement zoneManagement;
@@ -60,30 +73,43 @@ public class ZoneManagementTest {
         Zone zone = new Zone()
                 .setTenantId(ResolvedZone.PUBLIC)
                 .setName(DEFAULT_ZONE)
-                .setEnvoyTimeout(Duration.ofSeconds(100));
+                .setPollerTimeout(Duration.ofSeconds(100));
         zoneRepository.save(zone);
     }
 
-    private void createZonesForTenant(int count, String tenantId) {
+    private Zone createPublicZone() {
+        ZoneCreatePublic create = podamFactory.manufacturePojo(ZoneCreatePublic.class);
+        create.setName(ResolvedZone.PUBLIC_PREFIX + RandomStringUtils.randomAlphanumeric(6));
+        return zoneManagement.createPublicZone(create);
+    }
+
+    private Zone createPrivateZoneForTenant(String tenantId) {
+        ZoneCreatePrivate create = podamFactory.manufacturePojo(ZoneCreatePrivate.class);
+        create.setName(RandomStringUtils.randomAlphanumeric(10));
+        return zoneManagement.createPrivateZone(tenantId, create);
+    }
+
+    private List<Zone> createPrivateZonesForTenant(int count, String tenantId) {
+        List<Zone> zones = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            ZoneCreate create = podamFactory.manufacturePojo(ZoneCreate.class);
-            create.setName(RandomStringUtils.randomAlphanumeric(10));
-            zoneManagement.createZone(tenantId, create);
+            zones.add(createPrivateZoneForTenant(tenantId));
         }
+        return zones;
     }
 
     private void createRemoteMonitorsForTenant(int count, String tenantId, String zone) {
         for (int i = 0; i < count; i++) {
-            MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
+            Monitor create = podamFactory.manufacturePojo(Monitor.class);
             create.setSelectorScope(ConfigSelectorScope.REMOTE);
             create.setZones(Collections.singletonList(zone));
-            monitorManagement.createMonitor(tenantId, create);
+            create.setTenantId(tenantId);
+            monitorRepository.save(create);
         }
     }
 
     @Test
     public void testGetZone() {
-        Optional<Zone> zone = zoneManagement.getZone(ResolvedZone.PUBLIC, DEFAULT_ZONE);
+        Optional<Zone> zone = zoneManagement.getPublicZone(DEFAULT_ZONE);
         assertTrue(zone.isPresent());
         assertThat(zone.get().getId(), notNullValue());
         assertThat(zone.get().getTenantId(), equalTo(ResolvedZone.PUBLIC));
@@ -91,34 +117,68 @@ public class ZoneManagementTest {
     }
 
     @Test
-    public void testCreateZone() {
-        ZoneCreate create = podamFactory.manufacturePojo(ZoneCreate.class);
-        create.setName(RandomStringUtils.randomAlphanumeric(10));
+    public void testCreatePrivateZone() {
+        ZoneCreatePrivate create = new ZoneCreatePrivate()
+            .setName(RandomStringUtils.randomAlphanumeric(6))
+            .setProvider(RandomStringUtils.randomAlphanumeric(6))
+            .setProviderRegion(RandomStringUtils.randomAlphanumeric(6))
+            .setPollerTimeout(100L)
+            .setSourceIpAddresses(podamFactory.manufacturePojo(ArrayList.class, String.class));
         String tenant = RandomStringUtils.randomAlphabetic(10);
-        Zone zone = zoneManagement.createZone(tenant, create);
+        Zone zone = zoneManagement.createPrivateZone(tenant, create);
         assertThat(zone.getId(), notNullValue());
         assertThat(zone.getTenantId(), equalTo(tenant));
         assertThat(zone.getName(), equalTo(create.getName()));
-        assertThat(zone.getEnvoyTimeout(), equalTo(Duration.ofSeconds(create.getPollerTimeout())));
+        assertThat(zone.getPollerTimeout(), equalTo(Duration.ofSeconds(create.getPollerTimeout())));
+        assertThat(zone.getState(), equalTo(ZoneState.ACTIVE));
+        assertFalse(zone.isPublic());
 
-        Optional<Zone> z = zoneManagement.getZone(tenant, create.getName());
+        Optional<Zone> z = zoneManagement.getPrivateZone(tenant, create.getName());
         assertTrue(z.isPresent());
         assertThat(z.get().getName(), equalTo(create.getName()));
     }
 
     @Test
-    public void testCreateZoneNonAlphanumericName() {
+    public void testCreatePrivateZoneNonAlphanumericName() {
         // This should be successful because the alphanumeric validation only happens via Spring MVC.
-        ZoneCreate create = podamFactory.manufacturePojo(ZoneCreate.class);
+        ZoneCreatePrivate create = podamFactory.manufacturePojo(ZoneCreatePrivate.class);
         create.setName("onlyAlphaNumericAreAllowed!!!");
         String tenant = RandomStringUtils.randomAlphabetic(10);
-        Zone zone = zoneManagement.createZone(tenant, create);
+        Zone zone = zoneManagement.createPrivateZone(tenant, create);
         assertThat(zone.getId(), notNullValue());
         assertThat(zone.getTenantId(), equalTo(tenant));
         assertThat(zone.getName(), equalTo(create.getName()));
-        assertThat(zone.getEnvoyTimeout(), equalTo(Duration.ofSeconds(create.getPollerTimeout())));
+        assertThat(zone.getPollerTimeout(), equalTo(Duration.ofSeconds(create.getPollerTimeout())));
+        assertFalse(zone.isPublic());
 
-        Optional<Zone> z = zoneManagement.getZone(tenant, create.getName());
+        Optional<Zone> z = zoneManagement.getPrivateZone(tenant, create.getName());
+        assertTrue(z.isPresent());
+        assertThat(z.get().getName(), equalTo(create.getName()));
+    }
+
+    @Test
+    public void testCreatePublicZone() {
+        ZoneCreatePublic create = new ZoneCreatePublic()
+            .setName(ResolvedZone.PUBLIC_PREFIX + RandomStringUtils.randomAlphanumeric(6))
+            .setProvider(RandomStringUtils.randomAlphanumeric(6))
+            .setProviderRegion(RandomStringUtils.randomAlphanumeric(6))
+            .setPollerTimeout(100L)
+            .setSourceIpAddresses(podamFactory.manufacturePojo(ArrayList.class, String.class));
+
+        Zone zone = zoneManagement.createPublicZone(create);
+        assertThat(zone.getId(), notNullValue());
+        assertThat(zone.getTenantId(), equalTo(ResolvedZone.PUBLIC));
+        assertThat(zone.getName(), equalTo(create.getName()));
+        assertThat(zone.getProvider(), equalTo(create.getProvider()));
+        assertThat(zone.getProviderRegion(), equalTo(create.getProviderRegion()));
+        assertThat(zone.getState(), equalTo(ZoneState.INACTIVE));
+        assertThat(zone.getSourceIpAddresses(), hasSize(create.getSourceIpAddresses().size()));
+        //assertThat(zone.getSourceIpAddresses(), equalTo(create.getSourceIpAddresses()));// not sure why this isn't working. Looks fine when inspecting.
+        assertThat(zone.getState(), equalTo(create.getState()));
+        assertThat(zone.getPollerTimeout(), equalTo(Duration.ofSeconds(create.getPollerTimeout())));
+        assertTrue(zone.isPublic());
+
+        Optional<Zone> z = zoneManagement.getPublicZone(create.getName());
         assertTrue(z.isPresent());
         assertThat(z.get().getName(), equalTo(create.getName()));
     }
@@ -129,17 +189,17 @@ public class ZoneManagementTest {
 
         assertThat(original, notNullValue());
 
-        ZoneUpdate update = new ZoneUpdate().setPollerTimeout(original.getEnvoyTimeout().getSeconds() + 100);
+        ZoneUpdate update = new ZoneUpdate().setPollerTimeout(original.getPollerTimeout().getSeconds() + 100);
 
         Zone zone = zoneManagement.updateZone(ResolvedZone.PUBLIC, original.getName(), update);
         assertThat(zone.getId(), equalTo(original.getId()));
         assertThat(zone.getTenantId(), equalTo(original.getTenantId()));
         assertThat(zone.getName(), equalTo(original.getName()));
-        assertThat(zone.getEnvoyTimeout(), equalTo(Duration.ofSeconds(update.getPollerTimeout())));
+        assertThat(zone.getPollerTimeout(), equalTo(Duration.ofSeconds(update.getPollerTimeout())));
 
-        Optional<Zone> z = zoneManagement.getZone(ResolvedZone.PUBLIC, zone.getName());
+        Optional<Zone> z = zoneManagement.getPublicZone(zone.getName());
         assertTrue(z.isPresent());
-        assertThat(z.get().getEnvoyTimeout().getSeconds(), equalTo(update.getPollerTimeout()));
+        assertThat(z.get().getPollerTimeout().getSeconds(), equalTo(update.getPollerTimeout()));
     }
 
     @Test
@@ -154,11 +214,11 @@ public class ZoneManagementTest {
         assertThat(zoneManagement.getAvailableZonesForTenant(tenant), hasSize(1));
 
         // any new private zone for the tenant should be visible
-        createZonesForTenant(privateCount, tenant);
+        createPrivateZonesForTenant(privateCount, tenant);
         assertThat(zoneManagement.getAvailableZonesForTenant(tenant), hasSize(1 + privateCount));
 
         // new public zones should be visible too
-        createZonesForTenant(publicCount, ResolvedZone.PUBLIC);
+        createPrivateZonesForTenant(publicCount, ResolvedZone.PUBLIC);
         assertThat(zoneManagement.getAvailableZonesForTenant(tenant), hasSize(1 + privateCount + publicCount));
 
         // Another tenant can only see public zones
@@ -167,7 +227,7 @@ public class ZoneManagementTest {
 
     @Test
     public void testGetMonitorsForZone() {
-        int count = 0;
+        int count = 12;
         String tenant = RandomStringUtils.randomAlphabetic(10);
         String zone = RandomStringUtils.randomAlphabetic(10);
         assertThat(zoneManagement.getMonitorsForZone(tenant, zone), hasSize(0));
@@ -176,5 +236,86 @@ public class ZoneManagementTest {
         createRemoteMonitorsForTenant(count, tenant, "notMyZone");
 
         assertThat(zoneManagement.getMonitorsForZone(tenant, zone), hasSize(count));
+    }
+
+    @Test
+    public void testDeleteEmptyPrivateZone() {
+        String tenantId = RandomStringUtils.randomAlphanumeric(10);
+        Zone newZone = createPrivateZoneForTenant(tenantId);
+
+        when(zoneStorage.getActiveEnvoyCountForZone(any()))
+            .thenReturn(CompletableFuture.completedFuture(0L));
+
+        Optional<Zone> zone = zoneManagement.getPrivateZone(tenantId, newZone.getName());
+        assertTrue(zone.isPresent());
+        assertThat(zone.get(), notNullValue());
+
+        zoneManagement.removePrivateZone(tenantId, newZone.getName());
+        zone = zoneManagement.getPrivateZone(tenantId, newZone.getName());
+        assertTrue(!zone.isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteNonEmptyPrivateZone() {
+        String tenantId = RandomStringUtils.randomAlphanumeric(10);
+        Zone newZone = createPrivateZoneForTenant(tenantId);
+        when(zoneStorage.getActiveEnvoyCountForZone(any()))
+            .thenReturn(CompletableFuture.completedFuture(1L));
+
+        Optional<Zone> zone = zoneManagement.getPrivateZone(tenantId, newZone.getName());
+        assertTrue(zone.isPresent());
+        assertThat(zone.get(), notNullValue());
+
+        zoneManagement.removePrivateZone(tenantId, newZone.getName());
+    }
+
+    @Test
+    public void testDeleteEmptyPublicZone() {
+        String tenantId = RandomStringUtils.randomAlphanumeric(10);
+        Zone newZone = createPublicZone();
+
+        when(zoneStorage.getActiveEnvoyCountForZone(any()))
+            .thenReturn(CompletableFuture.completedFuture(0L));
+
+        Optional<Zone> zone = zoneManagement.getPublicZone(newZone.getName());
+        assertTrue(zone.isPresent());
+        assertThat(zone.get(), notNullValue());
+
+        zoneManagement.removePublicZone(newZone.getName());
+        zone = zoneManagement.getPublicZone(newZone.getName());
+        assertTrue(!zone.isPresent());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteNonEmptyPublicZone() {
+        String tenantId = RandomStringUtils.randomAlphanumeric(10);
+        Zone newZone = createPublicZone();
+        when(zoneStorage.getActiveEnvoyCountForZone(any()))
+            .thenReturn(CompletableFuture.completedFuture(1L));
+
+        Optional<Zone> zone = zoneManagement.getPublicZone(newZone.getName());
+        assertTrue(zone.isPresent());
+        assertThat(zone.get(), notNullValue());
+
+        zoneManagement.removePublicZone(newZone.getName());
+    }
+
+    @Test
+    public void testGetMonitorCountForZone() {
+        int privateCount = 13;
+        int publicCount = 17;
+        String tenant = RandomStringUtils.randomAlphabetic(10);
+        String privateZone = RandomStringUtils.randomAlphabetic(10);
+        String publicZone = ResolvedZone.PUBLIC_PREFIX + RandomStringUtils.randomAlphabetic(6);
+
+        assertThat(zoneManagement.getMonitorCountForPrivateZone(tenant, privateZone), equalTo(0));
+        assertThat(zoneManagement.getMonitorCountForPublicZone(publicZone), equalTo(0));
+
+        createRemoteMonitorsForTenant(privateCount, tenant, privateZone);
+        createRemoteMonitorsForTenant(privateCount, tenant, "anotherPrivateZone");
+        createRemoteMonitorsForTenant(publicCount, tenant, publicZone);
+
+        assertThat(zoneManagement.getMonitorCountForPrivateZone(tenant, privateZone), equalTo(privateCount));
+        assertThat(zoneManagement.getMonitorCountForPublicZone(publicZone), equalTo(publicCount));
     }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.any;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.monitor_management.entities.Monitor;
 import com.rackspace.salus.monitor_management.entities.Zone;
 import com.rackspace.salus.monitor_management.repositories.MonitorRepository;
 import com.rackspace.salus.monitor_management.repositories.ZoneRepository;
@@ -18,7 +19,6 @@ import com.rackspace.salus.monitor_management.web.model.ZoneUpdate;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
-import com.rackspace.salus.telemetry.model.Monitor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
@@ -200,14 +200,14 @@ public class ZoneManagementTest {
     }
 
     @Test
-    public void testUpdateZone() {
+    public void testUpdatePublicZone() {
         Zone original = zoneManagement.getAvailableZonesForTenant(ResolvedZone.PUBLIC).get(0);
 
         assertThat(original, notNullValue());
 
         ZoneUpdate update = new ZoneUpdate().setPollerTimeout(original.getPollerTimeout().getSeconds() + 100);
 
-        Zone zone = zoneManagement.updateZone(ResolvedZone.PUBLIC, original.getName(), update);
+        Zone zone = zoneManagement.updatePublicZone(original.getName(), update);
         assertThat(zone.getId(), equalTo(original.getId()));
         assertThat(zone.getTenantId(), equalTo(original.getTenantId()));
         assertThat(zone.getName(), equalTo(original.getName()));

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -1,7 +1,6 @@
 package com.rackspace.salus.monitor_management.web.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rackspace.salus.monitor_management.web.controller.ZoneApiController;
 import com.rackspace.salus.monitor_management.entities.Zone;
 import com.rackspace.salus.monitor_management.services.ZoneManagement;
 import com.rackspace.salus.monitor_management.web.model.ZoneCreate;
@@ -80,6 +79,26 @@ public class ZoneApiControllerTest {
 
         mvc.perform(post(
                     "/api/tenant/{tenantId}/zones", "t-1")
+                .content(objectMapper.writeValueAsString(create))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8.name()))
+                .andExpect(status().isCreated())
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().json(objectMapper.writeValueAsString(zone.toDTO())));
+    }
+
+    @Test
+    public void testCreateZoneWithUnderscores() throws Exception {
+        Zone zone = podamFactory.manufacturePojo(Zone.class);
+        when(zoneManagement.createZone(any(), any()))
+                .thenReturn(zone);
+
+        ZoneCreate create = newZoneCreate();
+        create.setName("underscores_are_allowed");
+
+        mvc.perform(post(
+                "/api/tenant/{tenantId}/zones", "t-1")
                 .content(objectMapper.writeValueAsString(create))
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding(StandardCharsets.UTF_8.name()))

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -56,7 +56,7 @@ public class ZoneApiControllerTest {
         Random random = new Random();
         return new ZoneCreatePrivate()
                 .setName(RandomStringUtils.randomAlphanumeric(10))
-                .setPollerTimeout(random.nextInt(1000) + 30);
+                .setPollerTimeout(random.nextInt(1000) + 30L);
     }
 
     private ZoneCreatePublic newZoneCreatePublic() {
@@ -65,7 +65,7 @@ public class ZoneApiControllerTest {
             .setName(ResolvedZone.PUBLIC_PREFIX + RandomStringUtils.randomAlphanumeric(6))
             .setProvider(RandomStringUtils.randomAlphanumeric(6))
             .setProviderRegion(RandomStringUtils.randomAlphanumeric(6))
-            .setPollerTimeout(random.nextInt(1000) + 30)
+            .setPollerTimeout(random.nextInt(1000) + 30L)
             .setSourceIpAddresses(podamFactory.manufacturePojo(ArrayList.class, String.class));
     }
 

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -73,14 +73,29 @@ public class ZoneApiControllerTest {
                 .thenReturn(Optional.of(expectedZone));
 
         mvc.perform(get(
-                "/api/tenant/{tenantId}/zones/{name}",
-                "t-1", "z-1")
+                "/api/tenant/{tenantId}/zones/{name}", "t-1", "z-1")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(objectMapper.writeValueAsString(expectedZone.toDTO())));
+    }
+
+    @Test
+    public void testGetPublicZone() throws Exception {
+        final Zone expectedZone = podamFactory.manufacturePojo(Zone.class);
+        when(zoneManagement.getPublicZone(any()))
+            .thenReturn(Optional.of(expectedZone));
+
+        mvc.perform(get(
+            "/api/admin/zones/{name}", "z-1")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(content()
+                .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(content().json(objectMapper.writeValueAsString(expectedZone.toDTO())));
     }
 
     @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidCidrListValidatorTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidCidrListValidatorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.validator;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+import com.rackspace.salus.monitor_management.web.model.ZoneCreatePrivate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+public class ValidCidrListValidatorTest {
+
+  private LocalValidatorFactoryBean validatorFactoryBean;
+
+  @Before
+  public void setup() {
+    validatorFactoryBean = new LocalValidatorFactoryBean();
+    validatorFactoryBean.afterPropertiesSet();
+  }
+
+  @Test
+  public void testEmptyList() {
+    List<String> addresses = Collections.emptyList();
+    validScenario(addresses);
+  }
+
+  @Test
+  public void testValidIpv4List() {
+    List<String> addresses = new ArrayList<>();
+    addresses.add("50.57.61.0/26");
+    addresses.add("159.135.132.32/27");
+    addresses.add("78.136.44.0/26");
+
+    validScenario(addresses);
+  }
+
+  @Test
+  public void testNonCidrIpv4Address() {
+    List<String> addresses = new ArrayList<>();
+    addresses.add("127.0.0.1");
+
+    failingScenario(addresses);
+  }
+
+  @Test
+  public void testValidIpv6List() {
+    List<String> addresses = new ArrayList<>();
+    addresses.add("2001:4801:7902:0001::/64");
+    addresses.add("2a00:1a48:7902:0001::/64");
+    addresses.add("2001:4802:7902:0001::/64");
+
+    validScenario(addresses);
+  }
+
+  @Test
+  public void testNonCidrIpv6Address() {
+    List<String> addresses = new ArrayList<>();
+    addresses.add("::1");
+
+    failingScenario(addresses);
+  }
+
+  private void validScenario(List<String> addresses) {
+    final ZoneCreatePrivate zone = new ZoneCreatePrivate()
+        .setName("test")
+        .setSourceIpAddresses(addresses);
+
+    final Set<ConstraintViolation<ZoneCreatePrivate>> errors = validatorFactoryBean.validate(zone);
+
+    assertThat(errors, hasSize(0));
+  }
+
+  private void failingScenario(List<String> addresses) {
+    final ZoneCreatePrivate zone = new ZoneCreatePrivate()
+        .setName("test")
+        .setSourceIpAddresses(addresses);
+
+    final Set<ConstraintViolation<ZoneCreatePrivate>> errors = validatorFactoryBean.validate(zone);
+
+    assertThat(errors, hasSize(1));
+    final ConstraintViolation<ZoneCreatePrivate> violation = errors.iterator().next();
+    assertThat(violation.getPropertyPath().toString(), equalTo("sourceIpAddresses"));
+    assertThat(violation.getMessage(), equalTo("All values must be valid CIDR notation"));
+  }
+}


### PR DESCRIPTION
# What

Mostly tweaks and tests involving public monitoring zones.
Has some other indentation changes... my IntelliJ went weird after undoing it's auto-indentation and wouldn't let me apply it again, so after this is merged I'll try do a sweep of files to get all the indentation correct.

# How

 * Changed `envoyTimeout` in the Zone to be `pollerTimeout` to make it consistent with customer facing fields.
 * Allow underscores in zone names so that customer can use that to namespace things if they wish.
 * Added some `count` repository methods to limit the amount of data passed between services where possible
 * Separate methods/objects for dealing with public/private zones when it comes to both creation and deletion.
 * Admin api endpoints start with `/admin`, `public` ones start with `/tenant`
 * Public zones default to `INACTIVE`
 * Private zones default to `ACTIVE`
 * Public zones cannot have null provider etc. fields
 * Various tests

## How to test

Run all tests

# Why

Allows us to interact with public zones correctly via the service api.  Things are handled differently for public zones vs. private zones.

# TODO

1. An indentation PR sweep
1. The admin api should be able to see the `state` of a zone, but the public api should not.  We need to figure out how we should "filter" certain fields based on what API requests the info.  I looked into `JsonFilter`, `JsonViews`, and some other things along those lines but none of them worked out well.  I really want to avoid creating a different DTO for each api response.
1. Public API PR will be created shortly.
1. Admin API is still using GraphQL so I ignored it for now.
1. The difference between the two methods below still baffles me.  They both log the same SQL but the first returns 0 results.  I realized my previous test was incorrect which allowed the first one to pass.  It now fails the test if used.  It happens with other `Contains` methods too.
```
List<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone);

@Query("select m from Monitor m where m.tenantId = :tenantId and :zone member of m.zones")
List<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone);
```
