### PR TITLE
Update net monitor defaults

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
@@ -27,5 +28,6 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 public class Net extends LocalPlugin {
   List<String> interfaces;
-  Boolean ignoreProtocolStats;
+  @JsonProperty(defaultValue = "true")
+  Boolean ignoreProtocolStats = true;
 }


### PR DESCRIPTION
I think we can default to ignoring the protocol stats.  If we collect those as default we'd be collecting a lot of metrics that would never get used.

Defaulting to exclude them also means the default config for windows and linux will be the same, since the protocol stats are only available on linux.

The docs for this are here - https://github.com/influxdata/telegraf/blob/master/plugins/inputs/net/NET_README.md#measurements--fields