### PR TITLE
 Store index of policy metadata used in monitor's contents 

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/config/MonitorContentProperties.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/MonitorContentProperties.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.monitor_management.config;
 
+import com.rackspace.salus.telemetry.entities.MetadataPolicy;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -30,4 +31,15 @@ public class MonitorContentProperties {
    * rendering. The default avoids conflicting with "{{ }}" used by Insomnia for its templating.
    */
   String placeholderDelimiters = "${ }";
+
+  /**
+   * Regex string that can be used the detect the variables set in the monitor's content.
+   *
+   * If any templated variables are found when using this regex with a Matcher, the variable
+   * name without the prefix can be retrieved with <code>matcher.group(1)</code>.
+   *
+   * If the {@link MonitorContentProperties:placeholderDelimiters} changes, this regex should
+   * also change.
+   */
+  String placeholderRegex = String.format("\\$\\{%s(.+?)}", MetadataPolicy.PREFIX);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
@@ -43,7 +43,7 @@ public class MonitorContentRenderer {
         .withDelims(properties.getPlaceholderDelimiters());
   }
 
-  public String render(String rawContent, ResourceDTO resource) throws InvalidTemplateException {
+  String render(String rawContent, ResourceDTO resource) throws InvalidTemplateException {
     final Template template = mustacheCompiler.compile(rawContent);
 
     final Map<String, Object> context = new HashMap<>();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,7 +16,7 @@ spring:
     properties:
       hibernate:
         generate_statistics: false
-    show-sql: false
+    show-sql: true
   datasource:
     username: dev
     password: pass

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
@@ -435,6 +435,7 @@ public class MonitorManagementPolicyTest {
                 .setId(monitor.getId())
                 .setAgentType(AgentType.TELEGRAF)
                 .setContent("new content")
+                .setTemplateVariables(Collections.emptyList())
                 .setTenantId(POLICY_TENANT)
                 .setSelectorScope(ConfigSelectorScope.REMOTE)
                 .setLabelSelector(monitor.getLabelSelector())

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/MonitorDTOTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/MonitorDTOTest.java
@@ -22,13 +22,10 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rackspace.salus.monitor_management.web.model.MonitorDTO;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import java.lang.reflect.Field;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.ReflectionUtils;


### PR DESCRIPTION
# What

Whenever a monitor is created or updated we will store any of the template variables within its content that corresponds to policy metadata.

# How

A regex is used to look for anything that fits the format `${rackspace.metadata.*}` and we will retrieve the value in place of the `*`.

## How to test

Runt tests.
Try manually.

# Why

Whenever policy metadata (the default configuration settings for monitors/tasks) is changed we will be able to easily look up any monitor that is using that field and therefore affected by the change.

# TODO / Incoming PRs

* Add the handling of metadata change events that will utilize this lookup.
   * Update `getRenderedContent` to retrieve the relevant policy metadata fields for the tenant.
* Policy Management PR to introduce the concept of policy metadata and the sending of events that will be consumed by monitor management.
* model changes to allow for this