### PR TITLE
adds the x509 and http remote monitors

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
@@ -21,13 +21,13 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
-import com.rackspace.salus.monitor_management.web.model.telegraf.X509_Cert;
+import com.rackspace.salus.monitor_management.web.model.telegraf.X509Cert;
 import com.rackspace.salus.monitor_management.web.model.telegraf.HttpResponse;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonSubTypes({
     @Type(name = "ping", value = Ping.class),
-    @Type(name = "x509_cert", value = X509_Cert.class),
+    @Type(name = "x509_cert", value = X509Cert.class),
     @Type(name = "http_response", value = HttpResponse.class)
 })
 public abstract class RemotePlugin {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
@@ -21,10 +21,12 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
+import com.rackspace.salus.monitor_management.web.model.telegraf.X509_Cert;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonSubTypes({
-    @Type(name = "ping", value = Ping.class)
+    @Type(name = "ping", value = Ping.class),
+    @Type(name = "x509_cert", value = X509_Cert.class)
 })
 public abstract class RemotePlugin {
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
@@ -22,11 +22,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
 import com.rackspace.salus.monitor_management.web.model.telegraf.X509_Cert;
+import com.rackspace.salus.monitor_management.web.model.telegraf.HttpResponse;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonSubTypes({
     @Type(name = "ping", value = Ping.class),
-    @Type(name = "x509_cert", value = X509_Cert.class)
+    @Type(name = "x509_cert", value = X509_Cert.class),
+    @Type(name = "http_response", value = HttpResponse.class)
 })
 public abstract class RemotePlugin {
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.telegraf;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.telemetry.model.AgentType;
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data @EqualsAndHashCode(callSuper = true)
+@ApplicableAgentType(AgentType.TELEGRAF)
+@JsonInclude(Include.NON_NULL)
+public class HttpResponse extends RemotePlugin {
+  List<String> sources;
+  String timeout;
+  String tlsCa;
+  String tlsCert;
+  String tlsKey;
+  boolean insecureSkipVerify;
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
@@ -21,18 +21,25 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
-import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.Map;
 
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @JsonInclude(Include.NON_NULL)
 public class HttpResponse extends RemotePlugin {
-  List<String> sources;
-  String timeout;
+  String address;
+  String httpProxy;
+  String responseTimeout;
+  String method;
+  boolean followRedirects;
+  String body;
+  String responseStringMatch;
   String tlsCa;
   String tlsCert;
   String tlsKey;
   boolean insecureSkipVerify;
+  Map<String, String> headers;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
@@ -35,7 +35,7 @@ public class HttpResponse extends RemotePlugin {
   @NotEmpty
   String address;
   String httpProxy;
-  @Pattern(regexp = "(([-+]?[0-9]*\\.?[0-9]+)(h|m|s|ns|us|ms))+", message = "invalid duration")
+  @Pattern(regexp = "([0-9]+)(h|m|s|ms)", message = "invalid duration")
   String responseTimeout;
   @Pattern(regexp = "GET|PUT|POST|DELETE|HEAD|OPTIONS|PATCH|TRACE", message = "invalid http method")
   String method;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
@@ -24,15 +24,20 @@ import com.rackspace.salus.telemetry.model.AgentType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
 import java.util.Map;
 
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @JsonInclude(Include.NON_NULL)
 public class HttpResponse extends RemotePlugin {
+  @NotEmpty
   String address;
   String httpProxy;
+  @Pattern(regexp = "(([-+]?[0-9]*\\.?[0-9]+)(h|m|s|ns|us|ms))+", message = "invalid duration")
   String responseTimeout;
+  @Pattern(regexp = "GET|PUT|POST|DELETE|HEAD|OPTIONS|PATCH|TRACE", message = "invalid http method")
   String method;
   boolean followRedirects;
   String body;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
@@ -25,11 +25,16 @@ import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @JsonInclude(Include.NON_NULL)
 public class X509Cert extends RemotePlugin {
+  @NotEmpty
   List<String> sources;
+  @Pattern(regexp = "(([-+]?[0-9]*\\.?[0-9]+)(h|m|s|ns|us|ms))+", message = "invalid duration")
   String timeout;
   String tlsCa;
   String tlsCert;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
@@ -28,7 +28,7 @@ import lombok.EqualsAndHashCode;
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @JsonInclude(Include.NON_NULL)
-public class X509_Cert extends RemotePlugin {
+public class X509Cert extends RemotePlugin {
   List<String> sources;
   String timeout;
   String tlsCa;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
@@ -34,7 +34,7 @@ import javax.validation.constraints.Pattern;
 public class X509Cert extends RemotePlugin {
   @NotEmpty
   List<String> sources;
-  @Pattern(regexp = "(([-+]?[0-9]*\\.?[0-9]+)(h|m|s|ns|us|ms))+", message = "invalid duration")
+  @Pattern(regexp = "([0-9]+)(h|m|s|ms)", message = "invalid duration")
   String timeout;
   String tlsCa;
   String tlsCert;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509_Cert.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509_Cert.java
@@ -34,5 +34,5 @@ public class X509_Cert extends RemotePlugin {
   String tlsCa;
   String tlsCert;
   String tlsKey;
-  boolean insecureSkipVerify
+  boolean insecureSkipVerify;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509_Cert.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509_Cert.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.telegraf;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.telemetry.model.AgentType;
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data @EqualsAndHashCode(callSuper = true)
+@ApplicableAgentType(AgentType.TELEGRAF)
+@JsonInclude(Include.NON_NULL)
+public class X509_Cert extends RemotePlugin {
+  List<String> sources;
+  String timeout;
+  String tlsCa;
+  String tlsCert;
+  String tlsKey;
+  boolean insecureSkipVerify
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -378,7 +378,6 @@ public class MonitorConversionServiceTest {
     validatorFactoryBean.afterPropertiesSet();
     Set<ConstraintViolation<X509Cert>> violations = validatorFactoryBean.validate(x509Plugin);
     assertEquals(violations.size(), 0);
-    violations = validatorFactoryBean.validate(x509Plugin);
     x509Plugin.setTimeout("xx");
     violations = validatorFactoryBean.validate(x509Plugin);
     assertEquals(violations.size(), 1);

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -382,6 +382,8 @@ public class MonitorConversionServiceTest {
     violations = validatorFactoryBean.validate(x509Plugin);
     assertEquals(violations.size(), 1);
     x509Plugin.setTimeout("300ms");
+    violations = validatorFactoryBean.validate(x509Plugin);
+    assertEquals(violations.size(), 0);
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.monitor_management.entities.Monitor;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
@@ -406,6 +407,8 @@ public class MonitorConversionServiceTest {
     labels.put("test", "convertToOutput_http");
 
     final String content = readContent("/MonitorConversionServiceTest_http.json");
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final HttpResponse httpResponse = objectMapper.readValue(content, HttpResponse.class);
 
     final UUID monitorId = UUID.randomUUID();
 
@@ -433,6 +436,17 @@ public class MonitorConversionServiceTest {
 
     final HttpResponse httpPlugin = (HttpResponse) plugin;
     assertThat(httpPlugin.getAddress()).isEqualTo("http://localhost");
+    assertThat(httpPlugin.getHttpProxy()).isEqualTo("http://localhost:8888");
+    assertThat(httpPlugin.getResponseTimeout()).isEqualTo("5s");
+    assertThat(httpPlugin.getMethod()).isEqualTo("GET");
+    assertThat(httpPlugin.isFollowRedirects()).isEqualTo(false);
+    assertThat(httpPlugin.getBody()).isEqualTo("{'fake':'data'}");
+    assertThat(httpPlugin.getResponseStringMatch()).isEqualTo("\"service_status\": \"up\"");
+    assertThat(httpPlugin.getTlsCa()).isEqualTo("/etc/telegraf/ca.pem");
+    assertThat(httpPlugin.getTlsCert()).isEqualTo("/etc/telegraf/cert.pem");
+    assertThat(httpPlugin.getTlsKey()).isEqualTo("/etc/telegraf/key.pem");
+    assertThat(httpPlugin.isInsecureSkipVerify()).isEqualTo(false);
+    assertThat(httpPlugin.getHeaders().get("host")).isEqualTo("github.com");
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -33,11 +33,7 @@ import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import javax.validation.ConstraintViolation;
 import org.json.JSONException;
 import org.junit.Assert;
@@ -367,9 +363,9 @@ public class MonitorConversionServiceTest {
     final RemoteMonitorDetails remoteMonitorDetails = (RemoteMonitorDetails) result.getDetails();
     assertThat(remoteMonitorDetails.getMonitoringZones()).contains("z-1");
     final RemotePlugin plugin = remoteMonitorDetails.getPlugin();
-    assertThat(plugin).isInstanceOf(X509_Cert.class);
+    assertThat(plugin).isInstanceOf(X509Cert.class);
 
-    final X509_Cert x509Plugin = (X509_Cert) plugin;
+    final X509Cert x509Plugin = (X509Cert) plugin;
     assertThat(x509Plugin.getSources()).contains("/etc/ssl/certs/ssl-cert-snakeoil.pem");
     assertThat(x509Plugin.getTimeout()).isEqualTo("5s");
     assertThat(x509Plugin.getTlsCa()).isEqualTo("/etc/telegraf/ca.pem");
@@ -383,11 +379,13 @@ public class MonitorConversionServiceTest {
     final Map<String, String> labels = new HashMap<>();
     labels.put("os", "linux");
     labels.put("test", "convertFromInput_x509");
+    final List<String> sources = new LinkedList<>();
+    sources.add("/etc/ssl/certs/ssl-cert-snakeoil.pem");
 
     final RemoteMonitorDetails details = new RemoteMonitorDetails();
     details.setMonitoringZones(Collections.singletonList("z-1"));
-    final X509_Cert plugin = new X509_Cert();
-    //plugin.setSources("/etc/ssl/certs/ssl-cert-snakeoil.pem");
+    final X509Cert plugin = new X509Cert();
+    plugin.setSources(sources);
     plugin.setTimeout("5s");
     plugin.setTlsCa("/etc/telegraf/ca.pem");
     plugin.setTlsCert("/etc/telegraf/cert.pem");

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.monitor_management.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
 
 import com.rackspace.salus.monitor_management.entities.Monitor;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
@@ -372,6 +373,25 @@ public class MonitorConversionServiceTest {
     assertThat(x509Plugin.getTlsCert()).isEqualTo("/etc/telegraf/cert.pem");
     assertThat(x509Plugin.getTlsKey()).isEqualTo("/etc/telegraf/key.pem");
     assertThat(x509Plugin.isInsecureSkipVerify()).isEqualTo(false);
+
+    final LocalValidatorFactoryBean validatorFactoryBean = new LocalValidatorFactoryBean();
+    validatorFactoryBean.afterPropertiesSet();
+    Set<ConstraintViolation<X509Cert>> violations = validatorFactoryBean.validate(x509Plugin);
+    assertEquals(violations.size(), 0);
+    violations = validatorFactoryBean.validate(x509Plugin);
+    x509Plugin.setTimeout("xx");
+    violations = validatorFactoryBean.validate(x509Plugin);
+    assertEquals(violations.size(), 1);
+    x509Plugin.setTimeout("300ms");
+    violations = validatorFactoryBean.validate(x509Plugin);
+    assertEquals(violations.size(), 0);
+    x509Plugin.setTimeout("-1.5h");
+    violations = validatorFactoryBean.validate(x509Plugin);
+    assertEquals(violations.size(), 0);
+    x509Plugin.setTimeout("2h45m");
+    violations = validatorFactoryBean.validate(x509Plugin);
+    assertEquals(violations.size(), 0);
+
   }
 
   @Test
@@ -452,6 +472,14 @@ public class MonitorConversionServiceTest {
     assertThat(httpPlugin.getTlsKey()).isEqualTo("/etc/telegraf/key.pem");
     assertThat(httpPlugin.isInsecureSkipVerify()).isEqualTo(false);
     assertThat(httpPlugin.getHeaders().get("host")).isEqualTo("github.com");
+
+    final LocalValidatorFactoryBean validatorFactoryBean = new LocalValidatorFactoryBean();
+    validatorFactoryBean.afterPropertiesSet();
+    Set<ConstraintViolation<HttpResponse>> violations = validatorFactoryBean.validate(httpPlugin);
+    assertEquals(violations.size(), 0);
+    httpPlugin.setMethod("badMethod");
+    violations = validatorFactoryBean.validate(httpPlugin);
+    assertEquals(violations.size(), 1);
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -370,7 +370,6 @@ public class MonitorConversionServiceTest {
     assertThat(plugin).isInstanceOf(X509_Cert.class);
 
     final X509_Cert x509Plugin = (X509_Cert) plugin;
-    assertThat(pingPlugin.getUrls()).contains("localhost");
     assertThat(x509Plugin.getSources()).contains("/etc/ssl/certs/ssl-cert-snakeoil.pem");
   }
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -19,7 +19,6 @@ package com.rackspace.salus.monitor_management.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.monitor_management.entities.Monitor;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
@@ -372,6 +371,11 @@ public class MonitorConversionServiceTest {
 
     final X509_Cert x509Plugin = (X509_Cert) plugin;
     assertThat(x509Plugin.getSources()).contains("/etc/ssl/certs/ssl-cert-snakeoil.pem");
+    assertThat(x509Plugin.getTimeout()).isEqualTo("5s");
+    assertThat(x509Plugin.getTlsCa()).isEqualTo("/etc/telegraf/ca.pem");
+    assertThat(x509Plugin.getTlsCert()).isEqualTo("/etc/telegraf/cert.pem");
+    assertThat(x509Plugin.getTlsKey()).isEqualTo("/etc/telegraf/key.pem");
+    assertThat(x509Plugin.isInsecureSkipVerify()).isEqualTo(false);
   }
 
   @Test
@@ -383,6 +387,12 @@ public class MonitorConversionServiceTest {
     final RemoteMonitorDetails details = new RemoteMonitorDetails();
     details.setMonitoringZones(Collections.singletonList("z-1"));
     final X509_Cert plugin = new X509_Cert();
+    //plugin.setSources("/etc/ssl/certs/ssl-cert-snakeoil.pem");
+    plugin.setTimeout("5s");
+    plugin.setTlsCa("/etc/telegraf/ca.pem");
+    plugin.setTlsCert("/etc/telegraf/cert.pem");
+    plugin.setTlsKey("/etc/telegraf/key.pem");
+    plugin.setInsecureSkipVerify(false);
     details.setPlugin(plugin);
 
     DetailedMonitorInput input = new DetailedMonitorInput()
@@ -407,9 +417,6 @@ public class MonitorConversionServiceTest {
     labels.put("test", "convertToOutput_http");
 
     final String content = readContent("/MonitorConversionServiceTest_http.json");
-    final ObjectMapper objectMapper = new ObjectMapper();
-    final HttpResponse httpResponse = objectMapper.readValue(content, HttpResponse.class);
-
     final UUID monitorId = UUID.randomUUID();
 
     Monitor monitor = new Monitor()
@@ -455,9 +462,24 @@ public class MonitorConversionServiceTest {
     labels.put("os", "linux");
     labels.put("test", "convertFromInput_http");
 
+    final Map<String, String> headers = new HashMap<>();
+    headers.put("host", "github.com");
+
     final RemoteMonitorDetails details = new RemoteMonitorDetails();
     details.setMonitoringZones(Collections.singletonList("z-1"));
     final HttpResponse plugin = new HttpResponse();
+    plugin.setAddress("http://localhost");
+    plugin.setHttpProxy("http://localhost:8888");
+    plugin.setResponseTimeout("5s");
+    plugin.setMethod("GET");
+    plugin.setFollowRedirects(false);
+    plugin.setBody("{'fake':'data'}");
+    plugin.setResponseStringMatch("\"service_status\": \"up\"");
+    plugin.setTlsCa("/etc/telegraf/ca.pem");
+    plugin.setTlsCert("/etc/telegraf/cert.pem");
+    plugin.setTlsKey("/etc/telegraf/key.pem");
+    plugin.setInsecureSkipVerify(false);
+    plugin.setHeaders(headers);
     details.setPlugin(plugin);
 
     DetailedMonitorInput input = new DetailedMonitorInput()

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -383,15 +383,6 @@ public class MonitorConversionServiceTest {
     violations = validatorFactoryBean.validate(x509Plugin);
     assertEquals(violations.size(), 1);
     x509Plugin.setTimeout("300ms");
-    violations = validatorFactoryBean.validate(x509Plugin);
-    assertEquals(violations.size(), 0);
-    x509Plugin.setTimeout("-1.5h");
-    violations = validatorFactoryBean.validate(x509Plugin);
-    assertEquals(violations.size(), 0);
-    x509Plugin.setTimeout("2h45m");
-    violations = validatorFactoryBean.validate(x509Plugin);
-    assertEquals(violations.size(), 0);
-
   }
 
   @Test

--- a/src/test/resources/MonitorConversionServiceTest_http.json
+++ b/src/test/resources/MonitorConversionServiceTest_http.json
@@ -1,0 +1,24 @@
+{
+  "type": "http_response",
+  "address": "http://localhost",
+  "httpProxy": "http://localhost:8888",
+  "responseTimeout": "5s",
+  "method": "GET",
+  "followRedirects": false,
+  "body": "{'fake':'data'}",
+  "responseStringMatch": "\"service_status\": \"up\"",
+  "tlsCa": "/etc/telegraf/ca.pem",
+  "tlsCert": "/etc/telegraf/cert.pem",
+  "tlsKey": "/etc/telegraf/key.pem",
+  "insecureSkipVerify": false,
+  "headers": {"host": "github.com"}
+}
+
+
+
+
+
+
+
+
+

--- a/src/test/resources/MonitorConversionServiceTest_http.json
+++ b/src/test/resources/MonitorConversionServiceTest_http.json
@@ -13,12 +13,3 @@
   "insecureSkipVerify": false,
   "headers": {"host": "github.com"}
 }
-
-
-
-
-
-
-
-
-

--- a/src/test/resources/MonitorConversionServiceTest_x509.json
+++ b/src/test/resources/MonitorConversionServiceTest_x509.json
@@ -1,0 +1,9 @@
+{
+  "type": "x509_cert",
+  "sources": ["/etc/ssl/certs/ssl-cert-snakeoil.pem"],
+  "timeout": = "5s",
+  "tlsCa": "/etc/telegraf/ca.pem",
+  "tlsCert": "/etc/telegraf/cert.pem",
+  "tlsKey": "/etc/telegraf/key.pem",
+  "insecure_skip_verify": false
+}

--- a/src/test/resources/MonitorConversionServiceTest_x509.json
+++ b/src/test/resources/MonitorConversionServiceTest_x509.json
@@ -1,9 +1,9 @@
 {
   "type": "x509_cert",
   "sources": ["/etc/ssl/certs/ssl-cert-snakeoil.pem"],
-  "timeout": = "5s",
+  "timeout": "5s",
   "tlsCa": "/etc/telegraf/ca.pem",
   "tlsCert": "/etc/telegraf/cert.pem",
   "tlsKey": "/etc/telegraf/key.pem",
-  "insecure_skip_verify": false
+  "insecureSkipVerify": false
 }


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/SALUS-364
https://jira.rax.io/browse/SALUS-363

# What
adds the x509 and http remote monitors



## How to test

unit tests

# TODO

I wanted to do an end to end test to confirm they correctly get passed from the ambassador to the envoy,  and tried to update the insomnia workspace to config them, but I'm confused by the state of what is configured with graphql and what is configured with insomnia.  No longer sure how to init/config the agents on the envoy.  I'll try to set that up soon.
