### PR TITLE
Handle public zones in GET zone endpoint

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -72,6 +72,7 @@ public class ZoneApiController implements ZoneApi {
 
     @GetMapping("/tenant/{tenantId}/zones/**")
     @ApiOperation(value = "Gets specific zone by tenant id and zone name")
+    @JsonView(View.Public.class)
     public ZoneDTO getAvailableZone(@PathVariable String tenantId, HttpServletRequest request) {
       String name = extractZoneNameFromUri(request);
       if (name.startsWith(ResolvedZone.PUBLIC_PREFIX)) {
@@ -129,6 +130,7 @@ public class ZoneApiController implements ZoneApi {
     @PostMapping("/admin/zones")
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "Creates a new public zone")
+    @JsonView(View.Admin.class)
     public ZoneDTO create(@Valid @RequestBody ZoneCreatePublic zone)
         throws ZoneAlreadyExists {
         return zoneManagement.createPublicZone(zone).toDTO();

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -76,7 +76,8 @@ public class ZoneApiController implements ZoneApi {
     public ZoneDTO getAvailableZone(@PathVariable String tenantId, HttpServletRequest request) {
       String name = extractZoneNameFromUri(request);
       if (name.startsWith(ResolvedZone.PUBLIC_PREFIX)) {
-        return getPublicZone(request); // probably have to change this when json views are merged.
+        // The JsonView on getPublicZone is ignored
+        return getPublicZone(request);
       }
       return getByZoneName(tenantId, name);
     }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -64,125 +64,123 @@ import org.springframework.web.servlet.HandlerMapping;
         })
 })
 public class ZoneApiController implements ZoneApi {
-    private ZoneManagement zoneManagement;
+  private ZoneManagement zoneManagement;
 
-    public ZoneApiController(ZoneManagement zoneManagement) {
-        this.zoneManagement = zoneManagement;
-    }
+  public ZoneApiController(ZoneManagement zoneManagement) {
+    this.zoneManagement = zoneManagement;
+  }
 
-    @GetMapping("/tenant/{tenantId}/zones/**")
-    @ApiOperation(value = "Gets specific zone by tenant id and zone name")
-    @JsonView(View.Public.class)
-    public ZoneDTO getAvailableZone(@PathVariable String tenantId, HttpServletRequest request) {
-      String name = extractZoneNameFromUri(request);
-      if (name.startsWith(ResolvedZone.PUBLIC_PREFIX)) {
-        // The JsonView on getPublicZone is ignored
-        return getPublicZone(request);
-      }
-      return getByZoneName(tenantId, name);
-    }
+  @GetMapping("/tenant/{tenantId}/zones/**")
+  @ApiOperation(value = "Gets specific zone by tenant id and zone name")
+  @JsonView(View.Public.class)
+  public ZoneDTO getAvailableZone(@PathVariable String tenantId, HttpServletRequest request) {
+    String name = extractZoneNameFromUri(request);
+    return getByZoneName(tenantId, name);
+  }
 
-    @Override
-    public ZoneDTO getByZoneName(@PathVariable String tenantId, @PathVariable String name) {
-        Optional<Zone> zone = zoneManagement.getPrivateZone(tenantId, name);
-        return zone.orElseThrow(() -> new NotFoundException(String.format("No zone found named %s on tenant %s",
-                name, tenantId)))
-                .toDTO();
+  @Override
+  public ZoneDTO getByZoneName(String tenantId, String name) {
+    Optional<Zone> zone;
+    if (name.startsWith(ResolvedZone.PUBLIC_PREFIX)) {
+      zone = zoneManagement.getPublicZone(name);
+    } else {
+      zone = zoneManagement.getPrivateZone(tenantId, name);
     }
+    return zone
+        .orElseThrow(() -> new NotFoundException(String.format("No zone found named %s", name)))
+        .toDTO();
+  }
 
-    @GetMapping("/admin/zones/**")
-    @ApiOperation(value = "Gets specific public zone by name")
-    @JsonView(View.Admin.class)
-    public ZoneDTO getPublicZone(HttpServletRequest request) {
-      String name = extractZoneNameFromUri(request);
-      Optional<Zone> zone = zoneManagement.getPublicZone(name);
-      return zone.orElseThrow(() -> new NotFoundException(String.format("No public zone found named %s",
-          name)))
-          .toDTO();
-    }
+  @GetMapping("/admin/zones/**")
+  @ApiOperation(value = "Gets specific public zone by name")
+  @JsonView(View.Admin.class)
+  public ZoneDTO getPublicZone(HttpServletRequest request) {
+    String name = extractZoneNameFromUri(request);
+    return getByZoneName(null, name);
+  }
 
-    /**
-     * Discovers the zone name within the uri.
-     * Handles both public zones containing slashes as well as more simple private zone.
-     * Using @PathVariable does not work for public zones.
-     * @param request The incoming http request.
-     * @return The zone name provided within the uri.
-     */
-    private String extractZoneNameFromUri(HttpServletRequest request){
-        // For example, /api/admin//zones/public/region_1
-        String path = (String) request
-            .getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
-        // For example, /api/admin/zones/**
-        String bestMatchPattern = (String) request
-            .getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
-        // For example, public/region_1
-        return new AntPathMatcher().extractPathWithinPattern(bestMatchPattern, path);
-    }
+  /**
+   * Discovers the zone name within the uri.
+   * Handles both public zones containing slashes as well as more simple private zone.
+   * Using @PathVariable does not work for public zones.
+   * @param request The incoming http request.
+   * @return The zone name provided within the uri.
+   */
+  private String extractZoneNameFromUri(HttpServletRequest request){
+    // For example, /api/admin//zones/public/region_1
+    String path = (String) request
+        .getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+    // For example, /api/admin/zones/**
+    String bestMatchPattern = (String) request
+        .getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+    // For example, public/region_1
+    return new AntPathMatcher().extractPathWithinPattern(bestMatchPattern, path);
+  }
 
-    @PostMapping("/tenant/{tenantId}/zones")
-    @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation(value = "Creates a new private zone for the tenant")
-    @JsonView(View.Public.class)
-    public ZoneDTO create(@PathVariable String tenantId, @Valid @RequestBody ZoneCreatePrivate zone)
-            throws ZoneAlreadyExists {
-        return zoneManagement.createPrivateZone(tenantId, zone).toDTO();
-    }
+  @PostMapping("/tenant/{tenantId}/zones")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiOperation(value = "Creates a new private zone for the tenant")
+  @JsonView(View.Public.class)
+  public ZoneDTO create(@PathVariable String tenantId, @Valid @RequestBody ZoneCreatePrivate zone)
+          throws ZoneAlreadyExists {
+    return zoneManagement.createPrivateZone(tenantId, zone).toDTO();
+  }
 
-    @PostMapping("/admin/zones")
-    @ResponseStatus(HttpStatus.CREATED)
-    @ApiOperation(value = "Creates a new public zone")
-    @JsonView(View.Admin.class)
-    public ZoneDTO create(@Valid @RequestBody ZoneCreatePublic zone)
-        throws ZoneAlreadyExists {
-        return zoneManagement.createPublicZone(zone).toDTO();
-    }
+  @PostMapping("/admin/zones")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiOperation(value = "Creates a new public zone")
+  @JsonView(View.Admin.class)
+  public ZoneDTO create(@Valid @RequestBody ZoneCreatePublic zone)
+      throws ZoneAlreadyExists {
+    return zoneManagement.createPublicZone(zone).toDTO();
+  }
 
-    @PutMapping("/tenant/{tenantId}/zones/{name}")
-    @ApiOperation(value = "Updates a specific private zone for the tenant")
-    @JsonView(View.Public.class)
-    public ZoneDTO update(@PathVariable String tenantId, @PathVariable String name, @Valid @RequestBody ZoneUpdate zone) {
-        return zoneManagement.updatePrivateZone(tenantId, name, zone).toDTO();
-    }
+  @PutMapping("/tenant/{tenantId}/zones/{name}")
+  @ApiOperation(value = "Updates a specific private zone for the tenant")
+  @JsonView(View.Public.class)
+  public ZoneDTO update(@PathVariable String tenantId, @PathVariable String name, @Valid @RequestBody ZoneUpdate zone) {
+    return zoneManagement.updatePrivateZone(tenantId, name, zone).toDTO();
+  }
 
-    @PutMapping("/admin/zones/{name}")
-    @ApiOperation(value = "Updates a specific public zone")
-    @JsonView(View.Admin.class)
-    public ZoneDTO update(@PathVariable String name, @Valid @RequestBody ZoneUpdate zone) {
-        return zoneManagement.updatePublicZone(name, zone).toDTO();
-    }
+  @PutMapping("/admin/zones/{name}")
+  @ApiOperation(value = "Updates a specific public zone")
+  @JsonView(View.Admin.class)
+  public ZoneDTO update(@PathVariable String name, @Valid @RequestBody ZoneUpdate zone) {
+    return zoneManagement.updatePublicZone(name, zone).toDTO();
+  }
 
-    @DeleteMapping("/tenant/{tenantId}/zones/{name}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @ApiOperation(value = "Deletes a specific private zone for the tenant")
-    @JsonView(View.Public.class)
-    public void delete(@PathVariable String tenantId, @PathVariable String name) {
-        zoneManagement.removePrivateZone(tenantId, name);
-    }
+  @DeleteMapping("/tenant/{tenantId}/zones/{name}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @ApiOperation(value = "Deletes a specific private zone for the tenant")
+  @JsonView(View.Public.class)
+  public void delete(@PathVariable String tenantId, @PathVariable String name) {
+    zoneManagement.removePrivateZone(tenantId, name);
+  }
 
-    @DeleteMapping("/admin/zones/{name}")
-    @ApiOperation(value = "Deletes a specific public zone")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @JsonView(View.Admin.class)
-    public void delete(@PathVariable String name) {
-        zoneManagement.removePublicZone(name);
-    }
+  @DeleteMapping("/admin/zones/{name}")
+  @ApiOperation(value = "Deletes a specific public zone")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @JsonView(View.Admin.class)
+  public void delete(@PathVariable String name) {
+    zoneManagement.removePublicZone(name);
+  }
 
-    @GetMapping("/tenant/{tenantId}/zones")
-    @ApiOperation(value = "Gets all zones available to be used in the tenant's monitor configurations")
-    @JsonView(View.Public.class)
-    public List<ZoneDTO> getAvailableZones(@PathVariable String tenantId) {
-        return zoneManagement.getAvailableZonesForTenant(tenantId)
-                .stream()
-                .map(Zone::toDTO)
-                .collect(Collectors.toList());
-    }
+  @GetMapping("/tenant/{tenantId}/zones")
+  @ApiOperation(value = "Gets all zones available to be used in the tenant's monitor configurations")
+  @JsonView(View.Public.class)
+  public List<ZoneDTO> getAvailableZones(@PathVariable String tenantId) {
+    return zoneManagement.getAvailableZonesForTenant(tenantId)
+        .stream()
+        .map(Zone::toDTO)
+        .collect(Collectors.toList());
+  }
 
-    @GetMapping("/tenant/{tenantId}/monitorsByZone/{zone}")
-    @ApiOperation(value = "Gets all monitors in a given zone for a specific tenant")
-    @JsonView(View.Public.class)
-    public List<MonitorDTO> getMonitorsForZone(@PathVariable String tenantId, @PathVariable String zone) {
-        return zoneManagement.getMonitorsForZone(tenantId, zone).stream()
-            .map(Monitor::toDTO)
-            .collect(Collectors.toList());
-    }
+  @GetMapping("/tenant/{tenantId}/monitorsByZone/{zone}")
+  @ApiOperation(value = "Gets all monitors in a given zone for a specific tenant")
+  @JsonView(View.Public.class)
+  public List<MonitorDTO> getMonitorsForZone(@PathVariable String tenantId, @PathVariable String zone) {
+    return zoneManagement.getMonitorsForZone(tenantId, zone).stream()
+        .map(Monitor::toDTO)
+        .collect(Collectors.toList());
+  }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -147,6 +147,30 @@ public class ZoneApiControllerTest {
     }
 
     @Test
+    public void testGetInvalidPublicZone() throws Exception {
+        final String errorMsg = "No zone found named testPublicZone";
+
+        mvc.perform(get(
+            "/api/admin/zones/{name}", "testPublicZone")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message", is(errorMsg)));
+    }
+
+    @Test
+    public void testGetInvalidPrivateZone() throws Exception {
+        final String errorMsg = "No zone found named public/testPrivateZone";
+
+        mvc.perform(get(
+            "/api/admin/zones/{name}", "public/testPrivateZone")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message", is(errorMsg)));
+    }
+
+    @Test
     public void testGetPublicZone() throws Exception {
         final Zone expectedZone = new Zone()
             .setId(UUID.randomUUID())
@@ -162,7 +186,7 @@ public class ZoneApiControllerTest {
             .thenReturn(Optional.of(expectedZone));
 
         mvc.perform(get(
-            "/api/admin/zones/{name}", "z-1")
+            "/api/admin/zones/{name}", "public/testPublicZone")
             .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isOk())

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -70,7 +70,7 @@ public class ZoneApiControllerTest {
     }
 
     @Test
-    public void testGetByZoneName() throws Exception {
+    public void testGetAvailablePrivateZoneForTenant() throws Exception {
         final Zone expectedZone = podamFactory.manufacturePojo(Zone.class);
         when(zoneManagement.getPrivateZone(any(), any()))
                 .thenReturn(Optional.of(expectedZone));
@@ -83,6 +83,22 @@ public class ZoneApiControllerTest {
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(objectMapper.writeValueAsString(expectedZone.toDTO())));
+    }
+
+    @Test
+    public void testGetAvailablePublicZoneForTenant() throws Exception {
+        final Zone expectedZone = podamFactory.manufacturePojo(Zone.class);
+        when(zoneManagement.getPublicZone(any()))
+            .thenReturn(Optional.of(expectedZone));
+
+        mvc.perform(get(
+            "/api/admin/zones/{name}", "public/z-1")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(content()
+                .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(content().json(objectMapper.writeValueAsString(expectedZone.toDTO())));
     }
 
     @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -100,11 +100,38 @@ public class ZoneApiControllerTest {
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(
-                    readContent("ZoneApiControllerTest/privateZone_basic.json")));
+                    readContent("ZoneApiControllerTest/privateZone_basic.json"), true));
     }
 
     @Test
     public void testGetAvailablePublicZoneForTenant() throws Exception {
+        final Zone expectedZone = new Zone()
+            .setId(UUID.randomUUID())
+            .setName("public/zone-1")
+            .setPollerTimeout(Duration.ofSeconds(60))
+            .setProvider("p-1")
+            .setProviderRegion("p-r-1")
+            .setPublic(true)
+            .setState(ZoneState.ACTIVE)
+            .setSourceIpAddresses(Collections.singletonList("127.0.0.1/27"));
+
+        when(zoneManagement.getPublicZone(any()))
+            .thenReturn(Optional.of(expectedZone));
+
+        mvc.perform(get(
+            "/api/tenant/{tenantId}/zones/{name}", "t-1", "public/zone-1")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(content()
+                .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(content().json(
+                // the STATE field should not be included
+                readContent("ZoneApiControllerTest/publicZone_as_customer.json"), true));
+    }
+
+    @Test
+    public void testGetAvailablePublicZoneAsAdmin() throws Exception {
         final Zone expectedZone = podamFactory.manufacturePojo(Zone.class);
         when(zoneManagement.getPublicZone(any()))
             .thenReturn(Optional.of(expectedZone));
@@ -116,7 +143,7 @@ public class ZoneApiControllerTest {
             .andExpect(status().isOk())
             .andExpect(content()
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-            .andExpect(content().json(objectMapper.writeValueAsString(expectedZone.toDTO())));
+            .andExpect(content().json(objectMapper.writeValueAsString(expectedZone.toDTO()), true));
     }
 
     @Test
@@ -142,7 +169,7 @@ public class ZoneApiControllerTest {
             .andExpect(content()
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                readContent("ZoneApiControllerTest/publicZone_basic.json")));
+                readContent("ZoneApiControllerTest/publicZone_basic.json"), true));
     }
 
     @Test
@@ -171,7 +198,7 @@ public class ZoneApiControllerTest {
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                readContent("ZoneApiControllerTest/privateZone_basic.json")));
+                readContent("ZoneApiControllerTest/privateZone_basic.json"), true));
     }
 
     @Test
@@ -217,7 +244,7 @@ public class ZoneApiControllerTest {
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(
-                    readContent("ZoneApiControllerTest/privateZone_underscores.json")));
+                    readContent("ZoneApiControllerTest/privateZone_underscores.json"), true));
     }
 
     @Test
@@ -265,7 +292,7 @@ public class ZoneApiControllerTest {
             .andExpect(content()
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                readContent("ZoneApiControllerTest/publicZone_basic.json")));
+                readContent("ZoneApiControllerTest/publicZone_basic.json"), true));
     }
 
     @Test

