### PR TITLE
migrated the sql label matching query into a sql file to more easily read it

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -22,7 +22,7 @@ import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPublic
 
 import com.google.common.collect.Streams;
 import com.google.common.math.Stats;
-import com.rackspace.salus.common.util.ResourceUtils;
+import com.rackspace.salus.common.util.SpringResourceUtils;
 import com.rackspace.salus.monitor_management.config.ZonesProperties;
 import com.rackspace.salus.monitor_management.errors.DeletionNotAllowedException;
 import com.rackspace.salus.monitor_management.errors.InvalidTemplateException;
@@ -142,7 +142,7 @@ public class MonitorManagement {
     this.zoneManagement = zoneManagement;
     this.zonesProperties = zonesProperties;
     this.jdbcTemplate = jdbcTemplate;
-    this.labelMatchQuery = ResourceUtils.readContent("sql-queries/monitor_label_matching_query.sql");
+    this.labelMatchQuery = SpringResourceUtils.readContent("sql-queries/monitor_label_matching_query.sql");
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -22,6 +22,7 @@ import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPublic
 
 import com.google.common.collect.Streams;
 import com.google.common.math.Stats;
+import com.rackspace.salus.common.util.ResourceUtils;
 import com.rackspace.salus.monitor_management.config.ZonesProperties;
 import com.rackspace.salus.monitor_management.errors.DeletionNotAllowedException;
 import com.rackspace.salus.monitor_management.errors.InvalidTemplateException;
@@ -52,6 +53,7 @@ import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
 import com.rackspace.salus.telemetry.repositories.MonitorPolicyRepository;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import com.rackspace.salus.telemetry.repositories.ResourceRepository;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -102,6 +104,7 @@ public class MonitorManagement {
   private final ResourceApi resourceApi;
   private final ZoneManagement zoneManagement;
   private final ZonesProperties zonesProperties;
+  private final String labelMatchQuery;
 
   private final MonitorRepository monitorRepository;
 
@@ -124,7 +127,7 @@ public class MonitorManagement {
       MonitorContentRenderer monitorContentRenderer,
       PolicyApi policyApi, ResourceApi resourceApi,
       ZoneManagement zoneManagement, ZonesProperties zonesProperties,
-      JdbcTemplate jdbcTemplate) {
+      JdbcTemplate jdbcTemplate) throws IOException {
     this.resourceRepository = resourceRepository;
     this.monitorPolicyRepository = monitorPolicyRepository;
     this.monitorRepository = monitorRepository;
@@ -139,6 +142,7 @@ public class MonitorManagement {
     this.zoneManagement = zoneManagement;
     this.zonesProperties = zonesProperties;
     this.jdbcTemplate = jdbcTemplate;
+    this.labelMatchQuery = ResourceUtils.readContent("sql-queries/monitor_label_matching_query.sql");
   }
 
   /**
@@ -1357,11 +1361,8 @@ public class MonitorManagement {
 
     MapSqlParameterSource paramSource = new MapSqlParameterSource();
     paramSource.addValue("tenantId", tenantId);
-    StringBuilder builder = new StringBuilder("SELECT monitors.id FROM monitors JOIN monitor_label_selectors AS ml WHERE monitors.id = ml.monitor_id AND monitors.id IN ");
-    builder.append("(SELECT monitor_id from monitor_label_selectors WHERE monitors.id IN (SELECT id FROM monitors WHERE tenant_id = :tenantId) AND ");
-    builder.append("monitors.id IN (SELECT search_labels.monitor_id FROM (SELECT monitor_id, COUNT(*) AS count FROM monitor_label_selectors GROUP BY monitor_id) AS total_labels JOIN (SELECT monitor_id, COUNT(*) AS count FROM monitor_label_selectors WHERE ");
+    StringBuilder builder = new StringBuilder();
     int i = 0;
-    labels.size();
     for(Map.Entry<String, String> entry : labels.entrySet()) {
       if(i > 0) {
         builder.append(" OR ");
@@ -1372,14 +1373,11 @@ public class MonitorManagement {
       paramSource.addValue("labelKey"+i, entry.getKey());
       i++;
     }
-    builder.append(" GROUP BY monitor_id) AS search_labels WHERE total_labels.monitor_id = search_labels.monitor_id AND search_labels.count >= total_labels.count GROUP BY search_labels.monitor_id)");
-
-    builder.append(") ORDER BY monitors.id");
     paramSource.addValue("i", i);
 
     //noinspection ConstantConditions
     NamedParameterJdbcTemplate namedParameterTemplate = new NamedParameterJdbcTemplate(jdbcTemplate.getDataSource());
-    final List<UUID> monitorIds = namedParameterTemplate.query(builder.toString(), paramSource,
+    final List<UUID> monitorIds = namedParameterTemplate.query(String.format(labelMatchQuery, builder.toString()), paramSource,
         (resultSet, rowIndex) -> UUID.fromString(resultSet.getString(1))
     );
 

--- a/src/main/resources/sql-queries/monitor_label_matching_query.sql
+++ b/src/main/resources/sql-queries/monitor_label_matching_query.sql
@@ -1,0 +1,32 @@
+SELECT   monitors.id
+FROM     monitors
+JOIN     monitor_label_selectors AS ml
+where    monitors.id = ml.monitor_id
+AND      monitors.id IN
+         (
+    SELECT monitor_id
+    FROM   monitor_label_selectors
+    WHERE  monitors.id IN
+       (
+          SELECT id
+          FROM   monitors
+          WHERE  tenant_id = :tenantId)
+    AND    monitors.id IN
+        (
+            SELECT   search_labels.monitor_id
+            FROM   (
+                SELECT   monitor_id,
+                   count(*) AS count
+                FROM     monitor_label_selectors
+                GROUP BY monitor_id) AS total_labels
+            JOIN
+                (
+                    SELECT   monitor_id,
+                        count(*) AS count
+                    FROM     monitor_label_selectors
+                    WHERE    %s
+                    GROUP BY monitor_id) AS search_labels
+            WHERE    total_labels.monitor_id = search_labels.monitor_id
+            AND      search_labels.count >= total_labels.count
+            GROUP BY search_labels.monitor_id))
+ORDER BY monitors.id

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -16,11 +16,11 @@
 
 package com.rackspace.salus.monitor_management.services;
 
-import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 
+import com.rackspace.salus.common.util.SpringResourceUtils;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
@@ -80,7 +80,7 @@ public class MonitorConversionServiceTest {
   public void convertToOutput_diskio() throws IOException {
     // NOTE: this unit test is purposely abbreviated compared convertToOutput
 
-    final String content = readContent("/MonitorConversionServiceTest_diskio.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_diskio.json");
 
     Monitor monitor = new Monitor()
         .setId(UUID.randomUUID())
@@ -112,7 +112,7 @@ public class MonitorConversionServiceTest {
   public void convertFromInput_diskio() throws JSONException, IOException {
     // NOTE: this unit test is purposely abbreviated compared convertFromInput
 
-    final String content = readContent("/MonitorConversionServiceTest_diskio.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_diskio.json");
 
     final DiskIo plugin = new DiskIo();
     plugin.setDevices(Collections.singletonList("sda"));
@@ -137,7 +137,7 @@ public class MonitorConversionServiceTest {
   public void convertToOutput_mem() throws IOException {
     // NOTE: this unit test is purposely abbreviated compared convertToOutput
 
-    final String content = readContent("/MonitorConversionServiceTest_mem.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_mem.json");
 
     Monitor monitor = new Monitor()
         .setId(UUID.randomUUID())
@@ -162,7 +162,7 @@ public class MonitorConversionServiceTest {
   public void convertFromInput_mem() throws JSONException, IOException {
     // NOTE: this unit test is purposely abbreviated compared convertFromInput
 
-    final String content = readContent("/MonitorConversionServiceTest_mem.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_mem.json");
 
     final Mem plugin = new Mem();
     // no config to set
@@ -185,7 +185,7 @@ public class MonitorConversionServiceTest {
     labels.put("os", "linux");
     labels.put("test", "convertToOutput_remote");
 
-    final String content = readContent("/MonitorConversionServiceTest_ping.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_ping.json");
 
     final UUID monitorId = UUID.randomUUID();
 
@@ -243,7 +243,7 @@ public class MonitorConversionServiceTest {
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
     assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.REMOTE);
-    final String content = readContent("/MonitorConversionServiceTest_ping.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_ping.json");
     JSONAssert.assertEquals(content, result.getContent(), true);
   }
 
@@ -253,7 +253,7 @@ public class MonitorConversionServiceTest {
     labels.put("os", "linux");
     labels.put("test", "convertToOutput_x509");
 
-    final String content = readContent("/MonitorConversionServiceTest_x509.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_x509.json");
 
     final UUID monitorId = UUID.randomUUID();
 
@@ -331,7 +331,7 @@ public class MonitorConversionServiceTest {
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
     assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.REMOTE);
-    final String content = readContent("/MonitorConversionServiceTest_x509.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_x509.json");
     JSONAssert.assertEquals(content, result.getContent(), true);
   }
 
@@ -341,7 +341,7 @@ public class MonitorConversionServiceTest {
     labels.put("os", "linux");
     labels.put("test", "convertToOutput_http");
 
-    final String content = readContent("/MonitorConversionServiceTest_http.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_http.json");
     final UUID monitorId = UUID.randomUUID();
 
     Monitor monitor = new Monitor()
@@ -428,7 +428,7 @@ public class MonitorConversionServiceTest {
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
     assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.REMOTE);
-    final String content = readContent("/MonitorConversionServiceTest_http.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_http.json");
     JSONAssert.assertEquals(content, result.getContent(), true);
   }
 
@@ -477,7 +477,7 @@ public class MonitorConversionServiceTest {
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
     assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.LOCAL);
-    final String content = readContent("/MonitorConversionServiceTest_procstat.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_procstat.json");
     JSONAssert.assertEquals(content, result.getContent(), true);
   }
 
@@ -487,7 +487,7 @@ public class MonitorConversionServiceTest {
     labels.put("os", "linux");
     labels.put("test", "convertToOutput_remote");
 
-    final String content = readContent("/MonitorConversionServiceTest_procstat.json");
+    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_procstat.json");
 
     final UUID monitorId = UUID.randomUUID();
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -19,8 +19,9 @@ package com.rackspace.salus.monitor_management.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static com.rackspace.salus.common.util.SpringResourceUtils.readContent;
 
-import com.rackspace.salus.common.util.SpringResourceUtils;
+
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
@@ -80,7 +81,7 @@ public class MonitorConversionServiceTest {
   public void convertToOutput_diskio() throws IOException {
     // NOTE: this unit test is purposely abbreviated compared convertToOutput
 
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_diskio.json");
+    final String content = readContent("/MonitorConversionServiceTest_diskio.json");
 
     Monitor monitor = new Monitor()
         .setId(UUID.randomUUID())
@@ -112,7 +113,7 @@ public class MonitorConversionServiceTest {
   public void convertFromInput_diskio() throws JSONException, IOException {
     // NOTE: this unit test is purposely abbreviated compared convertFromInput
 
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_diskio.json");
+    final String content = readContent("/MonitorConversionServiceTest_diskio.json");
 
     final DiskIo plugin = new DiskIo();
     plugin.setDevices(Collections.singletonList("sda"));
@@ -137,7 +138,7 @@ public class MonitorConversionServiceTest {
   public void convertToOutput_mem() throws IOException {
     // NOTE: this unit test is purposely abbreviated compared convertToOutput
 
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_mem.json");
+    final String content = readContent("/MonitorConversionServiceTest_mem.json");
 
     Monitor monitor = new Monitor()
         .setId(UUID.randomUUID())
@@ -162,7 +163,7 @@ public class MonitorConversionServiceTest {
   public void convertFromInput_mem() throws JSONException, IOException {
     // NOTE: this unit test is purposely abbreviated compared convertFromInput
 
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_mem.json");
+    final String content = readContent("/MonitorConversionServiceTest_mem.json");
 
     final Mem plugin = new Mem();
     // no config to set
@@ -185,7 +186,7 @@ public class MonitorConversionServiceTest {
     labels.put("os", "linux");
     labels.put("test", "convertToOutput_remote");
 
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_ping.json");
+    final String content = readContent("/MonitorConversionServiceTest_ping.json");
 
     final UUID monitorId = UUID.randomUUID();
 
@@ -243,7 +244,7 @@ public class MonitorConversionServiceTest {
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
     assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.REMOTE);
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_ping.json");
+    final String content = readContent("/MonitorConversionServiceTest_ping.json");
     JSONAssert.assertEquals(content, result.getContent(), true);
   }
 
@@ -253,7 +254,7 @@ public class MonitorConversionServiceTest {
     labels.put("os", "linux");
     labels.put("test", "convertToOutput_x509");
 
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_x509.json");
+    final String content = readContent("/MonitorConversionServiceTest_x509.json");
 
     final UUID monitorId = UUID.randomUUID();
 
@@ -331,7 +332,7 @@ public class MonitorConversionServiceTest {
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
     assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.REMOTE);
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_x509.json");
+    final String content = readContent("/MonitorConversionServiceTest_x509.json");
     JSONAssert.assertEquals(content, result.getContent(), true);
   }
 
@@ -341,7 +342,7 @@ public class MonitorConversionServiceTest {
     labels.put("os", "linux");
     labels.put("test", "convertToOutput_http");
 
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_http.json");
+    final String content = readContent("/MonitorConversionServiceTest_http.json");
     final UUID monitorId = UUID.randomUUID();
 
     Monitor monitor = new Monitor()
@@ -428,7 +429,7 @@ public class MonitorConversionServiceTest {
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
     assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.REMOTE);
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_http.json");
+    final String content = readContent("/MonitorConversionServiceTest_http.json");
     JSONAssert.assertEquals(content, result.getContent(), true);
   }
 
@@ -477,7 +478,7 @@ public class MonitorConversionServiceTest {
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
     assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.LOCAL);
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_procstat.json");
+    final String content = readContent("/MonitorConversionServiceTest_procstat.json");
     JSONAssert.assertEquals(content, result.getContent(), true);
   }
 
@@ -487,7 +488,7 @@ public class MonitorConversionServiceTest {
     labels.put("os", "linux");
     labels.put("test", "convertToOutput_remote");
 
-    final String content = SpringResourceUtils.readContent("/MonitorConversionServiceTest_procstat.json");
+    final String content = readContent("/MonitorConversionServiceTest_procstat.json");
 
     final UUID monitorId = UUID.randomUUID();
 

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -34,9 +34,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static com.rackspace.salus.common.util.SpringResourceUtils.readContent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rackspace.salus.common.util.SpringResourceUtils;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidCreateMonitor;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidUpdateMonitor;
 import com.rackspace.salus.telemetry.entities.Monitor;
@@ -490,7 +490,7 @@ public class MonitorApiControllerTest {
     ).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(
-            content().json(SpringResourceUtils.readContent("/MonitorApiControllerTest/monitor_label_selectors.json"), true));
+            content().json(readContent("/MonitorApiControllerTest/monitor_label_selectors.json"), true));
 
     verify(monitorManagement).getTenantMonitorLabelSelectors("t-1");
 

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -17,7 +17,6 @@
 package com.rackspace.salus.monitor_management.web.controller;
 
 import static com.rackspace.salus.telemetry.entities.Monitor.POLICY_TENANT;
-import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static com.rackspace.salus.test.WebTestUtils.classValidationError;
 import static com.rackspace.salus.test.WebTestUtils.validationError;
 import static org.hamcrest.CoreMatchers.is;
@@ -37,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.common.util.SpringResourceUtils;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidCreateMonitor;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidUpdateMonitor;
 import com.rackspace.salus.telemetry.entities.Monitor;
@@ -490,7 +490,7 @@ public class MonitorApiControllerTest {
     ).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(
-            content().json(readContent("/MonitorApiControllerTest/monitor_label_selectors.json"), true));
+            content().json(SpringResourceUtils.readContent("/MonitorApiControllerTest/monitor_label_selectors.json"), true));
 
     verify(monitorManagement).getTenantMonitorLabelSelectors("t-1");
 

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/TestMonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/TestMonitorApiControllerTest.java
@@ -25,10 +25,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.rackspace.salus.common.util.SpringResourceUtils;
 import com.rackspace.salus.monitor_management.services.TestMonitorService;
 import com.rackspace.salus.monitor_management.web.model.TestMonitorOutput;
 import com.rackspace.salus.telemetry.model.SimpleNameTagValueMetric;
-import com.rackspace.salus.test.JsonTestUtils;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
@@ -77,7 +77,7 @@ public class TestMonitorApiControllerTest {
         .andExpect(request().asyncStarted())
         .andReturn();
 
-    final String expectedRespJson = JsonTestUtils.readContent(
+    final String expectedRespJson = SpringResourceUtils.readContent(
         "TestMonitorApiControllerTest/resp_no_errors.json");
 
     mvc.perform(asyncDispatch(mvcResult))
@@ -113,7 +113,7 @@ public class TestMonitorApiControllerTest {
         .andExpect(request().asyncStarted())
         .andReturn();
 
-    final String expectedRespJson = JsonTestUtils.readContent(
+    final String expectedRespJson = SpringResourceUtils.readContent(
         "TestMonitorApiControllerTest/resp_with_errors.json");
 
     mvc.perform(asyncDispatch(mvcResult))
@@ -141,7 +141,7 @@ public class TestMonitorApiControllerTest {
         .andExpect(request().asyncStarted())
         .andReturn();
 
-    final String expectedRespJson = JsonTestUtils
+    final String expectedRespJson = SpringResourceUtils
         .readContent("TestMonitorApiControllerTest/resp_timeout.json");
 
     mvc.perform(asyncDispatch(mvcResult))

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/TestMonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/TestMonitorApiControllerTest.java
@@ -24,8 +24,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static com.rackspace.salus.common.util.SpringResourceUtils.readContent;
 
-import com.rackspace.salus.common.util.SpringResourceUtils;
 import com.rackspace.salus.monitor_management.services.TestMonitorService;
 import com.rackspace.salus.monitor_management.web.model.TestMonitorOutput;
 import com.rackspace.salus.telemetry.model.SimpleNameTagValueMetric;
@@ -77,7 +77,7 @@ public class TestMonitorApiControllerTest {
         .andExpect(request().asyncStarted())
         .andReturn();
 
-    final String expectedRespJson = SpringResourceUtils.readContent(
+    final String expectedRespJson = readContent(
         "TestMonitorApiControllerTest/resp_no_errors.json");
 
     mvc.perform(asyncDispatch(mvcResult))
@@ -113,7 +113,7 @@ public class TestMonitorApiControllerTest {
         .andExpect(request().asyncStarted())
         .andReturn();
 
-    final String expectedRespJson = SpringResourceUtils.readContent(
+    final String expectedRespJson = readContent(
         "TestMonitorApiControllerTest/resp_with_errors.json");
 
     mvc.perform(asyncDispatch(mvcResult))
@@ -141,8 +141,7 @@ public class TestMonitorApiControllerTest {
         .andExpect(request().asyncStarted())
         .andReturn();
 
-    final String expectedRespJson = SpringResourceUtils
-        .readContent("TestMonitorApiControllerTest/resp_timeout.json");
+    final String expectedRespJson = readContent("TestMonitorApiControllerTest/resp_timeout.json");
 
     mvc.perform(asyncDispatch(mvcResult))
         // due to errors and no metrics in response

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -35,6 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.common.util.SpringResourceUtils;
 import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.monitor_management.errors.DeletionNotAllowedException;
 import com.rackspace.salus.monitor_management.services.MonitorManagement;
@@ -139,7 +140,7 @@ public class ZoneApiControllerTest {
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(
-                    readContent("ZoneApiControllerTest/privateZone_basic.json"), true));
+                    SpringResourceUtils.readContent("ZoneApiControllerTest/privateZone_basic.json"), true));
     }
 
     @Test
@@ -168,7 +169,7 @@ public class ZoneApiControllerTest {
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
                 // the STATE field should not be included
-                readContent("ZoneApiControllerTest/publicZone_as_customer.json"), true));
+                SpringResourceUtils.readContent("ZoneApiControllerTest/publicZone_as_customer.json"), true));
     }
 
     @Test
@@ -236,7 +237,7 @@ public class ZoneApiControllerTest {
             .andExpect(content()
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                readContent("ZoneApiControllerTest/publicZone_basic.json"), true));
+                SpringResourceUtils.readContent("ZoneApiControllerTest/publicZone_basic.json"), true));
     }
 
     @Test
@@ -267,7 +268,7 @@ public class ZoneApiControllerTest {
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                readContent("ZoneApiControllerTest/privateZone_basic.json"), true));
+                SpringResourceUtils.readContent("ZoneApiControllerTest/privateZone_basic.json"), true));
     }
 
     @Test
@@ -315,7 +316,7 @@ public class ZoneApiControllerTest {
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(
-                    readContent("ZoneApiControllerTest/privateZone_underscores.json"), true));
+                    SpringResourceUtils.readContent("ZoneApiControllerTest/privateZone_underscores.json"), true));
     }
 
     @Test
@@ -362,7 +363,8 @@ public class ZoneApiControllerTest {
             .andExpect(content()
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                readContent("ZoneApiControllerTest/publicZone_basic.json")));
+                SpringResourceUtils.
+                    readContent("ZoneApiControllerTest/publicZone_basic.json")));
     }
 
     @Test
@@ -460,7 +462,7 @@ public class ZoneApiControllerTest {
             .andExpect(content()
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                readContent("ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json"),
+                SpringResourceUtils.readContent("ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json"),
                 true));
 
         verify(zoneManagement).exists("t-1", "z-1");
@@ -553,7 +555,7 @@ public class ZoneApiControllerTest {
             .andExpect(content()
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                readContent("ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json"),
+                SpringResourceUtils.readContent("ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json"),
                 true));
 
         verify(zoneManagement).publicZoneExists("public/west");
@@ -650,11 +652,5 @@ public class ZoneApiControllerTest {
             .andExpect(jsonPath("$.message", equalTo("Must provide a public zone name")));
 
         verifyNoMoreInteractions(zoneManagement, monitorManagement);
-    }
-
-    private static String readContent(String resource) throws IOException {
-        try (InputStream in = new ClassPathResource(resource).getInputStream()) {
-            return FileCopyUtils.copyToString(new InputStreamReader(in));
-        }
     }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -33,9 +33,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static com.rackspace.salus.common.util.SpringResourceUtils.readContent;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.rackspace.salus.common.util.SpringResourceUtils;
 import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.monitor_management.errors.DeletionNotAllowedException;
 import com.rackspace.salus.monitor_management.services.MonitorManagement;
@@ -140,7 +140,7 @@ public class ZoneApiControllerTest {
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(
-                    SpringResourceUtils.readContent("ZoneApiControllerTest/privateZone_basic.json"), true));
+                    readContent("ZoneApiControllerTest/privateZone_basic.json"), true));
     }
 
     @Test
@@ -169,7 +169,7 @@ public class ZoneApiControllerTest {
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
                 // the STATE field should not be included
-                SpringResourceUtils.readContent("ZoneApiControllerTest/publicZone_as_customer.json"), true));
+                readContent("ZoneApiControllerTest/publicZone_as_customer.json"), true));
     }
 
     @Test
@@ -237,7 +237,7 @@ public class ZoneApiControllerTest {
             .andExpect(content()
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                SpringResourceUtils.readContent("ZoneApiControllerTest/publicZone_basic.json"), true));
+                readContent("ZoneApiControllerTest/publicZone_basic.json"), true));
     }
 
     @Test
@@ -268,7 +268,7 @@ public class ZoneApiControllerTest {
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                SpringResourceUtils.readContent("ZoneApiControllerTest/privateZone_basic.json"), true));
+                readContent("ZoneApiControllerTest/privateZone_basic.json"), true));
     }
 
     @Test
@@ -316,7 +316,7 @@ public class ZoneApiControllerTest {
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(content().json(
-                    SpringResourceUtils.readContent("ZoneApiControllerTest/privateZone_underscores.json"), true));
+                    readContent("ZoneApiControllerTest/privateZone_underscores.json"), true));
     }
 
     @Test
@@ -363,7 +363,6 @@ public class ZoneApiControllerTest {
             .andExpect(content()
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                SpringResourceUtils.
                     readContent("ZoneApiControllerTest/publicZone_basic.json")));
     }
 
@@ -462,7 +461,7 @@ public class ZoneApiControllerTest {
             .andExpect(content()
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                SpringResourceUtils.readContent("ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json"),
+                readContent("ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json"),
                 true));
 
         verify(zoneManagement).exists("t-1", "z-1");
@@ -555,7 +554,7 @@ public class ZoneApiControllerTest {
             .andExpect(content()
                 .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(content().json(
-                SpringResourceUtils.readContent("ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json"),
+                readContent("ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json"),
                 true));
 
         verify(zoneManagement).publicZoneExists("public/west");


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-480

# What

This is meant to simplify reading and debugging of any of the actual SQL queries we need to write for Resource Management

# How

This migrates the StringBuilder approach into just a static .sql file. Most of the query is static with only a few locations needing parameters being set. The static query does utilize a String.Format tag to allow us to inject the complex label matching portion of the query into the middle of this template.

## How to test

Run the unit tests. We weren't testing the query in the first place so the tests dont need to change. We just need to make sure they still return the same.

# Why

I considered removing all of the string building from java and building the whole thing with a jmustache template. Ultimately this is for readability of the query and ease of debugging. I didn't think that jmustache would help with the readability and it actually would add a bit of weirdness because we still need to make sure we have cleansed our inputs by passing everything in through parameters to jdbc.
