### PR TITLE
Allowing monitoring interval to be configurable per monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/config/MonitorConversionProperties.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/MonitorConversionProperties.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.config;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+
+@ConfigurationProperties("salus.monitor-conversion")
+@Data
+public class MonitorConversionProperties {
+
+  /**
+   * Monitors are not allowed to be created/updated with an interval less than this value.
+   */
+  @DurationUnit(ChronoUnit.SECONDS)
+  Duration minimumAllowedInterval = Duration.ofSeconds(30);
+
+  /**
+   * This is the default value used if a create or update API call provides a local monitor
+   * without <code>interval</code> set.
+   */
+  @DurationUnit(ChronoUnit.SECONDS)
+  Duration defaultLocalInterval = Duration.ofSeconds(60);
+
+  /**
+   * This is the default value used if a create or update API call provides a remote monitor
+   * without <code>interval</code> set.
+   */
+  @DurationUnit(ChronoUnit.SECONDS)
+  Duration defaultRemoteInterval = Duration.ofSeconds(60);
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
@@ -18,12 +18,13 @@ package com.rackspace.salus.monitor_management.web.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.telemetry.entities.BoundMonitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
-import java.time.format.DateTimeFormatter;
-import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.telemetry.model.View;
+import java.time.Duration;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -42,6 +43,7 @@ public class BoundMonitorDTO {
   @JsonInclude(Include.NON_EMPTY)
   String zoneName;
   String resourceId;
+  Duration interval;
   ConfigSelectorScope selectorScope;
   AgentType agentType;
   String renderedContent;
@@ -54,6 +56,7 @@ public class BoundMonitorDTO {
     this.tenantId = boundMonitor.getTenantId();
     this.zoneName = boundMonitor.getZoneName();
     this.resourceId = boundMonitor.getResourceId();
+    this.interval = boundMonitor.getMonitor().getInterval();
     this.selectorScope = boundMonitor.getMonitor().getSelectorScope();
     this.agentType = boundMonitor.getMonitor().getAgentType();
     this.renderedContent = boundMonitor.getRenderedContent();

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
@@ -21,6 +21,7 @@ import com.rackspace.salus.monitor_management.web.model.validator.ValidUpdateMon
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.ValidLabelKeys;
 import io.swagger.annotations.ApiModelProperty;
+import java.time.Duration;
 import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -42,6 +43,8 @@ public class DetailedMonitorInput {
   LabelSelectorMethod labelSelectorMethod;
 
   String resourceId;
+
+  Duration interval;
 
   @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\",\"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false,\"reportActive\": false, \"totalcpu\": true}}")
   @NotNull(groups = ValidationGroups.Create.class)

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
@@ -19,9 +19,9 @@ package com.rackspace.salus.monitor_management.web.model;
 
 
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
-import java.util.Map;
-
 import io.swagger.annotations.ApiModelProperty;
+import java.time.Duration;
+import java.util.Map;
 import lombok.Data;
 
 @Data
@@ -31,6 +31,7 @@ public class DetailedMonitorOutput {
     Map<String,String> labelSelector;
     LabelSelectorMethod labelSelectorMethod;
     String resourceId;
+    Duration interval;
     @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\", \"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false, \"reportActive\": false, \"totalcpu\": true} }")
     MonitorDetails details;
     String createdTimestamp;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
@@ -20,6 +20,7 @@ import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import lombok.Data;
@@ -53,4 +54,6 @@ public class MonitorCU implements Serializable {
     List<String> zones;
 
     String resourceId;
+
+    Duration interval;
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -68,9 +68,6 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 @AutoConfigureJson
 public class MonitorConversionServiceTest {
 
-  // A timestamp to be used in tests that translates to "1970-01-02T03:46:40Z"
-  private static final Instant DEFAULT_TIMESTAMP = Instant.ofEpochSecond(100000);
-
   private static final Duration MIN_INTERVAL = Duration.ofSeconds(10);
   private static final Duration DEFAULT_LOCAL_INTERVAL = Duration.ofSeconds(30);
   private static final Duration DEFAULT_REMOTE_INTERVAL = Duration.ofMinutes(5);
@@ -102,8 +99,8 @@ public class MonitorConversionServiceTest {
         .setLabelSelector(Collections.singletonMap("os","linux"))
         .setLabelSelectorMethod(LabelSelectorMethod.OR)
         .setContent(content)
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
@@ -158,8 +155,8 @@ public class MonitorConversionServiceTest {
         .setSelectorScope(ConfigSelectorScope.LOCAL)
         .setLabelSelector(Collections.singletonMap("os","linux"))
         .setContent(content)
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
@@ -210,8 +207,8 @@ public class MonitorConversionServiceTest {
         .setZones(Collections.singletonList("z-1"))
         .setLabelSelector(labels)
         .setContent(content)
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
@@ -278,8 +275,8 @@ public class MonitorConversionServiceTest {
         .setZones(Collections.singletonList("z-1"))
         .setLabelSelector(labels)
         .setContent(content)
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
@@ -365,8 +362,8 @@ public class MonitorConversionServiceTest {
         .setZones(Collections.singletonList("z-1"))
         .setLabelSelector(labels)
         .setContent(content)
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
@@ -511,8 +508,8 @@ public class MonitorConversionServiceTest {
             .setSelectorScope(ConfigSelectorScope.LOCAL)
             .setLabelSelector(labels)
             .setContent(content)
-            .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-            .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+            .setCreatedTimestamp(Instant.EPOCH)
+            .setUpdatedTimestamp(Instant.EPOCH);
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
@@ -546,8 +543,8 @@ public class MonitorConversionServiceTest {
     Monitor monitor = new Monitor()
         .setResourceId("r-1")
         .setId(monitorId)
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
     assertThat(result.getResourceId()).isEqualTo(monitor.getResourceId());
   }
@@ -559,8 +556,8 @@ public class MonitorConversionServiceTest {
     Monitor monitor = new Monitor()
         .setLabelSelectorMethod(LabelSelectorMethod.AND)
         .setId(monitorId)
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
     assertThat(result.getLabelSelectorMethod()).isEqualTo(monitor.getLabelSelectorMethod());
   }
@@ -581,8 +578,8 @@ public class MonitorConversionServiceTest {
         .setLabelSelectorMethod(LabelSelectorMethod.AND)
         .setId(monitorId)
         .setInterval(Duration.ofSeconds(60))
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
     assertThat(result.getInterval()).isEqualTo(monitor.getInterval());
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -48,18 +49,15 @@ import com.rackspace.salus.monitor_management.config.DatabaseConfig;
 import com.rackspace.salus.monitor_management.config.MonitorContentProperties;
 import com.rackspace.salus.monitor_management.config.ServicesProperties;
 import com.rackspace.salus.monitor_management.config.ZonesProperties;
+import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.monitor_management.web.model.ZoneAssignmentCount;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.entities.BoundMonitor;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.entities.Resource;
 import com.rackspace.salus.telemetry.entities.Zone;
-import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
-import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
-import com.rackspace.salus.telemetry.repositories.MonitorRepository;
-import com.rackspace.salus.monitor_management.web.model.MonitorCU;
-import com.rackspace.salus.monitor_management.web.model.ZoneAssignmentCount;
-import com.rackspace.salus.resource_management.web.client.ResourceApi;
-import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
@@ -68,9 +66,13 @@ import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
+import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import com.rackspace.salus.telemetry.repositories.ResourceRepository;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -386,6 +388,38 @@ public class MonitorManagementTest {
 
     verifyNoMoreInteractions(monitorEventProducer, envoyResourceManagement,
         resourceApi, resourceRepository);
+  }
+
+  @Test
+  public void testCreateNewMonitor_interval() {
+    final Duration interval = Duration.ofSeconds(12);
+
+    MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
+    create.setSelectorScope(ConfigSelectorScope.LOCAL);
+    create.setZones(null);
+    create.setLabelSelector(null);
+    create.setInterval(interval);
+
+    String tenantId = RandomStringUtils.randomAlphanumeric(10);
+
+    final Resource resource = podamFactory.manufacturePojo(Resource.class);
+    when(resourceRepository.findByTenantIdAndResourceId(anyString(), any()))
+        .thenReturn(Optional.of(resource));
+    when(envoyResourceManagement.getOne(anyString(), anyString()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ResourceInfo()
+                    .setResourceId(resource.getResourceId())
+                    .setEnvoyId("e-1")));
+
+    Monitor returned = monitorManagement.createMonitor(tenantId, create);
+
+    assertThat(returned.getInterval(), equalTo(interval));
+
+    Optional<Monitor> retrieved = monitorManagement.getMonitor(tenantId, returned.getId());
+
+    assertTrue(retrieved.isPresent());
+    assertThat(retrieved.get().getInterval(), equalTo(interval));
   }
 
   @Test
@@ -893,6 +927,65 @@ public class MonitorManagementTest {
     // even though two bindings for r-2, the queries were grouped by resource and only one call here
     verify(resourceApi).getByResourceId("t-1", "r-2");
 
+    verify(monitorEventProducer).sendMonitorEvent(
+        new MonitorBoundEvent().setEnvoyId("e-1")
+    );
+
+    verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement, resourceApi,
+        zoneStorage, monitorEventProducer, resourceRepository);
+  }
+
+  @Test
+  public void testUpdateExistingMonitor_intervalChanged() {
+    final Duration initialInterval = Duration.ofSeconds(30);
+    final Duration updatedInterval = Duration.ofSeconds(42);
+
+    reset(envoyResourceManagement, resourceApi, boundMonitorRepository);
+
+    final Monitor monitor = new Monitor()
+        .setAgentType(AgentType.TELEGRAF)
+        .setContent("address=${resource.metadata.ping_ip}")
+        .setTenantId("t-1")
+        .setSelectorScope(ConfigSelectorScope.REMOTE)
+        .setLabelSelector(Collections.singletonMap("os", "linux"))
+        .setLabelSelectorMethod(LabelSelectorMethod.AND)
+        .setInterval(initialInterval);
+    entityManager.persist(monitor);
+
+    final BoundMonitor bound1 = new BoundMonitor()
+        .setMonitor(monitor)
+        .setTenantId("t-1")
+        .setResourceId("r-1")
+        .setEnvoyId("e-1")
+        .setZoneName("z-1")
+        .setRenderedContent("address=something_else");
+    entityManager.persist(bound1);
+
+    when(boundMonitorRepository.findAllByMonitor_Id(monitor.getId()))
+        .thenReturn(List.of(bound1));
+
+    // EXECUTE
+
+    final MonitorCU update = new MonitorCU()
+        .setInterval(updatedInterval);
+    final Monitor updatedMonitor = monitorManagement.updateMonitor("t-1", monitor.getId(), update);
+
+    // VERIFY
+
+    // verify returned entity's field
+    assertThat(updatedMonitor.getInterval(), equalTo(updatedInterval));
+
+    // and verify the stored entity
+    Optional<Monitor> retrieved = monitorManagement.getMonitor("t-1", updatedMonitor.getId());
+    assertTrue(retrieved.isPresent());
+    assertThat(retrieved.get().getInterval(), equalTo(updatedInterval));
+
+    verify(boundMonitorRepository).findAllByMonitor_Id(monitor.getId());
+
+    // should NOT re-save the bound monitor...just generates an event
+    verify(boundMonitorRepository, never()).saveAll(any());
+
+    // but should still send the update event
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent().setEnvoyId("e-1")
     );

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.controller;
 import static com.rackspace.salus.telemetry.entities.Monitor.POLICY_TENANT;
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static com.rackspace.salus.test.WebTestUtils.classValidationError;
+import static com.rackspace.salus.test.WebTestUtils.httpMessageNotReadable;
 import static com.rackspace.salus.test.WebTestUtils.validationError;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
@@ -626,7 +627,7 @@ public class MonitorApiControllerTest {
   }
 
   @Test
-  public void testCreateMonitor_intervalDurationParsing() throws Exception {
+  public void testCreateMonitor_intervalParsing_valid() throws Exception {
     final String content = readContent("MonitorApiControllerTest/create_monitor_duration.json");
 
     final Monitor stubMonitorResp = new Monitor()
@@ -653,6 +654,20 @@ public class MonitorApiControllerTest {
                 .setAgentType(AgentType.TELEGRAF)
                 .setContent(readContent("MonitorApiControllerTest/converted_monitor_duration.json"))
         );
+  }
+
+  @Test
+  public void testCreateMonitor_intervalParsing_invalidWithNumber() throws Exception {
+    final String content = readContent("MonitorApiControllerTest/create_monitor_duration_number.json");
+
+    mockMvc.perform(post("/api/tenant/t-1/monitors")
+        .content(content)
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andExpect(status().isBadRequest())
+        .andExpect(httpMessageNotReadable(
+            "Cannot deserialize value of type `java.time.Duration` from String \"30\""));
+
   }
 
   private class UpdateMonitorTestSetup {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOJsonTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOJsonTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,6 +54,7 @@ public class BoundMonitorDTOJsonTest {
         .setAgentType(AgentType.TELEGRAF)
         .setRenderedContent("{}")
         .setEnvoyId("e-1")
+        .setInterval(Duration.ofSeconds(30))
         .setCreatedTimestamp(DEFAULT_TIMESTAMP)
         .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
 
@@ -72,6 +74,7 @@ public class BoundMonitorDTOJsonTest {
         .setAgentType(AgentType.TELEGRAF)
         .setRenderedContent("{}")
         .setEnvoyId(null)
+        .setInterval(Duration.ofSeconds(30))
         .setCreatedTimestamp(DEFAULT_TIMESTAMP)
         .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
 
@@ -91,6 +94,7 @@ public class BoundMonitorDTOJsonTest {
         .setAgentType(AgentType.TELEGRAF)
         .setRenderedContent("{}")
         .setEnvoyId("e-1")
+        .setInterval(Duration.ofSeconds(30))
         .setCreatedTimestamp(DEFAULT_TIMESTAMP)
         .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
 

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOTest.java
@@ -60,5 +60,6 @@ public class BoundMonitorDTOTest {
     assertThat(dto.getAgentType(), equalTo(boundMonitor.getMonitor().getAgentType()));
     assertThat(dto.getRenderedContent(), equalTo(boundMonitor.getRenderedContent()));
     assertThat(dto.getEnvoyId(), equalTo(boundMonitor.getEnvoyId()));
+    assertThat(dto.getInterval(), equalTo(boundMonitor.getMonitor().getInterval()));
   }
 }

--- a/src/test/resources/BoundMonitorDTOJsonTest/testAllPopulated.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testAllPopulated.json
@@ -7,6 +7,7 @@
   "renderedContent": "{}",
   "envoyId": "e-1",
   "zoneName": "z-1",
+  "interval": "PT30S",
   "createdTimestamp": "1970-01-02T03:46:40Z",
   "updatedTimestamp": "1970-01-02T03:46:40Z"
 }

--- a/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nonNullEnvoy.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nonNullEnvoy.json
@@ -6,6 +6,7 @@
   "agentType": "TELEGRAF",
   "renderedContent": "{}",
   "envoyId": "e-1",
+  "interval": "PT30S",
   "createdTimestamp": "1970-01-02T03:46:40Z",
   "updatedTimestamp": "1970-01-02T03:46:40Z"
 }

--- a/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nullEnvoy.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nullEnvoy.json
@@ -6,6 +6,7 @@
   "agentType": "TELEGRAF",
   "renderedContent": "{}",
   "envoyId": null,
+  "interval": "PT30S",
   "createdTimestamp": "1970-01-02T03:46:40Z",
   "updatedTimestamp": "1970-01-02T03:46:40Z"
 }

--- a/src/test/resources/MonitorApiControllerTest/converted_monitor_duration.json
+++ b/src/test/resources/MonitorApiControllerTest/converted_monitor_duration.json
@@ -1,0 +1,1 @@
+{"type":"cpu","percpu":false,"totalcpu":true,"collectCpuTime":false,"reportActive":false}

--- a/src/test/resources/MonitorApiControllerTest/create_monitor_duration.json
+++ b/src/test/resources/MonitorApiControllerTest/create_monitor_duration.json
@@ -1,0 +1,12 @@
+{
+  "interval": "PT30S",
+  "labelSelector": {
+    "agent_environment": "localdev"
+  },
+  "details": {
+    "type": "local",
+    "plugin": {
+      "type": "cpu"
+    }
+  }
+}

--- a/src/test/resources/MonitorApiControllerTest/create_monitor_duration_number.json
+++ b/src/test/resources/MonitorApiControllerTest/create_monitor_duration_number.json
@@ -1,0 +1,12 @@
+{
+  "interval": "30",
+  "labelSelector": {
+    "agent_environment": "localdev"
+  },
+  "details": {
+    "type": "local",
+    "plugin": {
+      "type": "cpu"
+    }
+  }
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-592

# What

Propagate an optional monitoring interval from the users create and update requests into the stored monitor.

The conversion logic will apply a default per local/remote type and also enforce a configurable minimum bound on the interval.

The monitor update logic needed to be tweaked to ensure that if the user only changed the interval then simply an event went out to the affected envoys. The existing bound monitors don't need to be touched since the interval is not actually stored within those entities.

## How to test

Unit tests update