### PR TITLE
Allow empty label selectors

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
@@ -20,7 +20,6 @@ import com.rackspace.salus.telemetry.model.ValidLabelKeys;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.Map;
 import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -33,7 +32,7 @@ public class DetailedMonitorInput {
    * For a resource to be selected, it must contain at least all of the labels given here.
    */
   @ValidLabelKeys
-  @NotEmpty(groups = ValidationGroups.Create.class)
+  @NotNull(groups = ValidationGroups.Create.class)
   Map<String,String> labelSelector;
 
   @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\",\"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false,\"reportActive\": false, \"totalcpu\": true}}")

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -237,6 +237,53 @@ public class MonitorApiControllerTest {
   }
 
   @Test
+  public void testCreateMonitor_EmptyLabelSelector() throws Exception {
+    Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
+    monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
+    monitor.setAgentType(AgentType.TELEGRAF);
+    monitor.setContent("{\"type\":\"mem\"}");
+    when(monitorManagement.createMonitor(anyString(), any()))
+        .thenReturn(monitor);
+
+    String tenantId = RandomStringUtils.randomAlphabetic(8);
+    String url = String.format("/api/tenant/%s/monitors", tenantId);
+    DetailedMonitorInput create = podamFactory.manufacturePojo(DetailedMonitorInput.class);
+    create.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
+    create.setLabelSelector(Collections.emptyMap());
+
+    mockMvc.perform(post(url)
+        .content(objectMapper.writeValueAsString(create))
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andExpect(status().isCreated())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  public void testCreateMonitor_NullLabelSelector() throws Exception {
+    Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
+    monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
+    monitor.setAgentType(AgentType.TELEGRAF);
+    monitor.setContent("{\"type\":\"mem\"}");
+    when(monitorManagement.createMonitor(anyString(), any()))
+        .thenReturn(monitor);
+
+    String tenantId = RandomStringUtils.randomAlphabetic(8);
+    String url = String.format("/api/tenant/%s/monitors", tenantId);
+    DetailedMonitorInput create = podamFactory.manufacturePojo(DetailedMonitorInput.class);
+    create.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
+    create.setLabelSelector(null);
+
+    mockMvc.perform(post(url)
+        .content(objectMapper.writeValueAsString(create))
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andExpect(status().isBadRequest())
+        .andExpect(validationError("labelSelector", "must not be null"));
+  }
+
+  @Test
   public void testCreateRemotePingMonitor() throws Exception {
     Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
     monitor.setSelectorScope(ConfigSelectorScope.REMOTE);


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-446

# What

Allow an empty list of labels to be provided when creating/updating monitors.

# How

Change the validation annotation.

## How to test

Run tests.
Try manually.

# Why

We want customers to be able to match all resources by leaving this empty.
e.g. If they want ping monitors on all resources they can just provide `{}`.