--- a/src/test/resources/ZoneApiControllerTest/publicZone_as_customer.json
+++ b/src/test/resources/ZoneApiControllerTest/publicZone_as_customer.json
@@ -1,0 +1,8 @@
+{
+  "name":"public/zone-1",
+  "pollerTimeout":60,
+  "provider":"p-1",
+  "providerRegion":"p-r-1",
+  "sourceIpAddresses":["127.0.0.1/27"],
+  "public":true
+}


### PR DESCRIPTION
# What

Adds the ability to handle requests for public zones by a customer, such as:
```
GET http://localhost:8089/api/tenant/aaaaaa/zones/public/us-east
```

# How

Rather than using `@PathVariable` to extract the zone, which won't work with values containing `/` we can match on whatever string is after `.../zones/` and use that.

## How to test

Run tests. Try manually.

# Why

I don't think we will be adding any other endpoints after `.../zones/{id}` so we should be good to do that.

it means we can keep that endpoint and don't have to worry about it failing for customers who try to follow the same method they do for private zones.  It also means if we want to use it ourselves we don't have the url encode the zone name.

# TODO

I wont merge this until after the `JsonViews` changes as I think I might have to move things around since `getPublicZone` would likely return the `state` which we do not want to do.  Just wanted to put this out there for now.

We should probably also modify the name of `getByZoneName` but since that's an interface change I didn't want to do it here.