### PR TITLE
Fix NPE when binding agent monitors

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -246,7 +246,8 @@ public class MonitorManagement {
                     .join();
 
                 boundMonitors.add(
-                    bindAgentMonitor(monitor, resource, resourceInfo.getEnvoyId())
+                    bindAgentMonitor(monitor, resource,
+                        resourceInfo != null ? resourceInfo.getEnvoyId() : null)
                 );
             }
 


### PR DESCRIPTION
# What

Fixes a bug.

# How

Handle the null possibility.

## How to test

Run new tests.  They fail without the fix.

# Why

This causes agent monitor create requests to fail when an envoy has never been connected for that resource.