### PR TITLE
Handle ReattachEnvoyResourceEvent and re-bind local monitors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>21.0</version>
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
@@ -61,6 +61,12 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
 
   Page<BoundMonitor> findAllByMonitor_TenantId(String tenantId, Pageable pageable);
 
+  @Query("select b from BoundMonitor b"
+      + " where b.monitor.tenantId = :tenantId"
+      + "  and b.resourceId = :resourceId"
+      + "  and b.monitor.selectorScope = 'LOCAL'")
+  List<BoundMonitor> findAllLocalByTenantResource(String tenantId, String resourceId);
+
   List<BoundMonitor> findAllByMonitor_Id(UUID monitorId);
 
   List<BoundMonitor> findAllByMonitor_IdIn(Collection<UUID> monitorIds);

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -33,7 +33,6 @@ import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
-import com.rackspace.salus.telemetry.messaging.ReattachedEnvoyResourceEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.NotFoundException;
@@ -177,8 +176,8 @@ public class MonitorManagement {
                 .setZones(newMonitor.getZones());
 
         monitorRepository.save(monitor);
-        final List<BoundMonitor> boundMonitors = bindMonitor(monitor);
-        sendMonitorBoundEvents(boundMonitors);
+        final Set<String> affectedEnvoys = bindNewMonitor(monitor);
+        sendMonitorBoundEvents(affectedEnvoys);
         return monitor;
     }
 
@@ -199,12 +198,21 @@ public class MonitorManagement {
         }
     }
 
