### PR TITLE
Add endpoint to get policy monitors by id

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -96,6 +96,8 @@ public class MonitorManagement {
 
   private final EnvoyResourceManagement envoyResourceManagement;
 
+  public static final String POLICY_TENANT = "_POLICY_";
+
   JdbcTemplate jdbcTemplate;
 
   @Autowired
@@ -138,6 +140,16 @@ public class MonitorManagement {
    */
   public Optional<Monitor> getMonitor(String tenantId, UUID id) {
     return monitorRepository.findById(id).filter(m -> m.getTenantId().equals(tenantId));
+  }
+
+  /**
+   * Gets an individual policy monitor by id
+   * @param id The unique value representing the monitor.
+   * @return The monitor with the provided id.
+   * @throws NotFoundException If the monitor does not exist under the POLICY tenant.
+   */
+  public Optional<Monitor> getPolicyMonitor(UUID id) {
+    return getMonitor(POLICY_TENANT, id);
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
@@ -17,9 +17,11 @@
 package com.rackspace.salus.monitor_management.web.client;
 
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import java.util.List;
 
 public interface MonitorApi {
 
   List<BoundMonitorDTO> getBoundMonitors(String envoyId);
+  DetailedMonitorOutput getPolicyMonitorById(String monitorId);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -17,12 +17,14 @@
 package com.rackspace.salus.monitor_management.web.client;
 
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.telemetry.model.PagedContent;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -76,5 +78,23 @@ public class MonitorApiClient implements MonitorApi {
         null,
         PAGE_OF_BOUND_MONITOR
       ).getBody()).getContent();
+  }
+
+  @Override
+  public DetailedMonitorOutput getPolicyMonitorById(String monitorId) {
+    try {
+      return restTemplate.getForObject(
+          "/api/admin/policy-monitors/{monitorId}",
+          DetailedMonitorOutput.class,
+          monitorId
+      );
+    } catch (HttpClientErrorException e) {
+      if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+        return null;
+      }
+      else {
+        throw new IllegalArgumentException(e);
+      }
+    }
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -106,6 +106,13 @@ public class MonitorApiController {
                         uuid, tenantId)));
         return monitorConversionService.convertToOutput(monitor);
     }
+    @GetMapping("/admin/policy-monitors/{uuid}")
+    public DetailedMonitorOutput getPolicyMonitorById(@PathVariable UUID uuid) throws NotFoundException {
+        Monitor monitor =  monitorManagement.getPolicyMonitor(uuid).orElseThrow(() ->
+            new NotFoundException(String.format("No policy monitor found with id %s", uuid)));
+
+        return monitorConversionService.convertToOutput(monitor);
+    }
 
     @GetMapping("/tenant/{tenantId}/bound-monitors")
     @JsonView(View.Public.class)

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -273,6 +273,22 @@ public class MonitorManagementTest {
     }
 
     @Test
+    public void testGetPolicyMonitor() {
+        final Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
+        monitor.setTenantId(MonitorManagement.POLICY_TENANT);
+        Monitor saved = monitorRepository.save(monitor);
+
+        Optional<Monitor> m = monitorManagement.getPolicyMonitor(saved.getId());
+
+        assertTrue(m.isPresent());
+        assertThat(m.get().getTenantId(), equalTo(MonitorManagement.POLICY_TENANT));
+        assertThat(m.get().getId(), equalTo(saved.getId()));
+        assertThat(m.get().getLabelSelector(), equalTo(saved.getLabelSelector()));
+        assertThat(m.get().getContent(), equalTo(saved.getContent()));
+        assertThat(m.get().getAgentType(), equalTo(saved.getAgentType()));
+    }
+
+    @Test
     public void testCreateNewMonitor() {
         MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
         create.setSelectorScope(ConfigSelectorScope.LOCAL);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -120,6 +120,46 @@ public class MonitorApiControllerTest {
   }
 
   @Test
+  public void testGetPolicyMonitor() throws Exception {
+    Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
+    monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
+    monitor.setAgentType(AgentType.TELEGRAF);
+    monitor.setContent("{\"type\":\"mem\"}");
+    monitor.setTenantId(MonitorManagement.POLICY_TENANT);
+
+    when(monitorManagement.getPolicyMonitor(any()))
+        .thenReturn(Optional.of(monitor));
+
+    String url = String.format("/api/admin/policy-monitors/%s", monitor.getId());
+
+    mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id", is(monitor.getId().toString())));
+
+    verify(monitorManagement).getPolicyMonitor(monitor.getId());
+    verifyNoMoreInteractions(monitorManagement);
+  }
+
+  @Test
+  public void testGetPolicyMonitor_doesntExist() throws Exception {
+    when(monitorManagement.getPolicyMonitor(any()))
+        .thenReturn(Optional.empty());
+
+    UUID id = UUID.randomUUID();
+    String url = String.format("/api/admin/policy-monitors/%s", id);
+
+    mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+
+    verify(monitorManagement).getPolicyMonitor(id);
+    verifyNoMoreInteractions(monitorManagement);
+  }
+
+  @Test
   public void testNoMonitorFound() throws Exception {
     when(monitorManagement.getMonitor(anyString(), any()))
         .thenReturn(Optional.empty());


### PR DESCRIPTION
# What

Adds an api endpoint to retrieve a monitor under the `_POLICY_` tenant by its id.

# How

Use the existing `getById` method but hardcode the special tenant id.
Add all endpoints and tests.

## How to test

Run tests!

# Why

Policy Management will call this whenever a new monitor policy is created to verify that the monitor actually exists before the policy can be created.

# TODO

More changes will come for this service.  This is just the part that policy mgmt needs to interact with directly (and is used in tests).
