### PR TITLE
Add telegraf net_response and net plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
       <version>1.9.3</version>
     </dependency>
     <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+      <version>1.6</version>
+    </dependency>
+    <dependency>
         <groupId>com.rackspace.salus</groupId>
         <artifactId>salus-telemetry-etcd-adapter</artifactId>
         <version>0.1.0-SNAPSHOT</version>

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalPlugin.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalPlugin.java
@@ -20,7 +20,12 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.rackspace.salus.monitor_management.web.model.telegraf.*;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Cpu;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Disk;
+import com.rackspace.salus.monitor_management.web.model.telegraf.DiskIo;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Mem;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Net;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Procstat;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonSubTypes({
@@ -28,6 +33,7 @@ import com.rackspace.salus.monitor_management.web.model.telegraf.*;
     @Type(name = "disk", value = Disk.class),
     @Type(name = "diskio", value = DiskIo.class),
     @Type(name = "mem", value = Mem.class),
+    @Type(name = "net", value = Net.class),
     @Type(name = "procstat", value = Procstat.class)
 })
 public abstract class LocalPlugin {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
@@ -20,15 +20,17 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.rackspace.salus.monitor_management.web.model.telegraf.HttpResponse;
+import com.rackspace.salus.monitor_management.web.model.telegraf.NetResponse;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
 import com.rackspace.salus.monitor_management.web.model.telegraf.X509Cert;
-import com.rackspace.salus.monitor_management.web.model.telegraf.HttpResponse;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonSubTypes({
     @Type(name = "ping", value = Ping.class),
     @Type(name = "x509_cert", value = X509Cert.class),
-    @Type(name = "http_response", value = HttpResponse.class)
+    @Type(name = "http_response", value = HttpResponse.class),
+    @Type(name = "net_response", value = NetResponse.class)
 })
 public abstract class RemotePlugin {
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
@@ -20,13 +20,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.validator.ValidGoDuration;
 import com.rackspace.salus.telemetry.model.AgentType;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
+import java.util.Map;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
-import java.util.Map;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
@@ -35,7 +35,7 @@ public class HttpResponse extends RemotePlugin {
   @NotEmpty
   String address;
   String httpProxy;
-  @Pattern(regexp = "([0-9]+)(h|m|s|ms)", message = "invalid duration")
+  @ValidGoDuration
   String responseTimeout;
   @Pattern(regexp = "GET|PUT|POST|DELETE|HEAD|OPTIONS|PATCH|TRACE", message = "invalid http method")
   String method;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.telegraf;
+
+import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.telemetry.model.AgentType;
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data @EqualsAndHashCode(callSuper = false)
+@ApplicableAgentType(AgentType.TELEGRAF)
+public class Net extends LocalPlugin {
+  List<String> interfaces;
+  Boolean ignoreProtocolStats;
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
@@ -21,22 +21,35 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidGoDuration;
+import com.rackspace.salus.monitor_management.web.model.validator.ValidHostAndPort;
 import com.rackspace.salus.telemetry.model.AgentType;
-import java.util.List;
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @JsonInclude(Include.NON_NULL)
-public class X509Cert extends RemotePlugin {
-  @NotEmpty
-  List<String> sources;
+public class NetResponse extends RemotePlugin {
+
+  public enum Protocol {
+    udp, tcp
+  }
+
+  @NotNull
+  Protocol protocol;
+
+  @NotNull
+  @ValidHostAndPort
+  String address;
+
   @ValidGoDuration
   String timeout;
-  String tlsCa;
-  String tlsCert;
-  String tlsKey;
-  boolean insecureSkipVerify;
+
+  @ValidGoDuration
+  String readTimeout;
+
+  String send;
+
+  String expect;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidGoDuration.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidGoDuration.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.Pattern;
+
+/**
+ * Indicates that the string is a simplified Go duration formed as an integer value followed by a
+ * time unit suffix of "ms", "s", "m", or "h".
+ */
+@Pattern(regexp = "([0-9]+)(h|m|s|ms)", message = "invalid duration")
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Constraint(validatedBy = {}/*composite*/)
+public @interface ValidGoDuration {
+  String message() default "invalid duration";
+
+  Class<?>[] groups() default { };
+
+  Class<? extends Payload>[] payload() default { };
+
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidHostAndPort.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidHostAndPort.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Indicates that a string must be of the form host:port where host is a valid IP address or
+ * domain name and port is a valid integer.
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Constraint(validatedBy = ValidHostAndPortValidator.class)
+public @interface ValidHostAndPort {
+  String message() default "Must be a host:port";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidHostAndPortValidator.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidHostAndPortValidator.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.validator;
+
+import com.google.common.net.HostAndPort;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.validator.routines.DomainValidator;
+import org.apache.commons.validator.routines.InetAddressValidator;
+
+@Slf4j
+public class ValidHostAndPortValidator implements ConstraintValidator<ValidHostAndPort, String> {
+   public void initialize(ValidHostAndPort constraint) {
+   }
+
+   public boolean isValid(String value, ConstraintValidatorContext context) {
+      if (value == null) {
+         // to allow for optional fields
+         return true;
+      }
+
+      try {
+         // throws if unable to parse
+         final HostAndPort hostAndPort = HostAndPort.fromString(value);
+         // throws if port wasn't included in parsed
+         final int port = hostAndPort.getPort();
+
+         // but the parsing above doesn't validate the actual IP/host part
+         if (!InetAddressValidator.getInstance().isValid(hostAndPort.getHost()) &&
+               !DomainValidator.getInstance(true).isValid(hostAndPort.getHost())) {
+            log.trace("Value '{}' is not a valid IP address or domain", value);
+            return false;
+         }
+
+         log.debug("Validated '{}' as {}:{}", value, hostAndPort.getHost(), port);
+      } catch (IllegalArgumentException|IllegalStateException e) {
+         log.trace("Failed to validate '{}'", value, e);
+         return false;
+      }
+      return true;
+   }
+
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/TestUtils.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/TestUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.FileCopyUtils;
+
+public class TestUtils {
+
+  public static String readContent(String resource) throws IOException {
+    try (InputStream in = new ClassPathResource(resource).getInputStream()) {
+      return FileCopyUtils.copyToString(new InputStreamReader(in));
+    }
+  }
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.monitor_management.services;
 
+import static com.rackspace.salus.monitor_management.TestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -28,13 +29,24 @@ import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
-import com.rackspace.salus.monitor_management.web.model.telegraf.*;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Cpu;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Disk;
+import com.rackspace.salus.monitor_management.web.model.telegraf.DiskIo;
+import com.rackspace.salus.monitor_management.web.model.telegraf.HttpResponse;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Mem;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Procstat;
+import com.rackspace.salus.monitor_management.web.model.telegraf.X509Cert;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import javax.validation.ConstraintViolation;
 import org.json.JSONException;
 import org.junit.Assert;
@@ -45,9 +57,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.util.FileCopyUtils;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 @RunWith(SpringRunner.class)
@@ -250,7 +260,7 @@ public class MonitorConversionServiceTest {
     // no config to validate
   }
 
- @Test
+  @Test
   public void convertFromInput_mem() throws JSONException, IOException {
     // NOTE: this unit test is purposely abbreviated compared convertFromInput
 
@@ -597,11 +607,5 @@ public class MonitorConversionServiceTest {
     final Procstat procstatPlugin = (Procstat) plugin;
     assertThat(procstatPlugin.getPidFile()).contains("/path/to/file");
     assertThat(procstatPlugin.getProcessName()).contains("thisIsAProcess");
-  }
-
-  private static String readContent(String resource) throws IOException {
-    try (InputStream in = new ClassPathResource(resource).getInputStream()) {
-      return FileCopyUtils.copyToString(new InputStreamReader(in));
-    }
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetConversionTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.telegraf;
+
+import static com.rackspace.salus.monitor_management.TestUtils.readContent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rackspace.salus.monitor_management.entities.Monitor;
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
+import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
+import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@JsonTest
+@Import({MonitorConversionService.class})
+public class NetConversionTest {
+  @Configuration
+  public static class TestConfig { }
+
+  @Autowired
+  MonitorConversionService conversionService;
+
+  @Test
+  public void convertFromInput() throws JSONException, IOException {
+    final Map<String, String> labels = new HashMap<>();
+    labels.put("os", "linux");
+
+    final Net plugin = new Net()
+        .setInterfaces(Arrays.asList("eth*", "enp0s[0-1]"))
+        .setIgnoreProtocolStats(true);
+
+    final LocalMonitorDetails details = new LocalMonitorDetails()
+        .setPlugin(plugin);
+
+    final DetailedMonitorInput input = new DetailedMonitorInput()
+        .setLabelSelector(labels)
+        .setDetails(details);
+    final MonitorCU result = conversionService.convertFromInput(input);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
+    assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.LOCAL);
+    final String content = readContent("/ConversionTests/net.json");
+    JSONAssert.assertEquals(content, result.getContent(), true);
+  }
+
+  @Test
+  public void convertToOutput() throws IOException {
+    Map<String, String> labels = new HashMap<>();
+    labels.put("os", "linux");
+
+    final String content = readContent("/ConversionTests/net.json");
+
+    final UUID monitorId = UUID.randomUUID();
+
+    Monitor monitor = new Monitor()
+        .setId(monitorId)
+        .setAgentType(AgentType.TELEGRAF)
+        .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setLabelSelector(labels)
+        .setContent(content);
+
+    final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(monitorId.toString());
+    assertThat(result.getDetails()).isInstanceOf(LocalMonitorDetails.class);
+
+    final LocalMonitorDetails monitorDetails = (LocalMonitorDetails) result.getDetails();
+    final LocalPlugin plugin = monitorDetails.getPlugin();
+    assertThat(plugin).isInstanceOf(Net.class);
+
+    final Net expected = new Net()
+        .setInterfaces(Arrays.asList("eth*", "enp0s[0-1]"))
+        .setIgnoreProtocolStats(true);
+    assertThat(plugin).isEqualTo(expected);
+  }
+
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponseConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponseConversionTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.telegraf;
+
+import static com.rackspace.salus.monitor_management.TestUtils.readContent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rackspace.salus.monitor_management.entities.Monitor;
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
+import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
+import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.telegraf.NetResponse.Protocol;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@JsonTest
+@Import({MonitorConversionService.class})
+public class NetResponseConversionTest {
+  @Configuration
+  public static class TestConfig { }
+
+  @Autowired
+  MonitorConversionService conversionService;
+
+  @Test
+  public void convertFromInput() throws JSONException, IOException {
+    final Map<String, String> labels = new HashMap<>();
+    labels.put("os", "linux");
+
+    final NetResponse plugin = new NetResponse()
+        .setAddress("localhost:80")
+        .setProtocol(Protocol.tcp)
+        .setTimeout("5s")
+        .setReadTimeout("10s")
+        .setSend("request")
+        .setExpect("response");
+
+    final RemoteMonitorDetails details = new RemoteMonitorDetails()
+        .setPlugin(plugin);
+
+    final DetailedMonitorInput input = new DetailedMonitorInput()
+        .setLabelSelector(labels)
+        .setDetails(details);
+    final MonitorCU result = conversionService.convertFromInput(input);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
+    assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.REMOTE);
+    final String content = readContent("/ConversionTests/net_response.json");
+    JSONAssert.assertEquals(content, result.getContent(), true);
+  }
+
+  @Test
+  public void convertToOutput() throws IOException {
+    Map<String, String> labels = new HashMap<>();
+    labels.put("os", "linux");
+
+    final String content = readContent("/ConversionTests/net_response.json");
+
+    final UUID monitorId = UUID.randomUUID();
+
+    Monitor monitor = new Monitor()
+        .setId(monitorId)
+        .setAgentType(AgentType.TELEGRAF)
+        .setSelectorScope(ConfigSelectorScope.REMOTE)
+        .setLabelSelector(labels)
+        .setContent(content);
+
+    final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(monitorId.toString());
+    assertThat(result.getDetails()).isInstanceOf(RemoteMonitorDetails.class);
+
+    final RemoteMonitorDetails monitorDetails = (RemoteMonitorDetails) result.getDetails();
+    final RemotePlugin remotePlugin = monitorDetails.getPlugin();
+    assertThat(remotePlugin).isInstanceOf(NetResponse.class);
+
+    final NetResponse expected = new NetResponse()
+        .setAddress("localhost:80")
+        .setProtocol(Protocol.tcp)
+        .setTimeout("5s")
+        .setReadTimeout("10s")
+        .setSend("request")
+        .setExpect("response");
+    assertThat(remotePlugin).isEqualTo(expected);
+  }
+
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidGoDurationTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidGoDurationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.validator;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+public class ValidGoDurationTest {
+  private LocalValidatorFactoryBean validatorFactoryBean;
+
+  @AllArgsConstructor
+  static class WithDuration {
+    @ValidGoDuration
+    String duration;
+  }
+
+  @Before
+  public void setUp() {
+    validatorFactoryBean = new LocalValidatorFactoryBean();
+    validatorFactoryBean.afterPropertiesSet();
+  }
+
+  @Test
+  public void testValid() {
+    final WithDuration obj = new WithDuration("5s");
+
+    final Set<ConstraintViolation<WithDuration>> results = validatorFactoryBean.validate(obj);
+
+    assertThat(results, hasSize(0));
+  }
+
+  @Test
+  public void testInvalid_wrongUnits() {
+    final WithDuration obj = new WithDuration("5d");
+
+    final Set<ConstraintViolation<WithDuration>> results = validatorFactoryBean.validate(obj);
+
+    assertInvalidDuration(results);
+  }
+
+  @Test
+  public void testInvalid_noDigits() {
+    final WithDuration obj = new WithDuration("m");
+
+    final Set<ConstraintViolation<WithDuration>> results = validatorFactoryBean.validate(obj);
+
+    assertInvalidDuration(results);
+  }
+
+  @Test
+  public void testInvalid_empty() {
+    final WithDuration obj = new WithDuration("");
+
+    final Set<ConstraintViolation<WithDuration>> results = validatorFactoryBean.validate(obj);
+
+    assertInvalidDuration(results);
+  }
+
+  @Test
+  public void testInvalid_noUnits() {
+    final WithDuration obj = new WithDuration("12");
+
+    final Set<ConstraintViolation<WithDuration>> results = validatorFactoryBean.validate(obj);
+
+    assertInvalidDuration(results);
+  }
+
+  private void assertInvalidDuration(Set<ConstraintViolation<WithDuration>> results) {
+    assertThat(results, hasSize(1));
+    final ConstraintViolation<WithDuration> violation = results.iterator().next();
+    assertThat(
+        violation.getConstraintDescriptor().getAnnotation().annotationType(),
+        // since it's composite, the constituent constraint ends up here
+        equalTo(Pattern.class)
+    );
+    assertThat(violation.getMessage(), equalTo("invalid duration"));
+  }
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidHostAndPortValidatorTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidHostAndPortValidatorTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.validator;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+public class ValidHostAndPortValidatorTest {
+  private LocalValidatorFactoryBean validatorFactoryBean;
+
+  @AllArgsConstructor
+  static class WithOptionalAddress {
+    @ValidHostAndPort
+    String address;
+  }
+
+  @AllArgsConstructor
+  static class WithRequiredAddress {
+    @NotNull
+    @ValidHostAndPort
+    String address;
+  }
+
+  @Before
+  public void setUp() {
+    validatorFactoryBean = new LocalValidatorFactoryBean();
+    validatorFactoryBean.afterPropertiesSet();
+  }
+
+  @Test
+  public void testValidation_valid_ip() {
+    final WithRequiredAddress obj = new WithRequiredAddress("127.0.0.1:22");
+
+    final Set<ConstraintViolation<WithRequiredAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(0));
+  }
+
+  @Test
+  public void testValidation_valid_host() {
+    final WithRequiredAddress obj = new WithRequiredAddress("localhost:22");
+
+    final Set<ConstraintViolation<WithRequiredAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(0));
+  }
+
+  @Test
+  public void testValidation_valid_domain() {
+    final WithRequiredAddress obj = new WithRequiredAddress("example.com:22");
+
+    final Set<ConstraintViolation<WithRequiredAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(0));
+  }
+
+  @Test
+  public void testValidation_valid_optional() {
+    final WithOptionalAddress obj = new WithOptionalAddress(null);
+
+    final Set<ConstraintViolation<WithOptionalAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(0));
+  }
+
+  @Test
+  public void testValidation_missingPort() {
+    final WithRequiredAddress obj = new WithRequiredAddress("localhost");
+
+    final Set<ConstraintViolation<WithRequiredAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(1));
+    assertThat(
+        result.iterator().next().getConstraintDescriptor().getAnnotation().annotationType(),
+        equalTo(ValidHostAndPort.class)
+    );
+  }
+
+  @Test
+  public void testValidation_invalidIp() {
+    final WithRequiredAddress obj = new WithRequiredAddress("127.3:8080");
+
+    final Set<ConstraintViolation<WithRequiredAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(1));
+    assertThat(
+        result.iterator().next().getConstraintDescriptor().getAnnotation().annotationType(),
+        equalTo(ValidHostAndPort.class)
+    );
+  }
+
+  @Test
+  public void testValidation_invalidPort() {
+    final WithRequiredAddress obj = new WithRequiredAddress("localhost:notAPort");
+
+    final Set<ConstraintViolation<WithRequiredAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(1));
+    assertThat(
+        result.iterator().next().getConstraintDescriptor().getAnnotation().annotationType(),
+        equalTo(ValidHostAndPort.class)
+    );
+  }
+
+  @Test
+  public void testValidation_invalidDomain() {
+    final WithRequiredAddress obj = new WithRequiredAddress("not$valid:80");
+
+    final Set<ConstraintViolation<WithRequiredAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(1));
+    assertThat(
+        result.iterator().next().getConstraintDescriptor().getAnnotation().annotationType(),
+        equalTo(ValidHostAndPort.class)
+    );
+  }
+}

--- a/src/test/resources/ConversionTests/net.json
+++ b/src/test/resources/ConversionTests/net.json
@@ -1,0 +1,5 @@
+{
+  "type": "net",
+  "interfaces": ["eth*", "enp0s[0-1]"],
+  "ignoreProtocolStats": true
+}

--- a/src/test/resources/ConversionTests/net_response.json
+++ b/src/test/resources/ConversionTests/net_response.json
@@ -1,0 +1,9 @@
+{
+  "type": "net_response",
+  "address": "localhost:80",
+  "protocol": "tcp",
+  "timeout": "5s",
+  "readTimeout": "10s",
+  "send": "request",
+  "expect": "response"
+}


### PR DESCRIPTION
# Resolves

- https://jira.rax.io/browse/SALUS-373
- https://jira.rax.io/browse/SALUS-372

# What

Adds support for the telegraf plugins
- https://github.com/influxdata/telegraf/tree/master/plugins/inputs/net_response
- https://github.com/influxdata/telegraf/blob/master/plugins/inputs/net/NET_README.md

# How

While I was at it I added a `@ValidGoDuration` and retrofitted the http and x509 plugin schemas with that.

I also added `@ValidHostAndPort` which uses a bit of guava and a bit of Apache Commons validator library. Initially I was going to add these new validators into the "model" repo; however, that would have forced these new dependencies on practically everything. 

If this feels like too much validator bloat in monitor-management, then we can always create a repo for our validators specifically.

## How to test

Added new unit tests.

Speaking of which, rather than keep adding to `MonitorConversionServiceTest` I realized that it'll be better to create a new unit test class for each of these plugin "schemas". If this approach is agreeable then I can split out the existing unit tests into the same structure.