### PR TITLE
Provide zone rebalancing operation

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/config/ZonesProperties.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/ZonesProperties.java
@@ -32,10 +32,10 @@ public class ZonesProperties {
   /**
    * When rebalancing calculates the average and standard deviation of assignment counts, this
    * property indicates if Envoy's with zero assignments should be included in that calculation.
-   * Inclusion potentially skews the average downward and the standard deviation wider, but
-   * that could be mathematically "more correct".
+   * Exclusion potentially leaves the non-zero Envoys balanced with each other, but the unused
+   * Envoys would never get assignments due to lack of outliers.
    */
-  boolean rebalanceEvaluateZeroes = false;
+  boolean rebalanceEvaluateZeroes = true;
 
   /**
    * When rebalancing, this property indicates how many standard deviations above the average

--- a/src/main/java/com/rackspace/salus/monitor_management/config/ZonesProperties.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/ZonesProperties.java
@@ -29,4 +29,18 @@ public class ZonesProperties {
 
   List<String> defaultZones = Collections.emptyList();
 
+  /**
+   * When rebalancing calculates the average and standard deviation of assignment counts, this
+   * property indicates if Envoy's with zero assignments should be included in that calculation.
+   * Inclusion potentially skews the average downward and the standard deviation wider, but
+   * that could be mathematically "more correct".
+   */
+  boolean rebalanceEvaluateZeroes = false;
+
+  /**
+   * When rebalancing, this property indicates how many standard deviations above the average
+   * assignment count will be considered over-assigned. Those Envoys that are over-assigned will
+   * have bound monitors reassigned to other Envoys in the zone.
+   */
+  float rebalanceStandardDeviations = 1.0f;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
@@ -40,14 +40,30 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
           + " and b.envoyId is null")
   List<BoundMonitor> findAllWithoutEnvoyInPrivateZone(String tenantId, String zoneName);
 
+  /**
+   * Queries for all of the bound monitors assigned to the given envoy in a public zone.
+   * @param zoneName name of the public zone
+   * @param envoyId the envoy ID
+   * @param pageable if non-null, applies paging limits on the query
+   * @return bound monitors assigned to envoy in zone
+   */
   @Query("select b from BoundMonitor b where b.zoneName = :zoneName and b.envoyId = :envoyId")
-  List<BoundMonitor> findAllWithEnvoyInPublicZone(String zoneName, String envoyId);
+  List<BoundMonitor> findWithEnvoyInPublicZone(String zoneName, String envoyId, Pageable pageable);
 
+  /**
+   * Queries for all of the bound monitors assigned to the given envoy in a private zone.
+   * @param tenantId the tenant owning the private zone
+   * @param zoneName name of the private zone
+   * @param envoyId the envoy ID
+   * @param pageable if non-null, applies paging limits on the query
+   * @return bound monitors assigned to envoy in zone
+   */
   @Query("select b from BoundMonitor b"
       + " where b.monitor.tenantId = :tenantId"
       + " and b.zoneName = :zoneName"
       + " and b.envoyId = :envoyId")
-  List<BoundMonitor> findAllWithEnvoyInPrivateZone(String tenantId, String zoneName, String envoyId);
+  List<BoundMonitor> findWithEnvoyInPrivateZone(String tenantId, String zoneName, String envoyId,
+                                                Pageable pageable);
 
   @Query("select distinct b.resourceId from BoundMonitor b where b.monitor.id = :monitorId")
   Set<String> findResourceIdsBoundToMonitor(UUID monitorId);

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -70,6 +70,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -432,6 +433,7 @@ public class MonitorManagement {
             return createPublicZone(zone);
         }
         else {
+            Assert.notNull(tenantId, "Private zones require a tenantId");
             return createPrivateZone(tenantId, zone);
         }
     }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -20,6 +20,7 @@ import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPrivat
 import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPublicZone;
 
 import com.google.common.collect.Streams;
+import com.google.common.math.Stats;
 import com.rackspace.salus.monitor_management.config.ZonesProperties;
 import com.rackspace.salus.monitor_management.entities.BoundMonitor;
 import com.rackspace.salus.monitor_management.entities.Monitor;
