### PR TITLE
Fix response parsing in api client

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -918,6 +918,7 @@ public class MonitorManagement {
      * @param tenantId The tenant associated to the resource
      * @return the list of Monitor's that match the labels
      */
+    @SuppressWarnings("Duplicates")
     public Page<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId, Pageable page) throws IllegalArgumentException {
         if(labels.size() == 0) {
             throw new IllegalArgumentException("Labels must be provided for search");

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -17,10 +17,14 @@
 package com.rackspace.salus.monitor_management.web.client;
 
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
+import com.rackspace.salus.telemetry.model.PagedContent;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * This client component provides a small subset of Monitor Management REST operations that
@@ -50,7 +54,7 @@ import org.springframework.web.client.RestTemplate;
  */
 public class MonitorApiClient implements MonitorApi {
 
-  private static final ParameterizedTypeReference<List<BoundMonitorDTO>> LIST_OF_BOUND_MONITOR = new ParameterizedTypeReference<List<BoundMonitorDTO>>() {
+  private static final ParameterizedTypeReference<PagedContent<BoundMonitorDTO>> PAGE_OF_BOUND_MONITOR = new ParameterizedTypeReference<PagedContent<BoundMonitorDTO>>() {
   };
   private final RestTemplate restTemplate;
 
@@ -60,12 +64,17 @@ public class MonitorApiClient implements MonitorApi {
 
   @Override
   public List<BoundMonitorDTO> getBoundMonitors(String envoyId) {
-    return restTemplate.exchange(
-        "/api/boundMonitors/{envoyId}",
+    final String uri = UriComponentsBuilder
+        .fromPath("/api/admin/bound-monitors/{envoyId}")
+        .queryParam("size", Integer.MAX_VALUE)
+        .build(envoyId)
+        .toString();
+
+    return Objects.requireNonNull(restTemplate.exchange(
+        uri,
         HttpMethod.GET,
         null,
-        LIST_OF_BOUND_MONITOR,
-        envoyId
-    ).getBody();
+        PAGE_OF_BOUND_MONITOR
+      ).getBody()).getContent();
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClient.java
@@ -42,14 +42,14 @@ import org.springframework.web.util.UriComponentsBuilder;
  {@literal @}Configuration
  public class RestClientsConfig {
 
- {@literal @}Bean
- public ZoneApi zoneApi(RestTemplateBuilder restTemplateBuilder) {
- return new ZoneApiClient(
- restTemplateBuilder
- .rootUri("http://localhost:8089")
- .build()
- );
- }
+   {@literal @}Bean
+   public ZoneApi zoneApi(RestTemplateBuilder restTemplateBuilder) {
+      return new ZoneApiClient(
+        restTemplateBuilder
+          .rootUri("http://localhost:8089")
+          .build()
+      );
+   }
  }
  * </pre>
  *

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClient.java
@@ -17,13 +17,16 @@ package com.rackspace.salus.monitor_management.web.client;
 
 import com.rackspace.salus.monitor_management.web.model.MonitorDTO;
 import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
+import com.rackspace.salus.telemetry.model.PagedContent;
 import java.util.List;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * This client component provides a small subset of Zone Management REST operations that
@@ -39,14 +42,14 @@ import org.springframework.web.client.RestTemplate;
  {@literal @}Configuration
  public class RestClientsConfig {
 
-   {@literal @}Bean
-   public ZoneApi zoneApi(RestTemplateBuilder restTemplateBuilder) {
-     return new ZoneApiClient(
-       restTemplateBuilder
-       .rootUri("http://localhost:8089")
-       .build()
-     );
-   }
+ {@literal @}Bean
+ public ZoneApi zoneApi(RestTemplateBuilder restTemplateBuilder) {
+ return new ZoneApiClient(
+ restTemplateBuilder
+ .rootUri("http://localhost:8089")
+ .build()
+ );
+ }
  }
  * </pre>
  *
@@ -54,57 +57,65 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 public class ZoneApiClient implements ZoneApi {
 
-    private static final ParameterizedTypeReference<List<ZoneDTO>> LIST_OF_ZONES = new ParameterizedTypeReference<List<ZoneDTO>>() {
-    };
-    private static final ParameterizedTypeReference<List<MonitorDTO>> LIST_OF_MONITOR = new ParameterizedTypeReference<List<MonitorDTO>>() {
-    };
+  private static final ParameterizedTypeReference<PagedContent<ZoneDTO>> PAGE_OF_ZONES = new ParameterizedTypeReference<PagedContent<ZoneDTO>>() {
+  };
+  private static final ParameterizedTypeReference<PagedContent<MonitorDTO>> PAGE_OF_MONITOR = new ParameterizedTypeReference<PagedContent<MonitorDTO>>() {
+  };
 
-    private final RestTemplate restTemplate;
+  private final RestTemplate restTemplate;
 
 
-    public ZoneApiClient(RestTemplate restTemplate) {
-        this.restTemplate = restTemplate;
+  public ZoneApiClient(RestTemplate restTemplate) {
+    this.restTemplate = restTemplate;
+  }
+  @Override
+  public ZoneDTO getByZoneName(String tenantId, String name) {
+    try {
+      return restTemplate.getForObject(
+          "/api/tenant/{tenantId}/zones/{name}",
+          ZoneDTO.class,
+          tenantId, name
+      );
+    } catch (HttpClientErrorException e) {
+      if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+        return null;
+        // what happens if this isn't here?
+      }
+      else {
+        throw new IllegalArgumentException(e);
+      }
     }
-    @Override
-    public ZoneDTO getByZoneName(String tenantId, String name) {
-        try {
-            return restTemplate.getForObject(
-                    "/api/tenant/{tenantId}/zones/{name}",
-                    ZoneDTO.class,
-                    tenantId, name
-            );
-        } catch (HttpClientErrorException e) {
-            if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
-                return null;
-                // what happens if this isn't here?
-            }
-            else {
-                throw new IllegalArgumentException(e);
-            }
-        }
-    }
+  }
 
-    @Override
-    public List<ZoneDTO> getAvailableZones(String tenantId) {
+  @Override
+  public List<ZoneDTO> getAvailableZones(String tenantId) {
+    final String uri = UriComponentsBuilder
+        .fromPath("/api/tenant/{tenantId}/zones")
+        .queryParam("size", Integer.MAX_VALUE)
+        .build(tenantId)
+        .toString();
 
-        return restTemplate.exchange(
-                "/api/tenant/{tenantId}/zones",
-                HttpMethod.GET,
-                null,
-                LIST_OF_ZONES,
-                tenantId
-        ).getBody();
-    }
+    return Objects.requireNonNull(restTemplate.exchange(
+        uri,
+        HttpMethod.GET,
+        null,
+        PAGE_OF_ZONES
+    ).getBody()).getContent();
+  }
 
-    @Override
-    public List<MonitorDTO> getMonitorsForZone(String tenantId, String zone) {
-        return restTemplate.exchange(
-                "/api/tenant/{tenantId}/monitorsByZone/{zone}",
-                HttpMethod.GET,
-                null,
-                LIST_OF_MONITOR,
-                tenantId,
-                zone
-        ).getBody();
-    }
+  @Override
+  public List<MonitorDTO> getMonitorsForZone(String tenantId, String zone) {
+    final String uri = UriComponentsBuilder
+        .fromPath("/api/tenant/{tenantId}/monitors-by-zone/{zone}")
+        .queryParam("size", Integer.MAX_VALUE)
+        .build(tenantId, zone)
+        .toString();
+
+    return Objects.requireNonNull(restTemplate.exchange(
+        uri,
+        HttpMethod.GET,
+        null,
+        PAGE_OF_MONITOR
+    ).getBody()).getContent();
+  }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -173,6 +173,5 @@ public class MonitorApiController {
                                                  @RequestBody Map<String, String> labels, Pageable pageable) {
         return PagedContent.fromPage(monitorManagement.getMonitorsFromLabels(labels, tenantId, pageable)
             .map(monitor -> monitorConversionService.convertToOutput(monitor)));
-
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -262,7 +262,7 @@ public class ZoneApiController {
         .map(Zone::toDTO));
   }
 
-  @GetMapping("/tenant/{tenantId}/monitorsByZone/{zone}")
+  @GetMapping("/tenant/{tenantId}/monitors-by-zone/{zone}")
   @ApiOperation(value = "Gets all monitors in a given zone for a specific tenant")
   @JsonView(View.Public.class)
   public PagedContent<MonitorDTO> getMonitorsForZone(@PathVariable String tenantId, @PathVariable String zone, Pageable pageable) {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClientTest.java
@@ -24,6 +24,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
+import com.rackspace.salus.telemetry.model.PagedContent;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -33,6 +34,8 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -78,9 +81,11 @@ public class MonitorApiClientTest {
             .setMonitorId(id3)
             .setRenderedContent("{\"instance\":3, \"state\":1}")
     );
+    final PagedContent<BoundMonitorDTO> resultPage = PagedContent.fromPage(
+        new PageImpl<>(givenBoundMonitors, Pageable.unpaged(), givenBoundMonitors.size()));
 
-    mockServer.expect(requestTo("/api/boundMonitors/e-1"))
-        .andRespond(withSuccess(objectMapper.writeValueAsString(givenBoundMonitors), MediaType.APPLICATION_JSON));
+    mockServer.expect(requestTo("/api/admin/bound-monitors/e-1?size=2147483647"))
+        .andRespond(withSuccess(objectMapper.writeValueAsString(resultPage), MediaType.APPLICATION_JSON));
 
     final List<BoundMonitorDTO> boundMonitors = monitorApiClient.getBoundMonitors("e-1");
     assertThat(boundMonitors, equalTo(givenBoundMonitors));

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -131,7 +131,7 @@ public class MonitorApiControllerTest {
         int numberOfMonitors = 1;
         // Use the APIs default Pageable settings
         int page = 0;
-        int pageSize = 100;
+        int pageSize = 20;
         List<Monitor> monitors = createMonitors(numberOfMonitors);
 
         int start = page * pageSize;
@@ -286,7 +286,7 @@ public class MonitorApiControllerTest {
         int numberOfMonitors = 20;
         // Use the APIs default Pageable settings
         int page = 0;
-        int pageSize = 100;
+        int pageSize = 20;
         final List<Monitor> monitors = createMonitors(numberOfMonitors);
 
         int start = page * pageSize;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -75,242 +75,277 @@ import uk.co.jemos.podam.api.PodamFactoryImpl;
 @Import({MonitorConversionService.class})
 public class MonitorApiControllerTest {
 
-    private PodamFactory podamFactory = new PodamFactoryImpl();
+  private PodamFactory podamFactory = new PodamFactoryImpl();
 
-    @Autowired
-    MockMvc mockMvc;
+  @Autowired
+  MockMvc mockMvc;
 
-    @MockBean
-    MonitorManagement monitorManagement;
+  @MockBean
+  MonitorManagement monitorManagement;
 
-    @Autowired
-    ObjectMapper objectMapper;
+  @Autowired
+  ObjectMapper objectMapper;
 
-    @Autowired
-    MonitorConversionService monitorConversionService;
+  @Autowired
+  MonitorConversionService monitorConversionService;
 
-    @Test
-    public void testGetMonitor() throws Exception {
-        Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
-        monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
-        monitor.setAgentType(AgentType.TELEGRAF);
-        monitor.setContent("{\"type\":\"mem\"}");
-        when(monitorManagement.getMonitor(anyString(), any()))
-                .thenReturn(Optional.of(monitor));
+  @Test
+  public void testGetMonitor() throws Exception {
+    Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
+    monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
+    monitor.setAgentType(AgentType.TELEGRAF);
+    monitor.setContent("{\"type\":\"mem\"}");
+    when(monitorManagement.getMonitor(anyString(), any()))
+        .thenReturn(Optional.of(monitor));
 
-        String tenantId = RandomStringUtils.randomAlphabetic(8);
-        UUID id = UUID.randomUUID();
-        String url = String.format("/api/tenant/%s/monitors/%s", tenantId, id);
+    String tenantId = RandomStringUtils.randomAlphabetic(8);
+    UUID id = UUID.randomUUID();
+    String url = String.format("/api/tenant/%s/monitors/%s", tenantId, id);
 
-        mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content()
-                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.id", is(monitor.getId().toString())));
+    mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id", is(monitor.getId().toString())));
+  }
+
+  @Test
+  public void testNoMonitorFound() throws Exception {
+    when(monitorManagement.getMonitor(anyString(), any()))
+        .thenReturn(Optional.empty());
+
+    String tenantId = RandomStringUtils.randomAlphabetic(8);
+    UUID id = UUID.randomUUID();
+    String url = String.format("/api/tenant/%s/monitors/%s", tenantId, id);
+    String errorMsg = String.format("No monitor found for %s on tenant %s", id, tenantId);
+
+    mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.message", is(errorMsg)));
+  }
+
+  @Test
+  public void testGetAllForTenant() throws Exception {
+    int numberOfMonitors = 1;
+    // Use the APIs default Pageable settings
+    int page = 0;
+    int pageSize = 20;
+    List<Monitor> monitors = createMonitors(numberOfMonitors);
+
+    int start = page * pageSize;
+    Page<Monitor> pageOfMonitors = new PageImpl<>(monitors.subList(start, numberOfMonitors),
+        PageRequest.of(page, pageSize),
+        numberOfMonitors);
+
+    PagedContent<Monitor> result = PagedContent.fromPage(pageOfMonitors);
+
+    when(monitorManagement.getMonitors(anyString(), any()))
+        .thenReturn(pageOfMonitors);
+
+    String tenantId = RandomStringUtils.randomAlphabetic(8);
+    String url = String.format("/api/tenant/%s/monitors", tenantId);
+
+    mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().string(objectMapper.writeValueAsString(result.map(monitorConversionService::convertToOutput))))
+        .andExpect(jsonPath("$.content.*", hasSize(numberOfMonitors)))
+        .andExpect(jsonPath("$.totalPages", equalTo(1)))
+        .andExpect(jsonPath("$.totalElements", equalTo(numberOfMonitors)))
+        .andExpect(jsonPath("$.number", equalTo(page)))
+        .andExpect(jsonPath("$.last", is(true)))
+        .andExpect(jsonPath("$.first", is(true)));
+  }
+
+  private List<Monitor> createMonitors(int numberOfMonitors) {
+    List<Monitor> monitors = new ArrayList<>();
+    for (int i = 0; i < numberOfMonitors; i++) {
+      final Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
+      monitors.add(monitor);
+      monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
+      monitor.setAgentType(AgentType.TELEGRAF);
+      monitor.setContent("{\"type\":\"mem\"}");
     }
+    return monitors;
+  }
 
-    @Test
-    public void testNoMonitorFound() throws Exception {
-        when(monitorManagement.getMonitor(anyString(), any()))
-                .thenReturn(Optional.empty());
+  @Test
+  public void testGetAllForTenantPagination() throws Exception {
+    int numberOfMonitors = 99;
+    int pageSize = 4;
+    int page = 14;
+    final List<Monitor> monitors = createMonitors(numberOfMonitors);
+    int start = page * pageSize;
+    int end = start + pageSize;
+    Page<Monitor> pageOfMonitors = new PageImpl<>(monitors.subList(start, end),
+        PageRequest.of(page, pageSize),
+        numberOfMonitors);
 
-        String tenantId = RandomStringUtils.randomAlphabetic(8);
-        UUID id = UUID.randomUUID();
-        String url = String.format("/api/tenant/%s/monitors/%s", tenantId, id);
-        String errorMsg = String.format("No monitor found for %s on tenant %s", id, tenantId);
+    PagedContent<Monitor> result = PagedContent.fromPage(pageOfMonitors);
 
-        mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(content()
-                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.message", is(errorMsg)));
-    }
+    assertThat(pageOfMonitors.getContent().size(), equalTo(pageSize));
 
-    @Test
-    public void testGetAllForTenant() throws Exception {
-        int numberOfMonitors = 1;
-        // Use the APIs default Pageable settings
-        int page = 0;
-        int pageSize = 20;
-        List<Monitor> monitors = createMonitors(numberOfMonitors);
+    when(monitorManagement.getMonitors(anyString(), any()))
+        .thenReturn(pageOfMonitors);
 
-        int start = page * pageSize;
-        Page<Monitor> pageOfMonitors = new PageImpl<>(monitors.subList(start, numberOfMonitors),
-                PageRequest.of(page, pageSize),
-                numberOfMonitors);
+    String tenantId = RandomStringUtils.randomAlphabetic(8);
+    String url = String.format("/api/tenant/%s/monitors", tenantId);
 
-        PagedContent<Monitor> result = PagedContent.fromPage(pageOfMonitors);
+    mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON)
+        .param("page", Integer.toString(page))
+        .param("size", Integer.toString(pageSize)))
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().string(objectMapper.writeValueAsString(result.map(monitorConversionService::convertToOutput))))
+        .andExpect(jsonPath("$.content.*", hasSize(pageSize)))
+        .andExpect(jsonPath("$.totalPages", equalTo((numberOfMonitors + pageSize - 1) / pageSize)))
+        .andExpect(jsonPath("$.totalElements", equalTo(numberOfMonitors)))
+        .andExpect(jsonPath("$.number", equalTo(page)))
+        .andExpect(jsonPath("$.last", is(false)))
+        .andExpect(jsonPath("$.first", is(false)));
+  }
 
-        when(monitorManagement.getMonitors(anyString(), any()))
-                .thenReturn(pageOfMonitors);
+  @Test
+  public void testCreateMonitor() throws Exception {
+    Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
+    monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
+    monitor.setAgentType(AgentType.TELEGRAF);
+    monitor.setContent("{\"type\":\"mem\"}");
+    when(monitorManagement.createMonitor(anyString(), any()))
+        .thenReturn(monitor);
 
-        String tenantId = RandomStringUtils.randomAlphabetic(8);
-        String url = String.format("/api/tenant/%s/monitors", tenantId);
+    String tenantId = RandomStringUtils.randomAlphabetic(8);
+    String url = String.format("/api/tenant/%s/monitors", tenantId);
+    DetailedMonitorInput create = podamFactory.manufacturePojo(DetailedMonitorInput.class);
+    create.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
 
-        mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content()
-                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(content().string(objectMapper.writeValueAsString(result.map(monitorConversionService::convertToOutput))))
-                .andExpect(jsonPath("$.content.*", hasSize(numberOfMonitors)))
-                .andExpect(jsonPath("$.totalPages", equalTo(1)))
-                .andExpect(jsonPath("$.totalElements", equalTo(numberOfMonitors)))
-                .andExpect(jsonPath("$.number", equalTo(page)))
-                .andExpect(jsonPath("$.last", is(true)))
-                .andExpect(jsonPath("$.first", is(true)));
-    }
-
-    private List<Monitor> createMonitors(int numberOfMonitors) {
-        List<Monitor> monitors = new ArrayList<>();
-        for (int i = 0; i < numberOfMonitors; i++) {
-            final Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
-            monitors.add(monitor);
-            monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
-            monitor.setAgentType(AgentType.TELEGRAF);
-            monitor.setContent("{\"type\":\"mem\"}");
-        }
-        return monitors;
-    }
-
-    @Test
-    public void testGetAllForTenantPagination() throws Exception {
-        int numberOfMonitors = 99;
-        int pageSize = 4;
-        int page = 14;
-        final List<Monitor> monitors = createMonitors(numberOfMonitors);
-        int start = page * pageSize;
-        int end = start + pageSize;
-        Page<Monitor> pageOfMonitors = new PageImpl<>(monitors.subList(start, end),
-                PageRequest.of(page, pageSize),
-                numberOfMonitors);
-
-        PagedContent<Monitor> result = PagedContent.fromPage(pageOfMonitors);
-
-        assertThat(pageOfMonitors.getContent().size(), equalTo(pageSize));
-
-        when(monitorManagement.getMonitors(anyString(), any()))
-                .thenReturn(pageOfMonitors);
-
-        String tenantId = RandomStringUtils.randomAlphabetic(8);
-        String url = String.format("/api/tenant/%s/monitors", tenantId);
-
-        mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON)
-                .param("page", Integer.toString(page))
-                .param("size", Integer.toString(pageSize)))
-                .andExpect(status().isOk())
-                .andExpect(content()
-                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(content().string(objectMapper.writeValueAsString(result.map(monitorConversionService::convertToOutput))))
-                .andExpect(jsonPath("$.content.*", hasSize(pageSize)))
-                .andExpect(jsonPath("$.totalPages", equalTo((numberOfMonitors + pageSize - 1) / pageSize)))
-                .andExpect(jsonPath("$.totalElements", equalTo(numberOfMonitors)))
-                .andExpect(jsonPath("$.number", equalTo(page)))
-                .andExpect(jsonPath("$.last", is(false)))
-                .andExpect(jsonPath("$.first", is(false)));
-    }
-
-    @Test
-    public void testCreateMonitor() throws Exception {
-        Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
-        monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
-        monitor.setAgentType(AgentType.TELEGRAF);
-        monitor.setContent("{\"type\":\"mem\"}");
-        when(monitorManagement.createMonitor(anyString(), any()))
-                .thenReturn(monitor);
-
-        String tenantId = RandomStringUtils.randomAlphabetic(8);
-        String url = String.format("/api/tenant/%s/monitors", tenantId);
-        DetailedMonitorInput create = podamFactory.manufacturePojo(DetailedMonitorInput.class);
-        create.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
-
-        mockMvc.perform(post(url)
-                .content(objectMapper.writeValueAsString(create))
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding(StandardCharsets.UTF_8.name()))
-                .andExpect(status().isCreated())
-                .andExpect(content()
-                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
-    }
+    mockMvc.perform(post(url)
+        .content(objectMapper.writeValueAsString(create))
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andExpect(status().isCreated())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+  }
 
 
 
-    @Test
-    public void testUpdateMonitor() throws Exception {
-        Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
-        monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
-        monitor.setAgentType(AgentType.TELEGRAF);
-        monitor.setContent("{\"type\":\"mem\"}");
-        when(monitorManagement.updateMonitor(anyString(), any(), any()))
-                .thenReturn(monitor);
+  @Test
+  public void testUpdateMonitor() throws Exception {
+    Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
+    monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
+    monitor.setAgentType(AgentType.TELEGRAF);
+    monitor.setContent("{\"type\":\"mem\"}");
+    when(monitorManagement.updateMonitor(anyString(), any(), any()))
+        .thenReturn(monitor);
 
-        String tenantId = monitor.getTenantId();
-        UUID id = monitor.getId();
-        String url = String.format("/api/tenant/%s/monitors/%s", tenantId, id);
+    String tenantId = monitor.getTenantId();
+    UUID id = monitor.getId();
+    String url = String.format("/api/tenant/%s/monitors/%s", tenantId, id);
 
-        DetailedMonitorInput update = podamFactory.manufacturePojo(DetailedMonitorInput.class);
-        update.setLabelSelector(null);
-        update.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
+    DetailedMonitorInput update = podamFactory.manufacturePojo(DetailedMonitorInput.class);
+    update.setLabelSelector(null);
+    update.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
 
-        mockMvc.perform(put(url)
-                .content(objectMapper.writeValueAsString(update))
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding(StandardCharsets.UTF_8.name()))
-                .andExpect(status().isOk())
-                .andExpect(content()
-                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
-    }
+    mockMvc.perform(put(url)
+        .content(objectMapper.writeValueAsString(update))
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+  }
 
-    @Test
-    public void testUpdateNonExistentMonitor() throws Exception {
-        when(monitorManagement.updateMonitor(anyString(), any(), any()))
-                .thenThrow(new NotFoundException("Custom not found message"));
+  @Test
+  public void testUpdateNonExistentMonitor() throws Exception {
+    when(monitorManagement.updateMonitor(anyString(), any(), any()))
+        .thenThrow(new NotFoundException("Custom not found message"));
 
-        String tenantId = RandomStringUtils.randomAlphabetic(10);
-        UUID id = UUID.randomUUID();
-        String url = String.format("/api/tenant/%s/monitors/%s", tenantId, id);
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+    UUID id = UUID.randomUUID();
+    String url = String.format("/api/tenant/%s/monitors/%s", tenantId, id);
 
-        DetailedMonitorInput update = podamFactory.manufacturePojo(DetailedMonitorInput.class);
-        update.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
+    DetailedMonitorInput update = podamFactory.manufacturePojo(DetailedMonitorInput.class);
+    update.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
 
-        mockMvc.perform(put(url)
-                .content(objectMapper.writeValueAsString(update))
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding(StandardCharsets.UTF_8.name()))
-                .andExpect(status().isNotFound())
-                .andExpect(content()
-                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
-    }
+    mockMvc.perform(put(url)
+        .content(objectMapper.writeValueAsString(update))
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andExpect(status().isNotFound())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+  }
 
-    @Test
-    public void testGetAll() throws Exception {
-        int numberOfMonitors = 20;
-        // Use the APIs default Pageable settings
-        int page = 0;
-        int pageSize = 20;
-        final List<Monitor> monitors = createMonitors(numberOfMonitors);
+  @Test
+  public void testGetAll() throws Exception {
+    int numberOfMonitors = 20;
+    // Use the APIs default Pageable settings
+    int page = 0;
+    int pageSize = 20;
+    final List<Monitor> monitors = createMonitors(numberOfMonitors);
 
-        int start = page * pageSize;
-        Page<Monitor> pageOfMonitors = new PageImpl<>(monitors.subList(start, numberOfMonitors),
-                PageRequest.of(page, pageSize),
-                numberOfMonitors);
+    int start = page * pageSize;
+    Page<Monitor> pageOfMonitors = new PageImpl<>(monitors.subList(start, numberOfMonitors),
+        PageRequest.of(page, pageSize),
+        numberOfMonitors);
 
-        PagedContent<Monitor> result = PagedContent.fromPage(pageOfMonitors);
+    PagedContent<Monitor> result = PagedContent.fromPage(pageOfMonitors);
 
-        when(monitorManagement.getAllMonitors(any()))
-                .thenReturn(pageOfMonitors);
+    when(monitorManagement.getAllMonitors(any()))
+        .thenReturn(pageOfMonitors);
 
-        String url = "/api/admin/monitors";
+    String url = "/api/admin/monitors";
 
-        mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content()
-                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(content().string(objectMapper.writeValueAsString(result.map(monitorConversionService::convertToOutput))))
-                .andExpect(jsonPath("$.content.*", hasSize(numberOfMonitors)))
-                .andExpect(jsonPath("$.totalPages", equalTo(1)))
-                .andExpect(jsonPath("$.totalElements", equalTo(numberOfMonitors)))
-                .andExpect(jsonPath("$.number", equalTo(page)))
-                .andExpect(jsonPath("$.last", is(true)))
-                .andExpect(jsonPath("$.first", is(true)));
-    }
+    mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().string(objectMapper.writeValueAsString(result.map(monitorConversionService::convertToOutput))))
+        .andExpect(jsonPath("$.content.*", hasSize(numberOfMonitors)))
+        .andExpect(jsonPath("$.totalPages", equalTo(1)))
+        .andExpect(jsonPath("$.totalElements", equalTo(numberOfMonitors)))
+        .andExpect(jsonPath("$.number", equalTo(page)))
+        .andExpect(jsonPath("$.last", is(true)))
+        .andExpect(jsonPath("$.first", is(true)));
+  }
+
+  @Test
+  public void testGetAllMonitors_LargePage() throws Exception {
+    // This test is to verify that we can get more than 1000 results back via spring mvc.
+
+    int numberOfMonitors = 2000;
+    // Use the APIs default Pageable settings
+    int page = 0;
+    int pageSize = Integer.MAX_VALUE;
+    final List<Monitor> monitors = createMonitors(numberOfMonitors);
+
+    int start = page * pageSize;
+    Page<Monitor> pageOfMonitors = new PageImpl<>(monitors.subList(start, numberOfMonitors),
+        PageRequest.of(page, pageSize),
+        numberOfMonitors);
+
+    PagedContent<Monitor> result = PagedContent.fromPage(pageOfMonitors);
+
+    when(monitorManagement.getAllMonitors(any()))
+        .thenReturn(pageOfMonitors);
+
+    mockMvc.perform(get("/api/admin/monitors")
+        .requestAttr("size", pageSize)
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().string(objectMapper.writeValueAsString(result.map(monitorConversionService::convertToOutput))))
+        .andExpect(jsonPath("$.content.*", hasSize(numberOfMonitors)))
+        .andExpect(jsonPath("$.totalPages", equalTo(1)))
+        .andExpect(jsonPath("$.totalElements", equalTo(numberOfMonitors)))
+        .andExpect(jsonPath("$.number", equalTo(page)))
+        .andExpect(jsonPath("$.last", is(true)))
+        .andExpect(jsonPath("$.first", is(true)));
+  }
 }


### PR DESCRIPTION
# What

Updates the client to handle PagedContent response instead of List.

# How

To avoid getting multiple pages back we now make the request by providing the maximum size possible.

## How to test

Run tests.
Try to connect and envoy to the ambassador.  It now works.

I added a test to verify that there isnt a 1000 object limit in responses, but also tested this manually in case the test case wasn't hitting the right layers.
```
  "number": 0,
  "totalPages": 1,
  "totalElements": 1351,
  "last": true,
  "first": true
}
```
# Why

To fix inter-service communication.

# TODO

Need to double check resource api.
