### PR TITLE
Fix API Pagination

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/BoundMonitorRepository.java
@@ -29,6 +29,7 @@ import org.springframework.data.repository.CrudRepository;
 public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, BoundMonitor.PrimaryKey> {
 
   List<BoundMonitor> findAllByEnvoyId(String envoyId);
+  Page<BoundMonitor> findAllByEnvoyId(String envoyId, Pageable page);
 
   @Query("select b from BoundMonitor b where b.zoneName = :zoneName and b.envoyId is null")
   List<BoundMonitor> findAllWithoutEnvoyInPublicZone(String zoneName);
@@ -75,7 +76,8 @@ public interface BoundMonitorRepository extends CrudRepository<BoundMonitor, Bou
 
   List<BoundMonitor> findAllByMonitor_IdAndResourceId(UUID monitorId, String resourceId);
 
-  Page<BoundMonitor> findAllByMonitor_TenantId(String tenantId, Pageable pageable);
+  List<BoundMonitor> findAllByMonitor_TenantId(String tenantId);
+  Page<BoundMonitor> findAllByMonitor_TenantId(String tenantId, Pageable page);
 
   @Query("select b from BoundMonitor b"
       + " where b.monitor.tenantId = :tenantId"

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/MonitorRepository.java
@@ -31,7 +31,7 @@ public interface MonitorRepository extends PagingAndSortingRepository<Monitor, U
     Page<Monitor> findByTenantId(String tenantId, Pageable pageable);
 
     @Query("select m from Monitor m where m.tenantId = :tenantId and :zone member of m.zones")
-    List<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone);
+    Page<Monitor> findByTenantIdAndZonesContains(String tenantId, String zone, Pageable page);
 
     @Query("select count(m) from Monitor m where :zone member of m.zones")
     int countAllByZonesContains(String zone);

--- a/src/main/java/com/rackspace/salus/monitor_management/repositories/ZoneRepository.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/repositories/ZoneRepository.java
@@ -16,6 +16,10 @@
 package com.rackspace.salus.monitor_management.repositories;
 
 import com.rackspace.salus.monitor_management.entities.Zone;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import java.util.List;
@@ -25,7 +29,14 @@ import java.util.UUID;
 public interface ZoneRepository extends PagingAndSortingRepository<Zone, UUID> {
     Optional<Zone> findByTenantIdAndName(String tenantId, String name);
 
-    List<Zone> findAllByTenantId(String tenantId);
+    Page<Zone> findAllByTenantId(String tenantId, Pageable page);
+
+    @Query(
+        "select z from Zone z where z.tenantId = :tenantId"
+        + " or z.tenantId = com.rackspace.salus.telemetry.etcd.types.ResolvedZone.PUBLIC"
+            + " order by FIELD(tenantId, com.rackspace.salus.telemetry.etcd.types.ResolvedZone.PUBLIC) DESC"
+            + ", name ASC")
+    Page<Zone> findAllAvailableForTenant(String tenantId, Pageable page);
 
     boolean existsByTenantIdAndName(String tenantId, String name);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneManagement.java
@@ -28,13 +28,13 @@ import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -260,24 +260,20 @@ public class ZoneManagement {
         return zoneStorage.getActiveEnvoyCountForZone(resolvedZone).join();
     }
 
-    private List<Zone> getZonesByTenant(String tenantId) {
-        return zoneRepository.findAllByTenantId(tenantId);
+    private Page<Zone> getZonesByTenant(String tenantId, Pageable page) {
+        return zoneRepository.findAllByTenantId(tenantId, page);
     }
 
-    private List<Zone> getAllPublicZones() {
-        return getZonesByTenant(ResolvedZone.PUBLIC);
+    public Page<Zone> getAllPublicZones(Pageable page) {
+        return getZonesByTenant(ResolvedZone.PUBLIC, page);
     }
 
-    public List<Zone> getAvailableZonesForTenant(String tenantId) {
-        List<Zone> availableZones = new ArrayList<>();
-        availableZones.addAll(getAllPublicZones());
-        availableZones.addAll(getZonesByTenant(tenantId));
-
-        return availableZones;
+    public Page<Zone> getAvailableZonesForTenant(String tenantId, Pageable page) {
+        return zoneRepository.findAllAvailableForTenant(tenantId, page);
     }
 
-    public List<Monitor> getMonitorsForZone(String tenantId, String zone) {
-        return monitorRepository.findByTenantIdAndZonesContains(tenantId, zone);
+    public Page<Monitor> getMonitorsForZone(String tenantId, String zone, Pageable page) {
+        return monitorRepository.findByTenantIdAndZonesContains(tenantId, zone, page);
     }
 
   /**

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -40,6 +40,7 @@ import com.rackspace.salus.monitor_management.web.model.telegraf.Mem;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.PagedContent;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -138,6 +139,8 @@ public class MonitorApiControllerTest {
                 PageRequest.of(page, pageSize),
                 numberOfMonitors);
 
+        PagedContent<Monitor> result = PagedContent.fromPage(pageOfMonitors);
+
         when(monitorManagement.getMonitors(anyString(), any()))
                 .thenReturn(pageOfMonitors);
 
@@ -148,14 +151,13 @@ public class MonitorApiControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(content().string(objectMapper.writeValueAsString(pageOfMonitors.map(monitorConversionService::convertToOutput))))
+                .andExpect(content().string(objectMapper.writeValueAsString(result.map(monitorConversionService::convertToOutput))))
                 .andExpect(jsonPath("$.content.*", hasSize(numberOfMonitors)))
                 .andExpect(jsonPath("$.totalPages", equalTo(1)))
-                .andExpect(jsonPath("$.numberOfElements", equalTo(numberOfMonitors)))
                 .andExpect(jsonPath("$.totalElements", equalTo(numberOfMonitors)))
-                .andExpect(jsonPath("$.pageable.pageNumber", equalTo(page)))
-                .andExpect(jsonPath("$.pageable.pageSize", equalTo(pageSize)))
-                .andExpect(jsonPath("$.size", equalTo(pageSize)));
+                .andExpect(jsonPath("$.number", equalTo(page)))
+                .andExpect(jsonPath("$.last", is(true)))
+                .andExpect(jsonPath("$.first", is(true)));
     }
 
     private List<Monitor> createMonitors(int numberOfMonitors) {
@@ -182,6 +184,8 @@ public class MonitorApiControllerTest {
                 PageRequest.of(page, pageSize),
                 numberOfMonitors);
 
+        PagedContent<Monitor> result = PagedContent.fromPage(pageOfMonitors);
+
         assertThat(pageOfMonitors.getContent().size(), equalTo(pageSize));
 
         when(monitorManagement.getMonitors(anyString(), any()))
@@ -196,14 +200,13 @@ public class MonitorApiControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(content().string(objectMapper.writeValueAsString(pageOfMonitors.map(monitorConversionService::convertToOutput))))
+                .andExpect(content().string(objectMapper.writeValueAsString(result.map(monitorConversionService::convertToOutput))))
                 .andExpect(jsonPath("$.content.*", hasSize(pageSize)))
                 .andExpect(jsonPath("$.totalPages", equalTo((numberOfMonitors + pageSize - 1) / pageSize)))
-                .andExpect(jsonPath("$.numberOfElements", equalTo(pageSize)))
                 .andExpect(jsonPath("$.totalElements", equalTo(numberOfMonitors)))
-                .andExpect(jsonPath("$.pageable.pageNumber", equalTo(page)))
-                .andExpect(jsonPath("$.pageable.pageSize", equalTo(pageSize)))
-                .andExpect(jsonPath("$.size", equalTo(pageSize)));
+                .andExpect(jsonPath("$.number", equalTo(page)))
+                .andExpect(jsonPath("$.last", is(false)))
+                .andExpect(jsonPath("$.first", is(false)));
     }
 
     @Test
@@ -291,22 +294,23 @@ public class MonitorApiControllerTest {
                 PageRequest.of(page, pageSize),
                 numberOfMonitors);
 
+        PagedContent<Monitor> result = PagedContent.fromPage(pageOfMonitors);
+
         when(monitorManagement.getAllMonitors(any()))
                 .thenReturn(pageOfMonitors);
 
-        String url = "/api/monitors";
+        String url = "/api/admin/monitors";
 
         mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(content().string(objectMapper.writeValueAsString(pageOfMonitors.map(monitorConversionService::convertToOutput))))
+                .andExpect(content().string(objectMapper.writeValueAsString(result.map(monitorConversionService::convertToOutput))))
                 .andExpect(jsonPath("$.content.*", hasSize(numberOfMonitors)))
                 .andExpect(jsonPath("$.totalPages", equalTo(1)))
-                .andExpect(jsonPath("$.numberOfElements", equalTo(numberOfMonitors)))
                 .andExpect(jsonPath("$.totalElements", equalTo(numberOfMonitors)))
-                .andExpect(jsonPath("$.pageable.pageNumber", equalTo(page)))
-                .andExpect(jsonPath("$.pageable.pageSize", equalTo(pageSize)))
-                .andExpect(jsonPath("$.size", equalTo(pageSize)));
+                .andExpect(jsonPath("$.number", equalTo(page)))
+                .andExpect(jsonPath("$.last", is(true)))
+                .andExpect(jsonPath("$.first", is(true)));
     }
 }


### PR DESCRIPTION
# What

Updates the monitor and zone apis so that pagination params can be specified in the request and handled correctly.

# How

I changed my mind of a few times while doing this, but eventually realized we do have to settle with returning `Page` in our Repository and Management classes because that is the only place where we have all the info to construct it.  We cannot have Management return a List and then convert it into a Page because we do not have the total element values at that time.

 * Mostly this was just converting the use of Lists over to Pages
 * Had to create a sql function for `findAllAvailableForTenant`.  Previously we were concatenating two lists, but with that we cannot get accurate pagination details/functionality.
 * Implemented some custom pagination handling in `getMonitorsFromLabels` where we construct and execute our custom sql.
 * Updated responses to be `PagedContent`
 * Updated endpoints to be kebab-case
 * Updates tests and added a few new ones
 * The ApiController no longer implements to API interface.  I don't think this is a problem but let me know if you have other thoughts.  I have it so one returns Pages but the one used to read those outputs is consuming the responses as Lists instead.  I figured internal services consuming as a List might be preferred since we don't plan to paginate those requests.

## How to test

Run tests.  I also did some manual validation via the direct apis and via the public / admin api.

# Why

It finalizes our APIs a little more and will make them all work in a consistent manner.

# TODO

The insomnia endpoint list could use a refresh.
PRs for the other repos.