### PR TITLE
Handle reassignment of bound monitors / envoy disconnection

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -35,6 +35,7 @@ import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.Resource;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
@@ -289,12 +290,12 @@ public class MonitorManagement {
     private BoundMonitor bindRemoteMonitor(Monitor monitor, Resource resource, String zone) {
         final ResolvedZone resolvedZone = resolveZone(monitor.getTenantId(), zone);
 
-        final Optional<String> result = zoneStorage.findLeastLoadedEnvoy(resolvedZone).join();
+        final Optional<EnvoyResourcePair> result = zoneStorage.findLeastLoadedEnvoy(resolvedZone).join();
 
         final String envoyId;
         if (result.isPresent()) {
-            envoyId = result.get();
-            zoneStorage.incrementBoundCount(resolvedZone, envoyId)
+            envoyId = result.get().getEnvoyId();
+            zoneStorage.incrementBoundCount(resolvedZone, resource.getResourceId())
             .join();
         }
         else {
@@ -341,10 +342,11 @@ public class MonitorManagement {
 
         for (BoundMonitor boundMonitor : onesWithoutEnvoy) {
 
-            final Optional<String> result = zoneStorage.findLeastLoadedEnvoy(resolvedZone).join();
+            final Optional<EnvoyResourcePair> result = zoneStorage.findLeastLoadedEnvoy(resolvedZone).join();
             if (result.isPresent()) {
-                boundMonitor.setEnvoyId(result.get());
+                boundMonitor.setEnvoyId(result.get().getEnvoyId());
                 assigned.add(boundMonitor);
+                zoneStorage.incrementBoundCount(resolvedZone, result.get().getResourceId());
             }
         }
 
@@ -358,8 +360,9 @@ public class MonitorManagement {
     }
 
     public void handleEnvoyResourceChangedInZone(@Nullable String tenantId,
-                                                 String zoneName, String fromEnvoyId,
-                                                 String toEnvoyId) {
+                                                 String zoneName, String resourceId,
+                                                 String fromEnvoyId, String toEnvoyId) {
+        log.debug("Moving bound monitors to new envoy for same resource");
 
         final ResolvedZone resolvedZone = resolveZone(tenantId, zoneName);
 
@@ -386,9 +389,10 @@ public class MonitorManagement {
 
             boundMonitorRepository.saveAll(boundToPrev);
 
+
             zoneStorage.incrementBoundCount(
                 createPrivateZone(tenantId, zoneName),
-                toEnvoyId,
+                resourceId,
                 boundToPrev.size()
             );
 
@@ -793,7 +797,7 @@ public class MonitorManagement {
                 boundMonitor.getMonitor().getSelectorScope() == ConfigSelectorScope.REMOTE) {
 
                 zoneStorage.decrementBoundCount(getResolvedZoneOfBoundMonitor(boundMonitor),
-                    boundMonitor.getEnvoyId()
+                    boundMonitor.getResourceId()
                 );
 
             }
@@ -843,5 +847,27 @@ public class MonitorManagement {
             monitors.add(monitor);
         }
         return monitors;
+    }
+
+    /**
+     * Unassigns the old envoy from all relevant bound monitors,
+     * then attempts to reassign them to a different envoy if one is available.
+     * @param zoneTenantId The tenantId of the resolved zone.
+     * @param zoneName The name of the resolved zone.
+     * @param envoyId The envoy id that has disconnected.
+     */
+    public void handleExpiredEnvoy(String zoneTenantId, String zoneName, String envoyId) {
+        log.debug("Reassigning bound monitors for disconnected envoy={} with zoneName={} and zoneTenantId={}",
+            envoyId, zoneName, zoneTenantId);
+        List<BoundMonitor> boundMonitors = boundMonitorRepository.findAllByEnvoyId(envoyId);
+        if (boundMonitors.isEmpty()) {
+            return;
+        }
+        for (BoundMonitor boundMonitor : boundMonitors) {
+            boundMonitor.setEnvoyId(null);
+        }
+
+        boundMonitorRepository.saveAll(boundMonitors);
+        handleNewEnvoyInZone(zoneTenantId, zoneName);
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneEventListener.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.services;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.ExpiredResourceZoneEvent;
 import com.rackspace.salus.telemetry.messaging.NewResourceZoneEvent;
 import com.rackspace.salus.telemetry.messaging.ReattachedResourceZoneEvent;
 import com.rackspace.salus.telemetry.messaging.ZoneEvent;
@@ -62,9 +63,14 @@ public class ZoneEventListener {
       monitorManagement.handleEnvoyResourceChangedInZone(
           event.getTenantId(),
           event.getZoneName(),
+          event.getResourceId(),
           event.getFromEnvoyId(),
           event.getToEnvoyId()
       );
+    } else if (zoneEvent instanceof ExpiredResourceZoneEvent) {
+      final ExpiredResourceZoneEvent event = (ExpiredResourceZoneEvent) zoneEvent;
+      monitorManagement.handleExpiredEnvoy(
+          event.getTenantId(), event.getZoneName(), event.getEnvoyId());
     } else {
       log.warn("Discarding unknown ZoneEvent={}", zoneEvent);
     }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.services;
 import static org.mockito.Mockito.verify;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.ExpiredResourceZoneEvent;
 import com.rackspace.salus.telemetry.messaging.NewResourceZoneEvent;
 import com.rackspace.salus.telemetry.messaging.ReattachedResourceZoneEvent;
 import org.junit.Before;
@@ -64,5 +65,18 @@ public class ZoneEventListenerTest {
 
     verify(monitorManagement).handleEnvoyResourceChangedInZone(
         "t-1", "z-1", "r-1", "e-1", "e-2");
+  }
+
+  @Test
+  public void testExpiredResourceZoneEvent() {
+    zoneEventListener.handleEvent(
+        new ExpiredResourceZoneEvent()
+            .setEnvoyId("e-1")
+            .setTenantId("t-1")
+            .setZoneName("z-1")
+    );
+
+    verify(monitorManagement).handleExpiredEnvoy(
+        "t-1", "z-1", "e-1");
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneEventListenerTest.java
@@ -57,11 +57,12 @@ public class ZoneEventListenerTest {
         new ReattachedResourceZoneEvent()
             .setFromEnvoyId("e-1")
             .setToEnvoyId("e-2")
+            .setResourceId("r-1")
             .setTenantId("t-1")
             .setZoneName("z-1")
     );
 
     verify(monitorManagement).handleEnvoyResourceChangedInZone(
-        "t-1", "z-1", "e-1", "e-2");
+        "t-1", "z-1", "r-1", "e-1", "e-2");
   }
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-304

# What

Attempts to reassign bound monitors if an envoy was detected as being disconnected by the zone watcher.

# How

Unassigns all bound monitors related to the envoy then calls the pre-existing function to try and assign them to a new envoy if available.

## How to test
I've tested manually, but I'll add some other tests to this PR in future commits.

# Why

Because we don't want bound monitors to get orphaned with an old envoyId if it goes away forever.

# TODO

Tests.