-    List<BoundMonitor> bindMonitor(Monitor monitor) {
+    /**
+     * Performs label selection of the given monitor to locate resources and zones for bindings.
+     * @return affected envoy IDs
+     */
+    Set<String> bindNewMonitor(Monitor monitor) {
         return bindMonitor(monitor, determineMonitoringZones(monitor));
     }
 
-    List<BoundMonitor> bindMonitor(Monitor monitor,
-                                   List<String> zones) {
+    /**
+     * Performs label selection of the given monitor to locate resources for bindings.
+     * For remote monitors, this will only perform binding within the given zones.
+     * @return affected envoy IDs
+     */
+    Set<String> bindMonitor(Monitor monitor,
+                            List<String> zones) {
         final List<Resource> resources = resourceApi.getResourcesWithLabels(
             monitor.getTenantId(), monitor.getLabelSelector());
 
@@ -247,7 +255,7 @@ public class MonitorManagement {
             log.debug("No monitors were bound from monitor={}", monitor);
         }
 
-        return boundMonitors;
+        return extractEnvoyIds(boundMonitors);
     }
 
     private void sendMonitorBoundEvent(String envoyId) {
@@ -259,22 +267,12 @@ public class MonitorManagement {
     }
 
     /**
-     * This method sends at most one {@link MonitorBoundEvent} for each envoy ID referenced
-     * within the given collection of {@link BoundMonitor}s
-     * @param boundMonitors the {@link BoundMonitor}s to evaluate
+     * Sends monitor bound events to all of the given envoy IDs
+     * @param envoyIds envoy IDs to target
      */
-    void sendMonitorBoundEvents(List<BoundMonitor> boundMonitors) {
-        // Reduce the given bound monitors into one distinct event per envoy ID and send it
-        boundMonitors.stream()
-            // ...extract envoy ID
-            .map(BoundMonitor::getEnvoyId)
-            // ...only assigned ones
-            .filter(Objects::nonNull)
-            // ...remove dupes
-            .distinct()
-            // ...create events
-            .map(envoyId -> new MonitorBoundEvent()
-                .setEnvoyId(envoyId))
+    void sendMonitorBoundEvents(Set<String> envoyIds) {
+        envoyIds.stream()
+            .map(envoyId -> new MonitorBoundEvent().setEnvoyId(envoyId))
             .forEach(monitorEventProducer::sendMonitorEvent);
     }
 
@@ -354,7 +352,7 @@ public class MonitorManagement {
 
             boundMonitorRepository.saveAll(assigned);
 
-            sendMonitorBoundEvents(assigned);
+            sendMonitorBoundEvents(extractEnvoyIds(assigned));
         }
     }
 
@@ -439,14 +437,14 @@ public class MonitorManagement {
 
         validateMonitoringZones(tenantId, updatedValues.getZones());
 
-        final List<BoundMonitor> boundMonitorsChanges = new ArrayList<>();
+        final Set<String> affectedEnvoys = new HashSet<>();
 
         if (updatedValues.getLabelSelector() != null &&
             !updatedValues.getLabelSelector().equals(monitor.getLabelSelector())) {
             // Process potential changes to resource selection and therefore bindings
             // ...only need to process removed and new bindings
 
-            boundMonitorsChanges.addAll(
+            affectedEnvoys.addAll(
                 processMonitorLabelSelectorModified(monitor, updatedValues.getLabelSelector())
             );
 
@@ -465,7 +463,7 @@ public class MonitorManagement {
             // Process potential changes to bound resource rendered content
             // ...only need to process changed bindings
 
-            boundMonitorsChanges.addAll(
+            affectedEnvoys.addAll(
                 processMonitorContentModified(monitor, updatedValues.getContent())
             );
 
@@ -475,7 +473,7 @@ public class MonitorManagement {
         if (zonesChanged(updatedValues.getZones(), monitor.getZones())) {
             // Process potential changes to bound zones
 
-            boundMonitorsChanges.addAll(
+            affectedEnvoys.addAll(
                 processMonitorZonesModified(monitor, updatedValues.getZones())
             );
 
@@ -494,7 +492,7 @@ public class MonitorManagement {
                 .to(monitor::setMonitorName);
         monitorRepository.save(monitor);
 
-        sendMonitorBoundEvents(boundMonitorsChanges);
+        sendMonitorBoundEvents(affectedEnvoys);
 
         return monitor;
     }
@@ -505,8 +503,13 @@ public class MonitorManagement {
             !updatedZones.containsAll(prevZones));
     }
 
-    private List<BoundMonitor> processMonitorZonesModified(Monitor monitor,
-                                                           List<String> updatedZones) {
+    /**
+     * Reconciles the updated zones given against the current state of the given monitor by
+     * binding and unbinding as necessary.
+     * @return affected envoy IDs
+     */
+    private Set<String> processMonitorZonesModified(Monitor monitor,
+                                                    List<String> updatedZones) {
 
         // determine new zones
         final List<String> newZones = new ArrayList<>(updatedZones);
@@ -518,21 +521,24 @@ public class MonitorManagement {
         // ...by removing the ones still in the update
         oldZones.removeAll(updatedZones);
 
-        final List<BoundMonitor> changed = new ArrayList<>(
-            // this will also delete the unbound bindings
-            unbindByMonitorAndZone(monitor.getId(), oldZones)
-        );
+        // this will also delete the unbound bindings
+        final Set<String> affectedEnvoys = unbindByMonitorAndZone(monitor.getId(), oldZones);
 
-        changed.addAll(
+        affectedEnvoys.addAll(
             // this will also save the new bindings
             bindMonitor(monitor, newZones)
         );
 
-        return changed;
+        return affectedEnvoys;
     }
 
-    private List<BoundMonitor> processMonitorContentModified(Monitor monitor,
-                                                             String updatedContent) {
+    /**
+     * Reconciles the updated template content against existing bindings of the given monitor.
+     * Bindings are updated as needed where the rendered content has changed.
+     * @return affected envoy IDs
+     */
+    private Set<String> processMonitorContentModified(Monitor monitor,
+                                                      String updatedContent) {
         final List<BoundMonitor> boundMonitors = boundMonitorRepository
             .findAllByMonitor_Id(monitor.getId());
 
@@ -571,11 +577,16 @@ public class MonitorManagement {
             boundMonitorRepository.saveAll(modified);
         }
 
-        return modified;
+        return extractEnvoyIds(modified);
     }
 
-    private List<BoundMonitor> processMonitorLabelSelectorModified(Monitor monitor,
-                                                                   Map<String, String> updatedLabelSelector) {
+    /**
+     * Reconciles bindings to the resources selected by the given updated label selector. It
+     * creates new bindings and unbinds are necessary.
+     * @return affected envoy IDs
+     */
+    private Set<String> processMonitorLabelSelectorModified(Monitor monitor,
+                                                            Map<String, String> updatedLabelSelector) {
 
       final Set<String> boundResourceIds =
           boundMonitorRepository.findResourceIdsBoundToMonitor(monitor.getId());
@@ -591,26 +602,25 @@ public class MonitorManagement {
         resourceIdsToUnbind.removeAll(selectedResourceIds);
 
         // process un-bindings
-        final List<BoundMonitor> boundMonitorsChanges =
-            new ArrayList<>(
-                unbindByResourceId(monitor.getId(), resourceIdsToUnbind)
-            );
+        final Set<String> affectedEnvoys =
+                unbindByResourceId(monitor.getId(), resourceIdsToUnbind);
 
         // process new bindings
         selectedResources.stream()
             .filter(resource -> !boundResourceIds.contains(resource.getResourceId()))
             .forEach(resource -> {
 
-                boundMonitorsChanges.addAll(
+                affectedEnvoys.addAll(
                     upsertBindingToResource(
                         Collections.singletonList(monitor),
-                        resource
+                        resource,
+                        null
                     )
                 );
 
             });
 
-        return boundMonitorsChanges;
+        return affectedEnvoys;
     }
 
 
@@ -626,9 +636,9 @@ public class MonitorManagement {
               id, tenantId)));
 
         // need to unbind before deleting monitor since BoundMonitor references Monitor
-        final List<BoundMonitor> unbound = unbindByMonitorId(Collections.singletonList(id));
+        final Set<String> affectedEnvoys = unbindByMonitorId(Collections.singletonList(id));
 
-        sendMonitorBoundEvents(unbound);
+        sendMonitorBoundEvents(affectedEnvoys);
 
         monitorRepository.delete(monitor);
     }
@@ -644,6 +654,11 @@ public class MonitorManagement {
         final String tenantId = event.getTenantId();
         final String resourceId = event.getResourceId();
 
+        if (!event.isLabelsChanged() && event.getReattachedEnvoyId() != null) {
+            handleReattachedEnvoy(tenantId, resourceId, event.getReattachedEnvoyId());
+            return;
+        }
+
         final List<UUID> boundMonitorIds =
             boundMonitorRepository.findMonitorsBoundToResource(tenantId, resourceId);
 
@@ -655,6 +670,11 @@ public class MonitorManagement {
         final Resource resource = resourceApi.getByResourceId(tenantId, resourceId);
         if (resource != null) {
             // resource created or updated
+
+            if (event.isDeleted()) {
+                log.warn("Resource change event indicated deletion, but resource is present: {}", resource);
+                // continue with normal processing, assuming it got revived concurrently
+            }
 
             selectedMonitors = getMonitorsFromLabels(resource.getLabels(), tenantId);
 
@@ -672,29 +692,29 @@ public class MonitorManagement {
             // ...and monitorIdsToUnbind remains ALL of the currently bound
         }
 
-        List<BoundMonitor> changes = new ArrayList<>(
-            unbindByMonitorId(monitorIdsToUnbind)
-        );
+        final Set<String> affectedEnvoys = unbindByMonitorId(monitorIdsToUnbind);
 
         if (!selectedMonitors.isEmpty()) {
-            changes.addAll(
-                upsertBindingToResource(selectedMonitors, resource)
+            affectedEnvoys.addAll(
+                upsertBindingToResource(selectedMonitors, resource, event.getReattachedEnvoyId())
             );
         }
 
-        sendMonitorBoundEvents(changes);
+        sendMonitorBoundEvents(affectedEnvoys);
     }
 
     /**
      * Finds all the local monitors bound to the resource and re-bind them to the newly attached
      * Envoy
-     * @param resourceEvent the event indicating the re-attached envoy-resource
+     * @param tenantId
+     * @param resourceId
+     * @param envoyId
      */
-    void handleReattachedEnvoy(ReattachedEnvoyResourceEvent resourceEvent) {
+    private void handleReattachedEnvoy(String tenantId, String resourceId, String envoyId) {
         final List<BoundMonitor> bound = boundMonitorRepository
             .findAllLocalByTenantResource(
-                resourceEvent.getTenantId(),
-                resourceEvent.getResourceId()
+                tenantId,
+                resourceId
             );
 
         final List<String> previousEnvoyIds = bound.stream()
@@ -704,7 +724,7 @@ public class MonitorManagement {
             .collect(Collectors.toList());
 
         bound.forEach(boundMonitor ->
-            boundMonitor.setEnvoyId(resourceEvent.getEnvoyId())
+            boundMonitor.setEnvoyId(envoyId)
         );
 
         boundMonitorRepository.saveAll(bound);
@@ -713,17 +733,26 @@ public class MonitorManagement {
         // ...tell any previous envoys about loss of binding
         previousEnvoyIds.forEach(this::sendMonitorBoundEvent);
         // ...and tell the attached envoy about the re-bindings
-        sendMonitorBoundEvent(resourceEvent.getEnvoyId());
+        sendMonitorBoundEvent(envoyId);
     }
 
-    List<BoundMonitor> upsertBindingToResource(List<Monitor> monitors,
-                                                       Resource resource) {
+    /**
+     * Ensures that the given monitors are bound to the given resource or if already bound
+     * ensures that the rendered content of the monitor given the resource is up to date.
+     * It also ensures existing bindings are updated with the given reattachedEnvoyId, when non-null.
+     * @return affected envoy IDs
+     */
+    Set<String> upsertBindingToResource(List<Monitor> monitors,
+                                        Resource resource,
+                                        String reattachedEnvoyId) {
 
         final ResourceInfo resourceInfo = envoyResourceManagement
             .getOne(resource.getTenantId(), resource.getResourceId())
             .join();
 
         final List<BoundMonitor> boundMonitors = new ArrayList<>();
+
+        final Set<String> affectedEnvoys = new HashSet<>();
 
         for (Monitor monitor : monitors) {
             final List<BoundMonitor> existing = boundMonitorRepository
@@ -749,20 +778,29 @@ public class MonitorManagement {
                     }
                 }
             } else {
-                // existing bindings need to be tested and updated for rendered content changes
+                // existing bindings need to be tested and updated for
+                // - rendered content changes
+                // - envoy re-attachment
 
                 final String newRenderedContent = renderMonitorContent(monitor, resource);
 
-                boundMonitors.addAll(
-                    existing.stream()
-                        // rendered content change?
-                        .filter(existingBind ->
-                            !existingBind.getRenderedContent().equals(newRenderedContent))
-                        // for those that changed, modify entity
-                        .peek(existingBind -> existingBind.setRenderedContent(newRenderedContent))
-                        // and add all of these to list to save and return
-                        .collect(Collectors.toList())
-                );
+                for (BoundMonitor existingBind : existing) {
+                    if (!existingBind.getRenderedContent().equals(newRenderedContent)) {
+                        existingBind.setRenderedContent(newRenderedContent);
+                        boundMonitors.add(existingBind);
+                    } else if (
+                        reattachedEnvoyId != null &&
+                            monitor.getSelectorScope() == ConfigSelectorScope.LOCAL &&
+                            existingBind.getEnvoyId() != null
+                    ) {
+                        // need to send an event to old Envoy just in case it's around, but
+                        // probably won't be due to the re-attachment
+                        affectedEnvoys.add(existingBind.getEnvoyId());
+
+                        existingBind.setEnvoyId(reattachedEnvoyId);
+                        boundMonitors.add(existingBind);
+                    }
+                }
             }
         }
 
@@ -770,12 +808,20 @@ public class MonitorManagement {
             boundMonitors, monitors, resource);
         boundMonitorRepository.saveAll(boundMonitors);
 
-        return boundMonitors;
+        affectedEnvoys.addAll(
+            extractEnvoyIds(boundMonitors)
+        );
+
+        return affectedEnvoys;
     }
 
-    List<BoundMonitor> unbindByMonitorId(Collection<UUID> monitorIdsToUnbind) {
+    /**
+     * Removes all bindings associated with the given monitor IDs.
+     * @return affected envoy IDs
+     */
+    Set<String> unbindByMonitorId(Collection<UUID> monitorIdsToUnbind) {
         if (monitorIdsToUnbind.isEmpty()) {
-            return Collections.emptyList();
+            return new HashSet<>();
         }
 
         final List<BoundMonitor> boundMonitors =
@@ -786,13 +832,17 @@ public class MonitorManagement {
         boundMonitorRepository.deleteAll(boundMonitors);
         decrementBoundCounts(boundMonitors);
 
-        return boundMonitors;
+        return extractEnvoyIds(boundMonitors);
     }
 
-    private List<BoundMonitor> unbindByResourceId(UUID monitorId,
-                                                  List<String> resourceIdsToUnbind) {
+    /**
+     * Removes all bindings associated with the given monitor and resources.
+     * @return affected envoy IDs
+     */
+    private Set<String> unbindByResourceId(UUID monitorId,
+                                           List<String> resourceIdsToUnbind) {
         if (resourceIdsToUnbind.isEmpty()) {
-            return Collections.emptyList();
+            return new HashSet<>();
         }
 
         final List<BoundMonitor> boundMonitors = boundMonitorRepository
@@ -803,10 +853,14 @@ public class MonitorManagement {
         boundMonitorRepository.deleteAll(boundMonitors);
         decrementBoundCounts(boundMonitors);
 
-        return boundMonitors;
+        return extractEnvoyIds(boundMonitors);
     }
 
-    private List<BoundMonitor> unbindByMonitorAndZone(UUID monitorId, List<String> zones) {
+    /**
+     * Removes all bindings associated with the given monitor and zones.
+     * @return affected envoy IDs
+     */
+    private Set<String> unbindByMonitorAndZone(UUID monitorId, List<String> zones) {
 
         final List<BoundMonitor> needToDelete = boundMonitorRepository
             .findAllByMonitor_IdAndZoneNameIn(monitorId, zones);
@@ -816,7 +870,17 @@ public class MonitorManagement {
 
         decrementBoundCounts(needToDelete);
 
-        return needToDelete;
+        return extractEnvoyIds(needToDelete);
+    }
+
+    /**
+     * Extracts the distinct, non-null envoy IDs from the given bindings.
+     */
+    static Set<String> extractEnvoyIds(List<BoundMonitor> boundMonitors) {
+        return boundMonitors.stream()
+            .map(BoundMonitor::getEnvoyId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
     }
 
     private void decrementBoundCounts(List<BoundMonitor> needToDelete) {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ResourceEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ResourceEventListener.java
@@ -1,6 +1,7 @@
 package com.rackspace.salus.monitor_management.services;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.ReattachedEnvoyResourceEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +42,13 @@ public class ResourceEventListener {
     public void consumeResourceEvents(ResourceEvent resourceEvent) {
         log.debug("Processing new resource event: {}", resourceEvent);
 
-        monitorManagement.handleResourceEvent(resourceEvent);
+        if (resourceEvent instanceof ReattachedEnvoyResourceEvent) {
+            monitorManagement.handleReattachedEnvoy(
+                ((ReattachedEnvoyResourceEvent) resourceEvent)
+            );
+        }
+        else {
+            monitorManagement.handleResourceChangeEvent(resourceEvent);
+        }
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ResourceEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ResourceEventListener.java
@@ -1,7 +1,6 @@
 package com.rackspace.salus.monitor_management.services;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
-import com.rackspace.salus.telemetry.messaging.ReattachedEnvoyResourceEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,15 +39,8 @@ public class ResourceEventListener {
      */
     @KafkaListener(topics = "#{__listener.topic}")
     public void consumeResourceEvents(ResourceEvent resourceEvent) {
-        log.debug("Processing new resource event: {}", resourceEvent);
+        log.debug("Processing resource change event: {}", resourceEvent);
 
-        if (resourceEvent instanceof ReattachedEnvoyResourceEvent) {
-            monitorManagement.handleReattachedEnvoy(
-                ((ReattachedEnvoyResourceEvent) resourceEvent)
-            );
-        }
-        else {
-            monitorManagement.handleResourceChangeEvent(resourceEvent);
-        }
+        monitorManagement.handleResourceChangeEvent(resourceEvent);
     }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.rackspace.salus.monitor_management.config.MonitorContentProperties;
 import com.rackspace.salus.monitor_management.config.ServicesProperties;
 import com.rackspace.salus.monitor_management.config.ZonesProperties;
@@ -54,7 +55,6 @@ import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
-import com.rackspace.salus.telemetry.messaging.ReattachedEnvoyResourceEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
@@ -73,6 +73,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -201,15 +202,6 @@ public class MonitorManagementTest {
             // limit to local/agent monitors only
             create.setSelectorScope(ConfigSelectorScope.LOCAL);
             create.setZones(Collections.emptyList());
-            monitorManagement.createMonitor(tenantId, create);
-        }
-    }
-
-    private void createRemoteMonitorsForTenant(int count, String tenantId, String zone) {
-        for (int i = 0; i < count; i++) {
-            MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
-            create.setSelectorScope(ConfigSelectorScope.REMOTE);
-            create.setZones(Collections.singletonList(zone));
             monitorManagement.createMonitor(tenantId, create);
         }
     }
@@ -993,22 +985,31 @@ public class MonitorManagementTest {
     }
 
     @Test
-    public void testsendMonitorBoundEvents() {
+    public void testExtractEnvoyIds() {
 
         final List<BoundMonitor> input = Arrays.asList(
             new BoundMonitor().setEnvoyId("e-1"),
             new BoundMonitor().setEnvoyId("e-2"),
+            new BoundMonitor().setEnvoyId(null),
             new BoundMonitor().setEnvoyId("e-1"),
             new BoundMonitor().setEnvoyId("e-3")
         );
 
-        monitorManagement.sendMonitorBoundEvents(input);
+        final Set<String> result = MonitorManagement.extractEnvoyIds(input);
+
+        assertThat(result, containsInAnyOrder("e-1", "e-2", "e-3"));
+
+    }
+
+    @Test
+    public void testSendMonitorBoundEvents() {
+        monitorManagement.sendMonitorBoundEvents(Sets.newHashSet("e-3", "e-2", "e-1"));
 
         ArgumentCaptor<MonitorBoundEvent> evtCaptor = ArgumentCaptor.forClass(MonitorBoundEvent.class);
 
         verify(monitorEventProducer, times(3)).sendMonitorEvent(evtCaptor.capture());
 
-        assertThat(evtCaptor.getAllValues(), contains(
+        assertThat(evtCaptor.getAllValues(), containsInAnyOrder(
             new MonitorBoundEvent().setEnvoyId("e-1"),
             new MonitorBoundEvent().setEnvoyId("e-2"),
             new MonitorBoundEvent().setEnvoyId("e-3")
@@ -1026,7 +1027,7 @@ public class MonitorManagementTest {
             .setAgentType(AgentType.TELEGRAF)
             .setContent("{}");
 
-        final List<BoundMonitor> changes = monitorManagement.bindMonitor(monitor);
+        final Set<String> affectedEnvoys = monitorManagement.bindNewMonitor(monitor);
 
         final List<BoundMonitor> expected = Collections.singletonList(
             new BoundMonitor()
@@ -1040,7 +1041,7 @@ public class MonitorManagementTest {
             expected
         );
 
-        assertThat(changes, equalTo(expected));
+        assertThat(affectedEnvoys, contains(DEFAULT_ENVOY_ID));
 
         verifyNoMoreInteractions(monitorEventProducer, boundMonitorRepository);
     }
@@ -1086,7 +1087,7 @@ public class MonitorManagementTest {
             .setAgentType(AgentType.TELEGRAF)
             .setContent("{\"type\": \"ping\", \"urls\": [\"${resource.metadata.public_ip}\"]}");
 
-        final List<BoundMonitor> boundMonitors = monitorManagement.bindMonitor(monitor);
+        final Set<String> affectedEnvoys = monitorManagement.bindNewMonitor(monitor);
 
         final List<BoundMonitor> expected = Arrays.asList(
             new BoundMonitor()
@@ -1116,7 +1117,7 @@ public class MonitorManagementTest {
         );
         verify(boundMonitorRepository).saveAll(expected);
 
-        assertThat(boundMonitors, equalTo(expected));
+        assertThat(affectedEnvoys, containsInAnyOrder("zone1-e-1", "zoneWest-e-2"));
 
         verify(zoneStorage, times(2)).findLeastLoadedEnvoy(zone1);
         verify(zoneStorage, times(2)).findLeastLoadedEnvoy(zoneWest);
@@ -1149,7 +1150,7 @@ public class MonitorManagementTest {
             .setAgentType(AgentType.TELEGRAF)
             .setContent("{}");
 
-        final List<BoundMonitor> boundMonitors = monitorManagement.bindMonitor(monitor);
+        final Set<String> affectedEnvoys = monitorManagement.bindNewMonitor(monitor);
 
         verify(zoneStorage).findLeastLoadedEnvoy(zone1);
 
@@ -1163,7 +1164,7 @@ public class MonitorManagementTest {
         );
         verify(boundMonitorRepository).saveAll(expected);
 
-        assertThat(boundMonitors, equalTo(expected));
+        assertThat(affectedEnvoys, hasSize(0));
 
         // ...and no MonitorBoundEvent was sent
         verifyNoMoreInteractions(zoneStorage, monitorEventProducer, boundMonitorRepository);
@@ -1413,13 +1414,13 @@ public class MonitorManagementTest {
 
         // EXECUTE
 
-        final ReattachedEnvoyResourceEvent event = new ReattachedEnvoyResourceEvent()
-            .setEnvoyId("e-new");
-        event
+        final ResourceEvent event = new ResourceEvent()
+            .setReattachedEnvoyId("e-new")
+            .setLabelsChanged(false)
             .setTenantId("t-1")
             .setResourceId("r-1");
 
-        monitorManagement.handleReattachedEnvoy(event);
+        monitorManagement.handleResourceChangeEvent(event);
 
         // VERIFY
 
@@ -1457,33 +1458,33 @@ public class MonitorManagementTest {
         entityManager.persist(monitor);
         entityManager.flush();
 
-        when(boundMonitorRepository.findAllByMonitor_IdIn(any()))
-            .thenReturn(Arrays.asList(
-                new BoundMonitor()
+        final List<BoundMonitor> bound = Arrays.asList(
+            new BoundMonitor()
                 .setMonitor(monitor)
                 .setResourceId("r-0")
+                .setEnvoyId("e-1")
                 .setZoneName("z-1"),
-                new BoundMonitor()
+            new BoundMonitor()
                 .setMonitor(monitor)
                 .setResourceId("r-0")
+                .setEnvoyId("e-2")
                 .setZoneName("z-2")
-            ));
+        );
+        when(boundMonitorRepository.findAllByMonitor_IdIn(any()))
+            .thenReturn(bound);
 
         // EXECUTE
 
-        final List<BoundMonitor> result = monitorManagement
+        final Set<String> affectedEnvoys = monitorManagement
             .unbindByMonitorId(Collections.singletonList(monitor.getId()));
 
         // VERIFY
 
-        assertThat(result, hasSize(2));
-        for (BoundMonitor boundMonitor : result) {
-            assertThat(boundMonitor.getResourceId(), equalTo("r-0"));
-        }
+        assertThat(affectedEnvoys, contains("e-1", "e-2"));
 
         verify(boundMonitorRepository).findAllByMonitor_IdIn(Collections.singletonList(monitor.getId()));
 
-        verify(boundMonitorRepository).deleteAll(result);
+        verify(boundMonitorRepository).deleteAll(bound);
 
         verifyNoMoreInteractions(boundMonitorRepository);
     }
@@ -1573,40 +1574,12 @@ public class MonitorManagementTest {
 
         // EXERCISE
 
-        final List<BoundMonitor> results =
-            monitorManagement.upsertBindingToResource(monitors, resource);
+        final Set<String> affectedEnvoys =
+            monitorManagement.upsertBindingToResource(monitors, resource, null);
 
         // VERIFY
 
-        assertThat(results, hasSize(4));
-        assertThat(results, containsInAnyOrder(
-            new BoundMonitor()
-                .setMonitor(monitors.get(0))
-                .setResourceId("r-1")
-                .setEnvoyId("e-1")
-                .setRenderedContent("new local domain=prod")
-                .setZoneName(""),
-            new BoundMonitor()
-                .setMonitor(monitors.get(1))
-                .setResourceId("r-1")
-                .setEnvoyId("e-2")
-                .setRenderedContent("new remote domain=prod")
-                .setZoneName("z-1"),
-            new BoundMonitor()
-                .setMonitor(monitors.get(1))
-                .setResourceId("r-1")
-                .setEnvoyId("e-2")
-                .setRenderedContent("new remote domain=prod")
-                .setZoneName("z-2"),
-            new BoundMonitor()
-                .setMonitor(monitors.get(2))
-                .setResourceId("r-1")
-                .setEnvoyId("e-3")
-                .setRenderedContent("existing local domain=prod")
-                .setZoneName("")
-            // NOTE binding of m3 did not need to be re-bound since its "static content" was
-            // unaffected by the change in resource labels.
-        ));
+        assertThat(affectedEnvoys, containsInAnyOrder("e-1", "e-2", "e-3"));
 
         verify(envoyResourceManagement).getOne("t-1", "r-1");
 
@@ -1621,7 +1594,36 @@ public class MonitorManagementTest {
         verify(boundMonitorRepository).findAllByMonitor_IdAndResourceId(m1, "r-1");
         verify(boundMonitorRepository).findAllByMonitor_IdAndResourceId(m2, "r-1");
         verify(boundMonitorRepository).findAllByMonitor_IdAndResourceId(m3, "r-1");
-        verify(boundMonitorRepository).saveAll(results);
+        verify(boundMonitorRepository).saveAll(
+            Arrays.asList(
+                new BoundMonitor()
+                    .setMonitor(monitors.get(0))
+                    .setResourceId("r-1")
+                    .setEnvoyId("e-1")
+                    .setRenderedContent("new local domain=prod")
+                    .setZoneName(""),
+                new BoundMonitor()
+                    .setMonitor(monitors.get(1))
+                    .setResourceId("r-1")
+                    .setEnvoyId("e-2")
+                    .setRenderedContent("new remote domain=prod")
+                    .setZoneName("z-1"),
+                new BoundMonitor()
+                    .setMonitor(monitors.get(1))
+                    .setResourceId("r-1")
+                    .setEnvoyId("e-2")
+                    .setRenderedContent("new remote domain=prod")
+                    .setZoneName("z-2"),
+                new BoundMonitor()
+                    .setMonitor(monitors.get(2))
+                    .setResourceId("r-1")
+                    .setEnvoyId("e-3")
+                    .setRenderedContent("existing local domain=prod")
+                    .setZoneName("")
+                // NOTE binding of m3 did not need to be re-bound since its "static content" was
+                // unaffected by the change in resource labels.
+            )
+        );
 
         verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement,
             zoneStorage);
@@ -1661,26 +1663,12 @@ public class MonitorManagementTest {
 
         // EXERCISE
 
-        final List<BoundMonitor> results =
-            monitorManagement.upsertBindingToResource(monitors, resource);
+        final Set<String> affectedEnvoys =
+            monitorManagement.upsertBindingToResource(monitors, resource, null);
 
         // VERIFY
 
-        assertThat(results, hasSize(2));
-        assertThat(results, containsInAnyOrder(
-            new BoundMonitor()
-                .setMonitor(monitors.get(0))
-                .setResourceId("r-1")
-                .setEnvoyId(null)
-                .setRenderedContent("new local domain=prod")
-                .setZoneName(""),
-            new BoundMonitor()
-                .setMonitor(monitors.get(1))
-                .setResourceId("r-1")
-                .setEnvoyId(null)
-                .setRenderedContent("new remote domain=prod")
-                .setZoneName("z-1")
-        ));
+        assertThat(affectedEnvoys, hasSize(0));
 
         verify(envoyResourceManagement).getOne("t-1", "r-1");
 
@@ -1689,7 +1677,22 @@ public class MonitorManagementTest {
 
         verify(boundMonitorRepository).findAllByMonitor_IdAndResourceId(m0, "r-1");
         verify(boundMonitorRepository).findAllByMonitor_IdAndResourceId(m1, "r-1");
-        verify(boundMonitorRepository).saveAll(results);
+        verify(boundMonitorRepository).saveAll(
+            Arrays.asList(
+                new BoundMonitor()
+                    .setMonitor(monitors.get(0))
+                    .setResourceId("r-1")
+                    .setEnvoyId(null)
+                    .setRenderedContent("new local domain=prod")
+                    .setZoneName(""),
+                new BoundMonitor()
+                    .setMonitor(monitors.get(1))
+                    .setResourceId("r-1")
+                    .setEnvoyId(null)
+                    .setRenderedContent("new remote domain=prod")
+                    .setZoneName("z-1")
+            )
+        );
 
         verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement,
             zoneStorage
@@ -1832,6 +1835,87 @@ public class MonitorManagementTest {
         verify(monitorEventProducer).sendMonitorEvent(
             new MonitorBoundEvent()
                 .setEnvoyId("e-1")
+        );
+
+        verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement,
+            zoneStorage, monitorEventProducer, resourceApi);
+    }
+
+    @Test
+    public void testhandleResourceEvent_modifiedResourceAndReattached() {
+
+        // for this unit test the "new" value of the resource don't really matter as long as
+        // the monitor label selector continues to align
+        final Resource resource = new Resource()
+            .setLabels(Collections.singletonMap("env", "prod"))
+            .setMetadata(Collections.singletonMap("custom", "value"))
+            .setResourceId("r-1")
+            .setTenantId("t-1")
+            .setId(1001L);
+        when(resourceApi.getByResourceId(any(), any()))
+            .thenReturn(resource);
+
+        ResourceInfo resourceInfo = new ResourceInfo()
+            .setResourceId("r-1")
+            .setEnvoyId("e-not-used"); // for this particular use case
+        when(envoyResourceManagement.getOne(any(), any()))
+            .thenReturn(CompletableFuture.completedFuture(resourceInfo));
+
+        final Monitor monitor = new Monitor()
+            .setSelectorScope(ConfigSelectorScope.LOCAL)
+            .setTenantId("t-1")
+            .setLabelSelector(Collections.singletonMap("env", "prod"))
+            .setAgentType(AgentType.TELEGRAF)
+            .setContent("static content");
+        entityManager.persist(monitor);
+
+        entityManager.flush();
+
+        final BoundMonitor boundMonitor = new BoundMonitor()
+            .setMonitor(monitor)
+            .setResourceId("r-1")
+            .setZoneName("")
+            .setRenderedContent("static content")
+            .setEnvoyId("e-old");
+
+        when(boundMonitorRepository.findMonitorsBoundToResource("t-1", "r-1"))
+            .thenReturn(Collections.singletonList(monitor.getId()));
+
+        when(boundMonitorRepository.findAllLocalByTenantResource(any(), any()))
+            .thenReturn(Collections.singletonList(boundMonitor));
+
+        // EXERCISE
+
+        monitorManagement.handleResourceChangeEvent(
+            new ResourceEvent()
+            .setTenantId("t-1")
+            .setResourceId("r-1")
+            .setReattachedEnvoyId("e-new")
+        );
+
+        // VERIFY
+
+        verify(boundMonitorRepository).findAllLocalByTenantResource("t-1", "r-1");
+
+        verify(boundMonitorRepository).saveAll(captorOfBoundMonitorList.capture());
+        final List<BoundMonitor> savedBoundMonitors = captorOfBoundMonitorList.getValue();
+        assertThat(savedBoundMonitors, hasSize(1));
+        assertThat(savedBoundMonitors, contains(
+            new BoundMonitor()
+                .setMonitor(monitor)
+                .setResourceId("r-1")
+                .setEnvoyId("e-new")
+                .setRenderedContent("static content")
+                .setZoneName("")
+        ));
+
+        verify(monitorEventProducer).sendMonitorEvent(
+            new MonitorBoundEvent()
+                .setEnvoyId("e-old")
+        );
+        verify(monitorEventProducer).sendMonitorEvent(
+            new MonitorBoundEvent()
+                .setEnvoyId("e-new")
         );
 
         verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement,

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ResourceEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ResourceEventListenerTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.after;
 import static org.mockito.Mockito.verify;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
-import com.rackspace.salus.telemetry.messaging.ReattachedEnvoyResourceEvent;
+import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,15 +69,14 @@ public class ResourceEventListenerTest {
 
   @Test
   public void testReattachedEnvoyResourceEvent() throws InterruptedException {
-    final ReattachedEnvoyResourceEvent event = new ReattachedEnvoyResourceEvent()
-        .setEnvoyId("e-1");
-    event
+    final ResourceEvent event = new ResourceEvent()
+        .setReattachedEnvoyId("e-1")
+        .setLabelsChanged(false)
         .setTenantId("t-1")
         .setResourceId("r-1");
 
     kafkaTemplate.send(TOPIC, "t-1:r-1", event);
 
-    verify(monitorManagement, after(5000))
-        .handleReattachedEnvoy(event);
+    verify(monitorManagement, after(5000)).handleResourceChangeEvent(event);
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ResourceEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ResourceEventListenerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.services;
+
+import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.verify;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.ReattachedEnvoyResourceEvent;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+    classes = {
+        ResourceEventListener.class,
+        KafkaTopicProperties.class
+    },
+    properties = {
+        "salus.kafka.topics.resources=" + ResourceEventListenerTest.TOPIC,
+        // override app default so that we can produce before consumer is ready
+        "spring.kafka.consumer.auto-offset-reset=earliest"
+    }
+)
+@ImportAutoConfiguration({
+    KafkaAutoConfiguration.class
+})
+@EmbeddedKafka(topics = ResourceEventListenerTest.TOPIC)
+public class ResourceEventListenerTest {
+
+  static final String TOPIC = "resource_events";
+
+  static {
+    System.setProperty(
+        EmbeddedKafkaBroker.BROKER_LIST_PROPERTY, "spring.kafka.bootstrap-servers");
+  }
+
+  @Autowired
+  private KafkaTemplate<String, Object> kafkaTemplate;
+
+  @MockBean
+  MonitorManagement monitorManagement;
+
+  @Autowired
+  ResourceEventListener resourceEventListener;
+
+  @Test
+  public void testReattachedEnvoyResourceEvent() throws InterruptedException {
+    final ReattachedEnvoyResourceEvent event = new ReattachedEnvoyResourceEvent()
+        .setEnvoyId("e-1");
+    event
+        .setTenantId("t-1")
+        .setResourceId("r-1");
+
+    kafkaTemplate.send(TOPIC, "t-1:r-1", event);
+
+    verify(monitorManagement, after(5000))
+        .handleReattachedEnvoy(event);
+  }
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-360

# What

Consumes `ReattachedEnvoyResourceEvent` event introduced by https://github.com/racker/salus-telemetry-model/pull/52 , locates **local** monitors bound to the tenant's resource, and re-binds those to the newly attached Envoy. It then sends out monitor bind change events for the new envoy ID and just in case the old envoys are lingering, it sends change events for those too.

Design background is provided in https://github.com/racker/salus-telemetry-bundle/pull/50

## How to test

Unit tests updated.