@@ -27,15 +28,16 @@ import com.rackspace.salus.monitor_management.entities.Zone;
 import com.rackspace.salus.monitor_management.repositories.BoundMonitorRepository;
 import com.rackspace.salus.monitor_management.repositories.MonitorRepository;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.monitor_management.web.model.ZoneAssignmentCount;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
+import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
-import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.Resource;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
@@ -51,6 +53,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -61,6 +64,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -112,6 +116,14 @@ public class MonitorManagement {
         this.zoneManagement = zoneManagement;
         this.zonesProperties = zonesProperties;
         this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * FOR UNIT TESTING, provides the zone properties
+     * @return the {@link ZonesProperties} used by this service
+     */
+    ZonesProperties getZonesProperties() {
+        return zonesProperties;
     }
 
     /**
@@ -321,6 +333,12 @@ public class MonitorManagement {
         }
     }
 
+    /**
+     * Evaluates unassigned {@link BoundMonitor}s in the given zone and assigns those to
+     * least-bound envoys.
+     * @param zoneTenantId for private zones, the tenant owning the zone, or <code>null</code> for public zones
+     * @param zoneName the zone name
+     */
     public void handleNewEnvoyInZone(@Nullable String zoneTenantId, String zoneName) {
         log.debug("Locating bound monitors without assigned envoy with zoneName={} and zoneTenantId={}",
             zoneName, zoneTenantId);
@@ -367,16 +385,18 @@ public class MonitorManagement {
 
         final List<BoundMonitor> boundToPrev;
         if ( resolvedZone.isPublicZone()) {
-            boundToPrev = boundMonitorRepository.findAllWithEnvoyInPublicZone(
+            boundToPrev = boundMonitorRepository.findWithEnvoyInPublicZone(
                 zoneName,
-                fromEnvoyId
+                fromEnvoyId,
+                null
             );
         }
         else {
-            boundToPrev = boundMonitorRepository.findAllWithEnvoyInPrivateZone(
+            boundToPrev = boundMonitorRepository.findWithEnvoyInPrivateZone(
                 tenantId,
                 zoneName,
-                fromEnvoyId
+                fromEnvoyId,
+                null
             );
         }
 
@@ -389,7 +409,7 @@ public class MonitorManagement {
             boundMonitorRepository.saveAll(boundToPrev);
 
 
-            zoneStorage.incrementBoundCount(
+            zoneStorage.changeBoundCount(
                 createPrivateZone(tenantId, zoneName),
                 resourceId,
                 boundToPrev.size()
@@ -949,11 +969,12 @@ public class MonitorManagement {
     /**
      * Unassigns the old envoy from all relevant bound monitors,
      * then attempts to reassign them to a different envoy if one is available.
-     * @param zoneTenantId The tenantId of the resolved zone.
+     * @param zoneTenantId The tenantId of the resolved zone
+     *  or <code>null</code> if it is a public zone.
      * @param zoneName The name of the resolved zone.
      * @param envoyId The envoy id that has disconnected.
      */
-    public void handleExpiredEnvoy(String zoneTenantId, String zoneName, String envoyId) {
+    public void handleExpiredEnvoy(@Nullable String zoneTenantId, String zoneName, String envoyId) {
         log.debug("Reassigning bound monitors for disconnected envoy={} with zoneName={} and zoneTenantId={}",
             envoyId, zoneName, zoneTenantId);
         List<BoundMonitor> boundMonitors = boundMonitorRepository.findAllByEnvoyId(envoyId);
@@ -966,5 +987,96 @@ public class MonitorManagement {
 
         boundMonitorRepository.saveAll(boundMonitors);
         handleNewEnvoyInZone(zoneTenantId, zoneName);
+    }
+
+    public CompletableFuture<List<ZoneAssignmentCount>> getZoneAssignmentCounts(
+        @Nullable String zoneTenantId, String zoneName) {
+
+        final ResolvedZone zone = resolveZone(zoneTenantId, zoneName);
+
+        return zoneStorage.getZoneBindingCounts(zone)
+            .thenApply(bindingCounts ->
+                bindingCounts.entrySet().stream()
+                    .map(entry ->
+                        new ZoneAssignmentCount()
+                            .setResourceId(entry.getKey().getResourceId())
+                            .setEnvoyId(entry.getKey().getEnvoyId())
+                            .setAssignments(entry.getValue()))
+                    .collect(Collectors.toList()));
+    }
+
+    public CompletableFuture<Void> rebalanceZone(@Nullable String zoneTenantId, String zoneName) {
+        final ResolvedZone zone = resolveZone(zoneTenantId, zoneName);
+
+        return zoneStorage.getZoneBindingCounts(zone)
+            .thenAccept(bindingCounts ->
+                rebalanceWithZoneBindingCounts(zone, bindingCounts)
+            );
+    }
+
+    private void rebalanceWithZoneBindingCounts(ResolvedZone zone,
+                                                Map<EnvoyResourcePair, Integer> bindingCounts) {
+        if (bindingCounts.size() <= 1) {
+            // nothing to rebalance if only one or none envoys in zone
+            return;
+        }
+
+        log.debug("Rebalancing zone={} given bindingCounts={}", zone, bindingCounts);
+
+        final List<Integer> values = bindingCounts.values().stream()
+            .filter(value ->
+                zonesProperties.isRebalanceEvaluateZeroes() || value != 0)
+            .collect(Collectors.toList());
+
+        @SuppressWarnings("UnstableApiUsage")
+        final Stats stats = Stats.of(values);
+
+        final double stddev = stats.populationStandardDeviation();
+        final double avg = stats.mean();
+        final double threshold = avg + stddev * zonesProperties.getRebalanceStandardDeviations();
+        // round up to be lean towards slightly less reassignments
+        final int avgInt = (int) Math.ceil(avg);
+
+        final List<BoundMonitor> overAssigned = new ArrayList<>();
+
+        for (Entry<EnvoyResourcePair, Integer> entry : bindingCounts.entrySet()) {
+            if (entry.getValue() > threshold) {
+
+                // pick off enough bound monitors to bring this one down to average
+                final int amountToUnassign = entry.getValue() - avgInt;
+                final PageRequest limit = PageRequest.of(0, amountToUnassign);
+
+                final List<BoundMonitor> boundMonitors;
+                if (zone.isPublicZone()) {
+                    boundMonitors = boundMonitorRepository.findWithEnvoyInPublicZone(
+                        zone.getName(), entry.getKey().getEnvoyId(), limit
+                    );
+                }
+                else {
+                    boundMonitors = boundMonitorRepository.findWithEnvoyInPrivateZone(
+                        zone.getTenantId(), zone.getName(), entry.getKey().getEnvoyId(), limit
+                    );
+                }
+
+                overAssigned.addAll(boundMonitors);
+
+                // decrease the assignment count of bound monitors
+                zoneStorage.changeBoundCount(
+                    zone, entry.getKey().getResourceId(), -amountToUnassign
+                );
+            }
+        }
+
+        log.debug("Rebalancing boundMonitors={} in zone={}", overAssigned, zone);
+
+        // tell previous envoys to stop unassigned monitors
+        sendMonitorBoundEvents(extractEnvoyIds(overAssigned));
+
+        // "unassign" the bound monitors
+        overAssigned.forEach(boundMonitor -> boundMonitor.setEnvoyId(null));
+        boundMonitorRepository.saveAll(overAssigned);
+
+        // ...and then this will "re-assign" the bound monitors and send out new bound events
+        handleNewEnvoyInZone(zone.getTenantId(), zone.getName());
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
@@ -21,22 +21,21 @@ import com.rackspace.salus.monitor_management.errors.ZoneAlreadyExists;
 import com.rackspace.salus.monitor_management.errors.ZoneDeletionNotAllowed;
 import com.rackspace.salus.monitor_management.repositories.MonitorRepository;
 import com.rackspace.salus.monitor_management.repositories.ZoneRepository;
-import com.rackspace.salus.monitor_management.web.model.ZoneUpdate;
+import com.rackspace.salus.monitor_management.web.model.ZoneCreatePrivate;
 import com.rackspace.salus.monitor_management.web.model.ZoneCreatePublic;
+import com.rackspace.salus.monitor_management.web.model.ZoneUpdate;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.model.NotFoundException;
-import com.rackspace.salus.monitor_management.web.model.ZoneCreatePrivate;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.PropertyMapper;
-import org.springframework.stereotype.Service;
-
-import javax.validation.Valid;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import javax.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
@@ -312,7 +311,16 @@ public class ZoneManagement {
      * @param zoneName The unique value representing the zone.
      * @return True if the zone exists on the tenant, otherwise false.
      */
-    private boolean exists(String tenantId, String zoneName) {
+    public boolean exists(String tenantId, String zoneName) {
         return zoneRepository.existsByTenantIdAndName(tenantId, zoneName);
+    }
+
+    /**
+     * Tests whether the public zone exists.
+     * @param zoneName The unique value representing the zone.
+     * @return True if the zone exists, otherwise false.
+     */
+    public boolean publicZoneExists(String zoneName) {
+        return exists(ResolvedZone.PUBLIC, zoneName);
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -93,7 +93,7 @@ public class ZoneApiController implements ZoneApi {
             .toDTO();
     }
 
-    @GetMapping("/tenant/{tenantId}/zoneAssignmentCounts/{name}")
+    @GetMapping("/tenant/{tenantId}/zone-assignment-counts/{name}")
     @ApiOperation(value = "Gets assignment counts of monitors to poller-envoys in the private zone")
     public CompletableFuture<List<ZoneAssignmentCount>> getPrivateZoneAssignmentCounts(
         @PathVariable String tenantId, @PathVariable String name) {
@@ -101,7 +101,7 @@ public class ZoneApiController implements ZoneApi {
         return monitorManagement.getZoneAssignmentCounts(tenantId, name);
     }
 
-    @GetMapping("/admin/zoneAssignmentCounts/{name}")
+    @GetMapping("/admin/zone-assignment-counts/{name}")
     @ApiOperation(value = "Gets assignment counts of monitors to poller-envoys in the public zone")
     public CompletableFuture<List<ZoneAssignmentCount>> getPublicZoneAssignmentCounts(
         @PathVariable String name) {
@@ -140,7 +140,7 @@ public class ZoneApiController implements ZoneApi {
         return zoneManagement.updatePublicZone(name, zone).toDTO();
     }
 
-    @PostMapping("/tenant/{tenantId}/rebalanceZone/{name}")
+    @PostMapping("/tenant/{tenantId}/rebalance-zone/{name}")
     @ApiOperation(value = "Rebalances a private zone")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void rebalancePrivateZone(@PathVariable String tenantId,
@@ -152,7 +152,7 @@ public class ZoneApiController implements ZoneApi {
             .join();
     }
 
-    @PostMapping("/admin/rebalanceZone/{name}")
+    @PostMapping("/admin/rebalance-zone/{name}")
     @ApiOperation(value = "Rebalances a public zone")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void rebalancePublicZone(@PathVariable String name) {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -80,7 +80,6 @@ public class ZoneApiController implements ZoneApi {
     @ApiOperation(value = "Gets specific zone by tenant id and zone name")
     @JsonView(View.Public.class)
     public ZoneDTO getByZoneName(@PathVariable String tenantId, @PathVariable String name) {
-        // NOTE name doesn't need to be constrained to public or private since either can be queried here
         Optional<Zone> zone = zoneManagement.getPrivateZone(tenantId, name);
         return zone.orElseThrow(() -> new NotFoundException(String.format("No zone found named %s on tenant %s",
                 name, tenantId)))
@@ -90,7 +89,7 @@ public class ZoneApiController implements ZoneApi {
     @GetMapping("/admin/zones/{name}")
     @ApiOperation(value = "Gets specific public zone by name")
     @JsonView(View.Admin.class)
-    public ZoneDTO getPublicZone(@PathVariable @PublicZoneName String name) {
+    public ZoneDTO getPublicZone(@PathVariable String name) {
         Optional<Zone> zone = zoneManagement.getPublicZone(name);
         return zone.orElseThrow(() -> new NotFoundException(String.format("No public zone found named %s",
             name)))
@@ -141,17 +140,14 @@ public class ZoneApiController implements ZoneApi {
     @PutMapping("/tenant/{tenantId}/zones/{name}")
     @ApiOperation(value = "Updates a specific private zone for the tenant")
     @JsonView(View.Public.class)
-    public ZoneDTO update(@PathVariable String tenantId,
-                          @PathVariable @PrivateZoneName String name,
-                          @Valid @RequestBody ZoneUpdate zone) {
+    public ZoneDTO update(@PathVariable String tenantId, @PathVariable String name, @Valid @RequestBody ZoneUpdate zone) {
         return zoneManagement.updatePrivateZone(tenantId, name, zone).toDTO();
     }
 
     @PutMapping("/admin/zones/{name}")
     @ApiOperation(value = "Updates a specific public zone")
     @JsonView(View.Admin.class)
-    public ZoneDTO update(@PathVariable @PublicZoneName String name,
-                          @Valid @RequestBody ZoneUpdate zone) {
+    public ZoneDTO update(@PathVariable String name, @Valid @RequestBody ZoneUpdate zone) {
         return zoneManagement.updatePublicZone(name, zone).toDTO();
     }
 
@@ -182,7 +178,7 @@ public class ZoneApiController implements ZoneApi {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @ApiOperation(value = "Deletes a specific private zone for the tenant")
     @JsonView(View.Public.class)
-    public void delete(@PathVariable String tenantId, @PathVariable @PrivateZoneName String name) {
+    public void delete(@PathVariable String tenantId, @PathVariable String name) {
         zoneManagement.removePrivateZone(tenantId, name);
     }
 
@@ -190,7 +186,7 @@ public class ZoneApiController implements ZoneApi {
     @ApiOperation(value = "Deletes a specific public zone")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @JsonView(View.Admin.class)
-    public void delete(@PathVariable @PublicZoneName String name) {
+    public void delete(@PathVariable String name) {
         zoneManagement.removePublicZone(name);
     }
 
@@ -207,8 +203,7 @@ public class ZoneApiController implements ZoneApi {
     @GetMapping("/tenant/{tenantId}/monitorsByZone/{zone}")
     @ApiOperation(value = "Gets all monitors in a given zone for a specific tenant")
     @JsonView(View.Public.class)
-    public List<MonitorDTO> getMonitorsForZone(@PathVariable String tenantId,
-                                               @PathVariable @PrivateZoneName String zone) {
+    public List<MonitorDTO> getMonitorsForZone(@PathVariable String tenantId, @PathVariable String zone) {
         return zoneManagement.getMonitorsForZone(tenantId, zone).stream()
             .map(Monitor::toDTO)
             .collect(Collectors.toList());

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/RebalanceResult.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/RebalanceResult.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model;
+
+import lombok.Data;
+
+/**
+ * Encapsulates the result of a rebalance operation.
+ */
+@Data
+public class RebalanceResult {
+
+  /**
+   * The number of bound monitors that were re-assigned during rebalancing
+   */
+  int reassigned;
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneAssignmentCount.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneAssignmentCount.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model;
+
+import lombok.Data;
+
+@Data
+public class ZoneAssignmentCount {
+  String resourceId;
+  String envoyId;
+  int assignments;
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePrivate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePrivate.java
@@ -16,19 +16,21 @@
 package com.rackspace.salus.monitor_management.web.model;
 
 import com.rackspace.salus.monitor_management.web.model.validator.ValidCidrList;
+import com.rackspace.salus.telemetry.etcd.types.PrivateZoneName;
+import java.io.Serializable;
 import java.util.List;
-import lombok.Data;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
+import lombok.Data;
 import org.hibernate.validator.constraints.NotBlank;
-import java.io.Serializable;
 
 @Data
 public class ZoneCreatePrivate implements Serializable {
 
     @NotBlank
     @Pattern(regexp = "^[A-Za-z0-9_]+$", message = "Only alphanumeric and underscore characters can be used")
+    @PrivateZoneName
     String name;
 
     String provider;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePublic.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePublic.java
@@ -16,20 +16,22 @@
 package com.rackspace.salus.monitor_management.web.model;
 
 import com.rackspace.salus.monitor_management.web.model.validator.ValidCidrList;
+import com.rackspace.salus.telemetry.etcd.types.PublicZoneName;
+import java.io.Serializable;
 import java.util.List;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 import lombok.Data;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import org.hibernate.validator.constraints.NotBlank;
-import java.io.Serializable;
 
 @Data
 public class ZoneCreatePublic implements Serializable {
 
   @NotBlank
   @Pattern(regexp = "^[A-Za-z0-9_/]+$", message = "Only alphanumeric, underscores, and slashes can be used")
+  @PublicZoneName
   String name;
 
   @NotBlank

--- a/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepositoryTest.java
@@ -86,14 +86,39 @@ public class BoundMonitorRepositoryTest {
     save(monitor, "public/1", "r-5", "e-1");
     save(monitor, "public/2", "r-6", "e-1");
 
-    final List<BoundMonitor> t1z1 = repository.findAllWithEnvoyInPrivateZone(MONITOR_TENANT, "z-1", "e-1");
+    final List<BoundMonitor> t1z1 = repository.findWithEnvoyInPrivateZone(
+        MONITOR_TENANT, "z-1", "e-1", null);
     assertThat(t1z1, hasSize(2));
     assertThat(t1z1.get(0).getResourceId(), equalTo("r-2"));
     assertThat(t1z1.get(1).getResourceId(), equalTo("r-3"));
 
-    final List<BoundMonitor> publicResults = repository.findAllWithEnvoyInPublicZone("public/1", "e-1");
+    final List<BoundMonitor> publicResults = repository.findWithEnvoyInPublicZone("public/1", "e-1", null);
     assertThat(publicResults, hasSize(1));
     assertThat(publicResults.get(0).getResourceId(), equalTo("r-5"));
+  }
+
+  @Test
+  public void testFindOnesWithEnvoy_paging() {
+    final Monitor monitor = createMonitor(MONITOR_TENANT, ConfigSelectorScope.LOCAL);
+
+    save(monitor, "z-1", "r-1", "e-1");
+    save(monitor, "z-1", "r-2", "e-1");
+    save(monitor, "z-1", "r-3", "e-1");
+    save(monitor, "public/1", "r-4", "e-1");
+    save(monitor, "public/1", "r-5", "e-1");
+    save(monitor, "public/1", "r-6", "e-1");
+
+    final List<BoundMonitor> t1z1 = repository.findWithEnvoyInPrivateZone(
+        MONITOR_TENANT, "z-1", "e-1", PageRequest.of(0, 2));
+    assertThat(t1z1, hasSize(2));
+    assertThat(t1z1.get(0).getResourceId(), equalTo("r-1"));
+    assertThat(t1z1.get(1).getResourceId(), equalTo("r-2"));
+
+    final List<BoundMonitor> publicResults = repository.findWithEnvoyInPublicZone(
+        "public/1", "e-1", PageRequest.of(0, 2));
+    assertThat(publicResults, hasSize(2));
+    assertThat(publicResults.get(0).getResourceId(), equalTo("r-4"));
+    assertThat(publicResults.get(1).getResourceId(), equalTo("r-5"));
   }
 
   private void save(Monitor monitor, String zone, String resource, String envoyId) {

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -2237,9 +2237,12 @@ public class MonitorManagementTest {
 
         // EXECUTE
 
-        monitorManagement.rebalanceZone(null, "public/west").join();
+        final Integer reassigned =
+            monitorManagement.rebalanceZone(null, "public/west").join();
 
         // VERIFY
+
+        assertThat(reassigned, equalTo(2));
 
         final ResolvedZone zone = createPublicZone("public/west");
         verify(zoneStorage).getZoneBindingCounts(zone);
@@ -2316,9 +2319,12 @@ public class MonitorManagementTest {
 
         // EXECUTE
 
-        monitorManagement.rebalanceZone(null, "public/west").join();
+        final Integer reassigned =
+            monitorManagement.rebalanceZone(null, "public/west").join();
 
         // VERIFY
+
+        assertThat(reassigned, equalTo(3));
 
         final ResolvedZone zone = createPublicZone("public/west");
         verify(zoneStorage).getZoneBindingCounts(zone);
@@ -2351,6 +2357,29 @@ public class MonitorManagementTest {
             new BoundMonitor().setEnvoyId("e-least").setMonitor(e3bound.get(1).getMonitor()),
             new BoundMonitor().setEnvoyId("e-least").setMonitor(e3bound.get(2).getMonitor())
         ));
+
+        verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement,
+            zoneStorage, monitorEventProducer, resourceApi
+        );
+    }
+
+    @Test
+    public void testRebalanceZone_emptyZone() {
+        when(zoneStorage.getZoneBindingCounts(any()))
+            .thenReturn(CompletableFuture.completedFuture(
+                Collections.emptyMap()
+            ));
+
+        // EXECUTE
+
+        final Integer reassigned =
+            monitorManagement.rebalanceZone("t-1", "z-1").join();
+
+        // VERIFY
+
+        assertThat(reassigned, equalTo(0));
+
+        verify(zoneStorage).getZoneBindingCounts(ResolvedZone.createPrivateZone("t-1", "z-1"));
 
         verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement,
             zoneStorage, monitorEventProducer, resourceApi

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -1,9 +1,22 @@
 package com.rackspace.salus.monitor_management.web.controller;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.monitor_management.entities.Zone;
 import com.rackspace.salus.monitor_management.errors.ZoneAlreadyExists;
 import com.rackspace.salus.monitor_management.errors.ZoneDeletionNotAllowed;
+import com.rackspace.salus.monitor_management.services.MonitorManagement;
 import com.rackspace.salus.monitor_management.services.ZoneManagement;
 import com.rackspace.salus.monitor_management.web.model.ZoneCreatePrivate;
 import com.rackspace.salus.monitor_management.web.model.ZoneCreatePublic;
@@ -12,9 +25,12 @@ import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.Random;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
@@ -30,20 +46,6 @@ import org.springframework.util.FileCopyUtils;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Optional;
-import java.util.Random;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
-import static org.mockito.ArgumentMatchers.any;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 @RunWith(SpringRunner.class)
 @WebMvcTest(ZoneApiController.class)
 public class ZoneApiControllerTest {
@@ -53,6 +55,9 @@ public class ZoneApiControllerTest {
 
     @MockBean
     ZoneManagement zoneManagement;
+
+    @MockBean
+    MonitorManagement monitorManagement;
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/src/test/resources/ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json
+++ b/src/test/resources/ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json
@@ -1,0 +1,7 @@
+[
+  {
+    "resourceId": "r-1",
+    "envoyId": "e-1",
+    "assignments": 3
+  }
+]


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-294

# What

Active Envoys within a zone are assigned new bound monitors in a least-loaded way; however, if new Envoys are added later then they will be potentially left unutilized or underutilized.

# How

The rebalancing operation acts upon a given public/private zone. It will gather the assignment counts of all the envoy-resources in the zone and calculate the statistics over those counts. Specifically, the average (aka mean) and standard deviation calculations are of primary interest.

The algorithm looks for envoys that are outliers by computing a threshold that is

    threshold = avg + rebalanceStandardDeviations * stddev

Any envoys that have more assigned that `threshold` will have enough bound monitors unassigned such that it would end up with `avg` bound monitors assigned. After all of the un-assignments are executed, the pre-existing `handleNewEnvoyInZone` is used to trigger the re-assignment of those newly unassigned bindings to the least-loaded Envoys. In the case where new Envoys are active in the zone, the idea is that those Envoys are the ones that get the new assignments. 

**NOTE** more analysis might be needed to ensure that we don't end up with two clumps of Envoys: non-zero, but balanced and zero-assigned Envoys.

## How to test

Unit tests were updated and added.

## Requires

https://github.com/racker/salus-telemetry-etcd-adapter/pull/38

## TODO

- [x] After https://github.com/racker/salus-telemetry-monitor-management/pull/37 is merged, the APIs need to be updated to use the ant-pattern logic to allow for zone names with slashes.