### PR TITLE
Add tenant APIs to query label selectors in use

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/entities/Monitor.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/entities/Monitor.java
@@ -38,6 +38,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -48,6 +50,10 @@ import org.hibernate.validator.constraints.NotBlank;
 @Entity
 @Table(name = "monitors", indexes = {
     @Index(name = "by_tenant", columnList = "tenant_id")
+})
+@NamedQueries({
+    @NamedQuery(name = "Monitor.getDistinctLabelSelectors",
+        query = "select distinct entry(m.labelSelector) from Monitor m where m.tenantId = :tenantId")
 })
 @Data
 public class Monitor implements Serializable {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1057,6 +1057,19 @@ public class MonitorManagement {
         );
   }
 
+  public MultiValueMap<String, String> getTenantMonitorLabelSelectors(String tenantId) {
+    final List<Map.Entry> distinctLabelTuples = entityManager.createNamedQuery(
+        "Monitor.getDistinctLabelSelectors", Map.Entry.class)
+        .setParameter("tenantId", tenantId)
+        .getResultList();
+
+    final MultiValueMap<String,String> combined = new LinkedMultiValueMap<>();
+    for (Entry entry : distinctLabelTuples) {
+      combined.add((String)entry.getKey(), (String)entry.getValue());
+    }
+    return combined;
+  }
+
   private int rebalanceWithZoneBindingCounts(ResolvedZone zone,
       Map<EnvoyResourcePair, Integer> bindingCounts) {
     if (bindingCounts.size() <= 1) {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -26,9 +26,9 @@ import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.monitor_management.web.model.ValidationGroups;
-import com.rackspace.salus.telemetry.model.View;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
+import com.rackspace.salus.telemetry.model.View;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -41,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -173,5 +174,12 @@ public class MonitorApiController {
                                                  @RequestBody Map<String, String> labels, Pageable pageable) {
         return PagedContent.fromPage(monitorManagement.getMonitorsFromLabels(labels, tenantId, pageable)
             .map(monitor -> monitorConversionService.convertToOutput(monitor)));
+    }
+
+    @GetMapping("/tenant/{tenantId}/monitor-label-selectors")
+    @ApiOperation("Lists the label selector keys and the values for each that are currently in use on monitors")
+    @JsonView(View.Public.class)
+    public MultiValueMap<String,String> getMonitorLabelSelectors(@PathVariable String tenantId) {
+        return monitorManagement.getTenantMonitorLabelSelectors(tenantId);
     }
 }

--- a/src/test/resources/MonitorApiControllerTest/monitor_label_selectors.json
+++ b/src/test/resources/MonitorApiControllerTest/monitor_label_selectors.json
@@ -1,0 +1,15 @@
+{
+  "agent_discovered_os": [
+    "linux",
+    "darwin",
+    "windows"
+  ],
+  "agent_discovered_arch": [
+    "amd64",
+    "386"
+  ],
+  "cluster": [
+    "dev",
+    "prod"
+  ]
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-450

# What

Adds tenant REST API to query for the label selectors (key-value) currently in use on their monitors. This will enable UIs to auto-suggest label selectors for monitor create and update operations.

## How to test

Unit tests expanded to cover new operation