### PR TITLE
Add label selector method & some small changes

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -54,6 +54,7 @@ public class MonitorConversionService {
         .setId(monitor.getId().toString())
         .setName(monitor.getMonitorName())
         .setLabelSelector(monitor.getLabelSelector())
+        .setLabelSelectorMethod(monitor.getLabelSelectorMethod())
         .setResourceId(monitor.getResourceId())
         .setCreatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(monitor.getCreatedTimestamp()))
         .setUpdatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(monitor.getUpdatedTimestamp()));
@@ -104,6 +105,7 @@ public class MonitorConversionService {
     final MonitorCU monitor = new MonitorCU()
         .setMonitorName(input.getName())
         .setLabelSelector(input.getLabelSelector())
+        .setLabelSelectorMethod(input.getLabelSelectorMethod())
         .setResourceId(input.getResourceId());
 
     final MonitorDetails details = input.getDetails();

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -32,15 +32,13 @@ import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.monitor_management.errors.InvalidTemplateException;
 import com.rackspace.salus.telemetry.messaging.PolicyMonitorUpdateEvent;
 import com.rackspace.salus.telemetry.messaging.TenantPolicyChangeEvent;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.monitor_management.web.model.ZoneAssignmentCount;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
-import com.rackspace.salus.telemetry.entities.BoundMonitor;
-import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
@@ -230,6 +228,7 @@ public class MonitorManagement {
         .setTenantId(tenantId)
         .setMonitorName(newMonitor.getMonitorName())
         .setLabelSelector(newMonitor.getLabelSelector())
+        .setLabelSelectorMethod(newMonitor.getLabelSelectorMethod())
         .setResourceId(newMonitor.getResourceId())
         .setContent(newMonitor.getContent())
         .setAgentType(newMonitor.getAgentType())
@@ -253,10 +252,16 @@ public class MonitorManagement {
 
     validateMonitoringZones(POLICY_TENANT, null, newMonitor);
 
+    if (!StringUtils.isBlank(newMonitor.getResourceId())) {
+      throw new IllegalArgumentException(
+          "Policy Monitors must use label selectors and not a resourceId");
+    }
+
     Monitor monitor = new Monitor()
         .setTenantId(POLICY_TENANT)
         .setMonitorName(newMonitor.getMonitorName())
         .setLabelSelector(newMonitor.getLabelSelector())
+        .setLabelSelectorMethod(newMonitor.getLabelSelectorMethod())
         .setContent(newMonitor.getContent())
         .setAgentType(newMonitor.getAgentType())
         .setSelectorScope(newMonitor.getSelectorScope())
@@ -561,16 +566,35 @@ public class MonitorManagement {
       monitor.setResourceId(updatedValues.getResourceId());
     }
 
-    if (updatedValues.getLabelSelector() != null &&
-        !updatedValues.getLabelSelector().equals(monitor.getLabelSelector())) {
+    boolean labelSelectorChanged = labelSelectorChanged(monitor, updatedValues);
+    boolean methodChanged = labelSelectorMethodChanged(monitor, updatedValues);
+    if (labelSelectorChanged || methodChanged) {
       // Process potential changes to resource selection and therefore bindings
       // ...only need to process removed and new bindings
 
+      // Set the new label selector
+      if (methodChanged) {
+        monitor.setLabelSelectorMethod(updatedValues.getLabelSelectorMethod());
+      }
+
+      // Determine what the newest labels are
+      Map<String, String> labels;
+      if (labelSelectorChanged) {
+        labels = updatedValues.getLabelSelector();
+      } else {
+        labels = monitor.getLabelSelector();
+      }
+
       affectedEnvoys.addAll(
-          processMonitorLabelSelectorModified(tenantId, monitor, updatedValues.getLabelSelector())
+          processMonitorLabelSelectorModified(tenantId, monitor, labels)
       );
 
-      monitor.setLabelSelector(updatedValues.getLabelSelector());
+      // Finally, update the monitors labels
+      if (labelSelectorChanged) {
+        monitor.setLabelSelector(new HashMap<>(updatedValues.getLabelSelector()));
+      } else {
+        monitor.setLabelSelector(new HashMap<>(monitor.getLabelSelector()));
+      }
     }
     else if (monitor.getLabelSelector() != null) {
       // JPA's EntityManager is a little strange with re-saving (aka merging) an entity
@@ -629,6 +653,11 @@ public class MonitorManagement {
    * @return The newly updated monitor.
    */
   public Monitor updatePolicyMonitor(UUID id, @Valid MonitorCU updatedValues) {
+    if (!StringUtils.isBlank(updatedValues.getResourceId())) {
+      throw new IllegalArgumentException(
+          "Policy Monitors must use label selectors and not a resourceId");
+    }
+
     Monitor monitor = getMonitor(POLICY_TENANT, id).orElseThrow(() ->
         new NotFoundException(String.format("No policy monitor found for %s", id)));
 
@@ -643,6 +672,9 @@ public class MonitorManagement {
     map.from(updatedValues.getContent())
         .whenNonNull()
         .to(monitor::setContent);
+    map.from(updatedValues.getLabelSelectorMethod())
+        .whenNonNull()
+        .to(monitor::setLabelSelectorMethod);
 
     // PropertyMapper cannot efficiently handle these two fields.
     if (updatedValues.getLabelSelector() != null &&
@@ -716,6 +748,16 @@ public class MonitorManagement {
     return updatedZones != null &&
         ( updatedZones.size() != prevZones.size() ||
             !updatedZones.containsAll(prevZones));
+  }
+
+  private static boolean labelSelectorChanged(Monitor original, MonitorCU newValues) {
+    return newValues.getLabelSelector() != null &&
+        !newValues.getLabelSelector().equals(original.getLabelSelector());
+  }
+
+  private static boolean labelSelectorMethodChanged(Monitor original, MonitorCU newValues) {
+    return newValues.getLabelSelectorMethod() != null &&
+        !newValues.getLabelSelectorMethod().equals(original.getLabelSelectorMethod());
   }
 
   /**
@@ -1549,13 +1591,26 @@ public class MonitorManagement {
    * @param resource The resource to get the policy monitors for.
    * @return A list of monitors.
    */
-  private List<Monitor> getPolicyMonitorsForResource(Resource resource) {
+  List<Monitor> getPolicyMonitorsForResource(Resource resource) {
     String tenantId = resource.getTenantId();
     List<UUID> policyMonitorIds = policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId);
 
     List<Monitor> resourcePolicies = monitorRepository.findByIdIn(policyMonitorIds)
         .stream()
-        .filter(m -> resource.getLabels().entrySet().containsAll(m.getLabelSelector().entrySet()))
+        .filter(m -> {
+          if (m.getLabelSelector().isEmpty()) {
+            // If no labels are set the monitor applies to all resources
+            return true;
+          }
+          else if (m.getLabelSelectorMethod().equals(LabelSelectorMethod.OR)) {
+            return m.getLabelSelector().entrySet().stream().anyMatch(labels -> {
+              log.info("Testing if {} is in the resource: {}", labels,resource.getLabels().entrySet().contains(labels));
+              return resource.getLabels().entrySet().contains(labels);
+            });
+          } else {
+            return resource.getLabels().entrySet().containsAll(m.getLabelSelector().entrySet());
+          }
+        })
         .collect(Collectors.toList());
 
     log.info("Found {} monitor policies for resource={} from {} total policies for tenant={}",

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -261,11 +261,14 @@ public class MonitorManagement {
         .setTenantId(POLICY_TENANT)
         .setMonitorName(newMonitor.getMonitorName())
         .setLabelSelector(newMonitor.getLabelSelector())
-        .setLabelSelectorMethod(newMonitor.getLabelSelectorMethod())
         .setContent(newMonitor.getContent())
         .setAgentType(newMonitor.getAgentType())
         .setSelectorScope(newMonitor.getSelectorScope())
         .setZones(newMonitor.getZones());
+
+    if (newMonitor.getLabelSelectorMethod() != null) {
+      monitor.setLabelSelectorMethod(newMonitor.getLabelSelectorMethod());
+    }
 
     monitor = monitorRepository.save(monitor);
     return monitor;

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1607,7 +1607,6 @@ public class MonitorManagement {
           }
           else if (m.getLabelSelectorMethod().equals(LabelSelectorMethod.OR)) {
             return m.getLabelSelector().entrySet().stream().anyMatch(labels -> {
-              log.info("Testing if {} is in the resource: {}", labels,resource.getLabels().entrySet().contains(labels));
               return resource.getLabels().entrySet().contains(labels);
             });
           } else {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -593,11 +593,7 @@ public class MonitorManagement {
       );
 
       // Finally, update the monitors labels
-      if (labelSelectorChanged) {
-        monitor.setLabelSelector(new HashMap<>(updatedValues.getLabelSelector()));
-      } else {
-        monitor.setLabelSelector(new HashMap<>(monitor.getLabelSelector()));
-      }
+      monitor.setLabelSelector(new HashMap<>(labels));
     }
     else if (monitor.getLabelSelector() != null) {
       // JPA's EntityManager is a little strange with re-saving (aka merging) an entity

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.monitor_management.web.model;
 
 import com.rackspace.salus.monitor_management.web.model.validator.ValidCreateMonitor;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidUpdateMonitor;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.ValidLabelKeys;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.Map;
@@ -37,6 +38,8 @@ public class DetailedMonitorInput {
    */
   @ValidLabelKeys
   Map<String,String> labelSelector;
+
+  LabelSelectorMethod labelSelectorMethod;
 
   String resourceId;
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
@@ -18,6 +18,7 @@
 package com.rackspace.salus.monitor_management.web.model;
 
 
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.util.Map;
 
 import io.swagger.annotations.ApiModelProperty;
@@ -28,6 +29,7 @@ public class DetailedMonitorOutput {
     String id;
     String name;
     Map<String,String> labelSelector;
+    LabelSelectorMethod labelSelectorMethod;
     String resourceId;
     @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\", \"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false, \"reportActive\": false, \"totalcpu\": true} }")
     MonitorDetails details;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.monitor_management.web.model;
 
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,8 @@ public class MonitorCU implements Serializable {
     String monitorName;
 
     Map<String,String> labelSelector;
+
+    LabelSelectorMethod labelSelectorMethod;
 
     String content;
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDTO.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,8 @@ public class MonitorDTO {
   String monitorName;
 
   Map<String,String> labelSelector;
+
+  LabelSelectorMethod labelSelectorMethod;
 
   String tenantId;
 
@@ -55,6 +58,7 @@ public class MonitorDTO {
     this.id = monitor.getId();
     this.monitorName = monitor.getMonitorName();
     this.labelSelector = monitor.getLabelSelector();
+    this.labelSelectorMethod = monitor.getLabelSelectorMethod();
     this.resourceId = monitor.getResourceId();
     this.tenantId = monitor.getMonitorName();
     this.content = monitor.getContent();

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -37,6 +37,7 @@ import com.rackspace.salus.monitor_management.web.model.telegraf.Procstat;
 import com.rackspace.salus.monitor_management.web.model.telegraf.X509Cert;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
@@ -86,6 +87,7 @@ public class MonitorConversionServiceTest {
         .setAgentType(AgentType.TELEGRAF)
         .setSelectorScope(ConfigSelectorScope.LOCAL)
         .setLabelSelector(Collections.singletonMap("os","linux"))
+        .setLabelSelectorMethod(LabelSelectorMethod.OR)
         .setContent(content)
         .setCreatedTimestamp(DEFAULT_TIMESTAMP)
         .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
@@ -204,6 +206,7 @@ public class MonitorConversionServiceTest {
     assertThat(result.getId()).isEqualTo(monitorId.toString());
     assertThat(result.getName()).isEqualTo("name-a");
     assertThat(result.getLabelSelector()).isEqualTo(labels);
+    assertThat(result.getLabelSelectorMethod()).isEqualTo(LabelSelectorMethod.AND);
     assertThat(result.getDetails()).isInstanceOf(RemoteMonitorDetails.class);
 
     final RemoteMonitorDetails remoteMonitorDetails = (RemoteMonitorDetails) result.getDetails();
@@ -230,11 +233,13 @@ public class MonitorConversionServiceTest {
     DetailedMonitorInput input = new DetailedMonitorInput()
         .setName("name-a")
         .setLabelSelector(labels)
+        .setLabelSelectorMethod(LabelSelectorMethod.OR)
         .setDetails(details);
     final MonitorCU result = conversionService.convertFromInput(input);
 
     assertThat(result).isNotNull();
     assertThat(result.getLabelSelector()).isEqualTo(labels);
+    assertThat(result.getLabelSelectorMethod()).isEqualTo(LabelSelectorMethod.OR);
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
     assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.REMOTE);
@@ -534,5 +539,24 @@ public class MonitorConversionServiceTest {
     assertThat(result.getResourceId()).isEqualTo(monitor.getResourceId());
   }
 
+  @Test
+  public void testConvertTo_LabelSelectorMethod() {
+    final UUID monitorId = UUID.randomUUID();
 
+    Monitor monitor = new Monitor()
+        .setLabelSelectorMethod(LabelSelectorMethod.AND)
+        .setId(monitorId)
+        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
+        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+    final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
+    assertThat(result.getLabelSelectorMethod()).isEqualTo(monitor.getLabelSelectorMethod());
+  }
+
+  @Test
+  public void testConvertFrom_LabelSelectorMethod() {
+    DetailedMonitorInput input = new DetailedMonitorInput()
+        .setLabelSelectorMethod(LabelSelectorMethod.OR);
+    final MonitorCU result = conversionService.convertFromInput(input);
+    assertThat(result.getLabelSelectorMethod()).isEqualTo(input.getLabelSelectorMethod());
+  }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -677,13 +677,13 @@ public class MonitorManagementTest {
 
     final ResourceDTO windowsResource = new ResourceDTO()
         .setLabels(Map.of("os", "windows", "env", "dev"))
-        .setResourceId("r-1")
+        .setResourceId("r-windows")
         .setAssociatedWithEnvoy(true)
         .setTenantId("t-1");
 
     final ResourceDTO linuxResource = new ResourceDTO()
         .setLabels(labels)
-        .setResourceId("r-2")
+        .setResourceId("r-linux")
         .setAssociatedWithEnvoy(true)
         .setTenantId("t-1");
 
@@ -702,15 +702,15 @@ public class MonitorManagementTest {
         .thenReturn(List.of(linuxResource, windowsResource));
 
     // An envoy will have to be found for the windows resource when method is changed to OR
-    when(envoyResourceManagement.getOne("t-1", "r-1"))
+    when(envoyResourceManagement.getOne("t-1", "r-windows"))
         .thenReturn(
             CompletableFuture.completedFuture(
-                new ResourceInfo().setResourceId("r-1").setEnvoyId("e-1")
+                new ResourceInfo().setResourceId("r-windows").setEnvoyId("e-1")
             )
         );
 
     when(boundMonitorRepository.findResourceIdsBoundToMonitor(any()))
-        .thenReturn(Set.of("r-2"));
+        .thenReturn(Set.of("r-linux"));
     when(boundMonitorRepository.findAllByMonitor_IdAndResourceId(any(), anyString()))
         .thenReturn(Collections.emptyList());
 
@@ -737,15 +737,15 @@ public class MonitorManagementTest {
         new BoundMonitor()
             .setMonitor(monitor)
             .setTenantId("t-1")
-            .setResourceId("r-1")
+            .setResourceId("r-windows")
             .setEnvoyId("e-1")
             .setZoneName("")
             .setRenderedContent("{}")
     ));
-    verify(boundMonitorRepository).findAllByMonitor_IdAndResourceId(monitor.getId(), "r-1");
+    verify(boundMonitorRepository).findAllByMonitor_IdAndResourceId(monitor.getId(), "r-windows");
 
     verify(boundMonitorRepository).findResourceIdsBoundToMonitor(monitor.getId());
-    verify(envoyResourceManagement).getOne("t-1", "r-1");
+    verify(envoyResourceManagement).getOne("t-1", "r-windows");
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent().setEnvoyId("e-1")
     );

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -49,6 +49,7 @@ import com.rackspace.salus.monitor_management.web.model.telegraf.Mem;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
 import java.nio.charset.StandardCharsets;
@@ -267,6 +268,7 @@ public class MonitorApiControllerTest {
     monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
     monitor.setAgentType(AgentType.TELEGRAF);
     monitor.setContent("{\"type\":\"mem\"}");
+    monitor.setLabelSelectorMethod(LabelSelectorMethod.OR);
     when(monitorManagement.createMonitor(anyString(), any()))
         .thenReturn(monitor);
 


### PR DESCRIPTION
## You'll want to enable the setting to ignore whitespace changes when reviewing!

# What

* Adds ability to set labelSelectorMethod.
* Adds basic handling of labelSelectorMethod in `getPolicyMonitorsForResource`
* Updates the models used by the api
* Prevents Policy Monitors from being created with a `resourceId`
* Adds tests (that assume the resource API has already been updated)
* Fixes indentation in test file

## How to test

Run tests.
Since not all services are updated yet, this option does not work in reality, but only in tests when we can mock out some of the other requests.

# Why

This adds more flexibility to the Monitor configurations and allows for scenarios such as

```
monitorType: SSH
labelSelector: [{"os":"linux"}, {"agent_discovered_os": "linux"}]
labelSelectorMethod: OR
```

With this an SSH monitor will be applied to resources whether there is a user (or automation) specified label on the resource, or if there is an OS label discovered by the envoy that matches.

# TODO

Adam will be working on these.

* Update resource management and its api to understand the label selector method and act differently whether it is AND or OR.
* Update monitor management label selector query to understand the label selector method.

Other thought:
* We should probably get rid of MonitorDTO and/or rename the detailed output to MonitorDTO