### PR TITLE
MethodArgumentNotValidException should be a 400

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/RestExceptionHandler.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -37,7 +38,7 @@ public class RestExceptionHandler extends
     super(errorAttributes);
   }
 
-  @ExceptionHandler({IllegalArgumentException.class})
+  @ExceptionHandler({IllegalArgumentException.class, MethodArgumentNotValidException.class})
   public ResponseEntity<?> handleBadRequest(
       HttpServletRequest request) {
     return respondWith(request, HttpStatus.BAD_REQUEST);


### PR DESCRIPTION
# What

Convert MethodArgumentNotValidException to send a 400 instead of 500.

# How

Adds the exception to our handler.

## How to test

Tested manually

# Why

A request through the admin api to create a public zone returned a 500.  The mon-mgmt service logged the below details.

I had thought these got translated to `IllegalArgumentException` and that's what our tests appear to validate.  Running locally I have not been able to reproduce the 500 so I'm not sure if this change is accurate.  Prod currently returns `500 Failed to route the request to the origin service`

```
2019-07-01 19:00:10.897  WARN 1 --- [nio-8080-exec-5] .w.s.m.s.DefaultHandlerExceptionResolver : Resolved [org.springframework.web.bind.MethodArgumentNotValidException: Validation failed for argument [0] in public com.rackspace.salus.monitor_management.web.model.ZoneDTO com.rackspace.salus.monitor_management.web.controller.ZoneApiController.create(com.rackspace.salus.monitor_management.web.model.ZoneCreatePublic) throws com.rackspace.salus.telemetry.errors.AlreadyExistsException: [Field error in object 'zoneCreatePublic' on field 'name': rejected value [public/us-central-1]; codes [Pattern.zoneCreatePublic.name,Pattern.name,Pattern.java.lang.String,Pattern]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [zoneCreatePublic.name,name]; arguments []; default message [name],[Ljavax.validation.constraints.Pattern$Flag;@5d6f7bff,org.springframework.validation.beanvalidation.SpringValidatorAdapter$ResolvableAttribute@52a6f971]; default message [Only alphanumeric, underscores, and slashes can be used]] ]
```

# TODO

We should probably apply this to all services.