### PR TITLE
Avoid binding monitors when the rendered content is not valid

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/errors/InvalidTemplateException.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/errors/InvalidTemplateException.java
@@ -1,0 +1,8 @@
+package com.rackspace.salus.monitor_management.errors;
+
+public class InvalidTemplateException extends Exception {
+
+  public InvalidTemplateException(String message, Throwable e) {
+    super(message, e);
+  }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.services;
 
 import com.rackspace.salus.monitor_management.config.MonitorContentProperties;
+import com.rackspace.salus.monitor_management.errors.InvalidTemplateException;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.samskivert.mustache.Escapers;
 import com.samskivert.mustache.Mustache;
@@ -38,12 +39,11 @@ public class MonitorContentRenderer {
   @Autowired
   public MonitorContentRenderer(MonitorContentProperties properties) {
     mustacheCompiler = Mustache.compiler()
-        .defaultValue("")
         .withEscaper(Escapers.NONE)
         .withDelims(properties.getPlaceholderDelimiters());
   }
 
-  public String render(String rawContent, ResourceDTO resource) {
+  public String render(String rawContent, ResourceDTO resource) throws InvalidTemplateException {
     final Template template = mustacheCompiler.compile(rawContent);
 
     final Map<String, Object> context = new HashMap<>();
@@ -52,7 +52,7 @@ public class MonitorContentRenderer {
     try {
       return template.execute(context);
     } catch (MustacheException e) {
-      throw new IllegalArgumentException("Unable to render monitor content template", e);
+      throw new InvalidTemplateException("Unable to render monitor content template", e);
     }
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentRendererTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentRendererTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.rackspace.salus.monitor_management.config.MonitorContentProperties;
+import com.rackspace.salus.monitor_management.errors.InvalidTemplateException;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,7 +30,7 @@ import org.junit.Test;
 public class MonitorContentRendererTest {
 
   @Test
-  public void testRenderTypical() {
+  public void testRenderTypical() throws InvalidTemplateException {
     Map<String, String> labels = new HashMap<>();
 
     final Map<String, String> metadata = new HashMap<>();
@@ -49,8 +50,8 @@ public class MonitorContentRendererTest {
     assertThat(rendered, equalTo("{\"type\": \"ping\", \"urls\": [\"150.1.2.3\"]}"));
   }
 
-  @Test
-  public void testMetadataFieldNotPresent() {
+  @Test(expected = InvalidTemplateException.class)
+  public void testMetadataFieldNotPresent() throws InvalidTemplateException {
     final ResourceDTO resource = new ResourceDTO()
         .setLabels(Collections.emptyMap())
         .setMetadata(Collections.emptyMap());
@@ -62,12 +63,10 @@ public class MonitorContentRendererTest {
         "address=${resource.metadata.address}",
         resource
     );
-
-    assertThat(rendered, equalTo("address="));
   }
 
-  @Test
-  public void testMetadataFieldIsNull() {
+  @Test(expected = InvalidTemplateException.class)
+  public void testMetadataFieldIsNull() throws InvalidTemplateException {
     final ResourceDTO resource = new ResourceDTO()
         .setLabels(Collections.emptyMap())
         .setMetadata(Collections.singletonMap("nullness", null));
@@ -79,12 +78,10 @@ public class MonitorContentRendererTest {
         "value=${resource.metadata.nullness}",
         resource
     );
-
-    assertThat(rendered, equalTo("value="));
   }
 
-  @Test
-  public void testTopLevelBadReference() {
+  @Test(expected = InvalidTemplateException.class)
+  public void testTopLevelBadReference() throws InvalidTemplateException {
     final ResourceDTO resource = new ResourceDTO()
         .setLabels(Collections.emptyMap())
         .setMetadata(Collections.emptyMap());
@@ -96,12 +93,10 @@ public class MonitorContentRendererTest {
         "value=${nothere.novalue}",
         resource
     );
-
-    assertThat(rendered, equalTo("value="));
   }
 
-  @Test
-  public void testResourceLevelBadReference() {
+  @Test(expected = InvalidTemplateException.class)
+  public void testResourceLevelBadReference() throws InvalidTemplateException {
     final ResourceDTO resource = new ResourceDTO()
         .setLabels(Collections.emptyMap())
         .setMetadata(Collections.emptyMap());
@@ -113,12 +108,10 @@ public class MonitorContentRendererTest {
         "value=${resource.wrong.reference}",
         resource
     );
-
-    assertThat(rendered, equalTo("value="));
   }
 
   @Test
-  public void testDottedLabelFields() {
+  public void testDottedLabelFields() throws InvalidTemplateException {
     final ResourceDTO resource = new ResourceDTO()
         .setLabels(Collections.singletonMap("agent.discovered.os", "linux"))
         .setMetadata(Collections.emptyMap());
@@ -140,7 +133,7 @@ public class MonitorContentRendererTest {
   }
 
   @Test
-  public void testUnderscoredLabelFields() {
+  public void testUnderscoredLabelFields() throws InvalidTemplateException {
     final ResourceDTO resource = new ResourceDTO()
         .setLabels(Collections.singletonMap("agent_discovered_os", "linux"))
         .setMetadata(Collections.emptyMap());
@@ -157,7 +150,7 @@ public class MonitorContentRendererTest {
   }
 
   @Test
-  public void testDashedLabelFields() {
+  public void testDashedLabelFields() throws InvalidTemplateException {
     final ResourceDTO resource = new ResourceDTO()
         .setLabels(Collections.singletonMap("agent-discovered-os", "linux"))
         .setMetadata(Collections.emptyMap());

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -2545,20 +2545,19 @@ public class MonitorManagementTest {
 
         verify(resourceApi).getByResourceId("t-1", "r-1");
 
+        verify(monitorEventProducer).sendMonitorEvent(
+            new MonitorBoundEvent()
+                .setEnvoyId("e-1")
+        );
+
         verify(boundMonitorRepository).findMonitorsBoundToResource("t-1", "r-1");
 
         verify(boundMonitorRepository).findAllByMonitor_IdIn(
             new HashSet<>(Collections.singletonList(monitor.getId()))
         );
 
-        verify(boundMonitorRepository).deleteAll(captorOfBoundMonitorList.capture());
-        final List<BoundMonitor> deletedBoundMonitors = captorOfBoundMonitorList.getValue();
-        assertThat(deletedBoundMonitors, hasSize(1));
-        assertThat(deletedBoundMonitors.get(0).getMonitor().getId(), equalTo(monitor.getId()));
-
-        verify(monitorEventProducer).sendMonitorEvent(
-            new MonitorBoundEvent()
-                .setEnvoyId("e-1")
+        verify(boundMonitorRepository).deleteAll(
+            Collections.singletonList(boundMonitor)
         );
 
         verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement,


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-495

# What

Previously, a "relaxed" setting of jmustache was being used for rendering monitor content where it would replace unresolvable template variables with an empty string. That leads to a misleading result where bound monitors would still get created, but with incorrect/invalid agent configuration blobs. It is better to avoid creating those bound monitors in the first place and reply upon a resource or monitor change to re-evaluate the monitor content.

# How

Remove the relaxed jmustache setting and handle the newly thrown `InvalidTemplateException`. In most cases it is as simple as not creating the bound monitoring and logging. The hardest case was when a resource change event comes across existing bindings that would become invalid due to a change in resource labels, for example.

## How to test

Existing unit tests and new unit tests were added.