### PR TITLE
Set monitorType on new Monitor entities

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -161,14 +161,14 @@ public class MonitorConversionService {
     }
   }
 
-  private MonitorType populateMonitorType(MonitorCU monitor, Object plugin) {
+  private void populateMonitorType(MonitorCU monitor, Object plugin) {
     final ApplicableMonitorType applicableMonitorType = plugin.getClass()
         .getAnnotation(ApplicableMonitorType.class);
     if (applicableMonitorType == null) {
       log.warn("monitorClass={} is missing ApplicableMonitorType", plugin.getClass());
       throw new IllegalStateException("Missing ApplicableMonitorType");
     }
-    return applicableMonitorType.value();
+    monitor.setMonitorType(applicableMonitorType.value());
   }
 
   private void populateAgentConfigContent(DetailedMonitorInput input, MonitorCU monitor,

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -30,6 +30,7 @@ import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.format.DateTimeFormatter;
@@ -114,6 +115,7 @@ public class MonitorConversionService {
 
     final MonitorCU monitor = new MonitorCU()
         .setMonitorName(input.getName())
+        .setMonitorType(input.getDetails().getType())
         .setLabelSelector(input.getLabelSelector())
         .setLabelSelectorMethod(input.getLabelSelectorMethod())
         .setResourceId(input.getResourceId())

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -266,7 +266,7 @@ public class MonitorManagement {
     Monitor monitor = new Monitor()
         .setTenantId(POLICY_TENANT)
         .setMonitorName(newMonitor.getMonitorName())
-        .setMonitorType(MonitorType.cpu)
+        .setMonitorType(newMonitor.getMonitorType())
         .setLabelSelector(newMonitor.getLabelSelector())
         .setContent(newMonitor.getContent())
         .setAgentType(newMonitor.getAgentType())

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ApplicableMonitorType.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ApplicableMonitorType.java
@@ -16,20 +16,17 @@
 
 package com.rackspace.salus.monitor_management.web.model;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.rackspace.salus.telemetry.model.MonitorType;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-@ApiModel(discriminator="type", subTypes={LocalMonitorDetails.class, RemoteMonitorDetails.class})
-@JsonTypeInfo(use = Id.NAME, property = "type")
-@JsonSubTypes({
-    @Type(name = "local", value=LocalMonitorDetails.class),
-    @Type(name = "remote", value=RemoteMonitorDetails.class)
-})
-public abstract class MonitorDetails {
-  public abstract MonitorType getType();
+/**
+ * This annotation helps the API gateway determine how to construct the backend monitor object.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ApplicableMonitorType {
+  MonitorType value();
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalMonitorDetails.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalMonitorDetails.java
@@ -16,7 +16,6 @@
 
 package com.rackspace.salus.monitor_management.web.model;
 
-import com.rackspace.salus.telemetry.model.MonitorType;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
@@ -31,14 +30,4 @@ import lombok.extern.slf4j.Slf4j;
 public class LocalMonitorDetails extends MonitorDetails {
   @NotNull @Valid
   LocalPlugin plugin;
-
-  public MonitorType getType() {
-    final ApplicableMonitorType applicableMonitorType = plugin.getClass()
-        .getAnnotation(ApplicableMonitorType.class);
-    if (applicableMonitorType == null) {
-      log.warn("monitorClass={} is missing ApplicableMonitorType", plugin.getClass());
-      throw new IllegalStateException("Missing ApplicableMonitorType");
-    }
-    return applicableMonitorType.value();
-  }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalMonitorDetails.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalMonitorDetails.java
@@ -16,16 +16,29 @@
 
 package com.rackspace.salus.monitor_management.web.model;
 
+import com.rackspace.salus.telemetry.model.MonitorType;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import io.swagger.annotations.ApiModel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @ApiModel(parent=MonitorDetails.class)
 @Data @EqualsAndHashCode(callSuper = false)
 public class LocalMonitorDetails extends MonitorDetails {
   @NotNull @Valid
   LocalPlugin plugin;
+
+  public MonitorType getType() {
+    final ApplicableMonitorType applicableMonitorType = plugin.getClass()
+        .getAnnotation(ApplicableMonitorType.class);
+    if (applicableMonitorType == null) {
+      log.warn("monitorClass={} is missing ApplicableMonitorType", plugin.getClass());
+      throw new IllegalStateException("Missing ApplicableMonitorType");
+    }
+    return applicableMonitorType.value();
+  }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.List;
@@ -46,6 +47,8 @@ public class MonitorCU implements Serializable {
     LabelSelectorMethod labelSelectorMethod;
 
     String content;
+
+    MonitorType monitorType;
 
     AgentType agentType;
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDetails.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDetails.java
@@ -20,9 +20,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.rackspace.salus.telemetry.model.MonitorType;
 import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel(discriminator="type", subTypes={LocalMonitorDetails.class, RemoteMonitorDetails.class})
 @JsonTypeInfo(use = Id.NAME, property = "type")
@@ -31,5 +29,4 @@ import io.swagger.annotations.ApiModelProperty;
     @Type(name = "remote", value=RemoteMonitorDetails.class)
 })
 public abstract class MonitorDetails {
-  public abstract MonitorType getType();
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/RemoteMonitorDetails.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/RemoteMonitorDetails.java
@@ -16,12 +16,15 @@
 
 package com.rackspace.salus.monitor_management.web.model;
 
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class RemoteMonitorDetails extends MonitorDetails {
@@ -33,4 +36,14 @@ public class RemoteMonitorDetails extends MonitorDetails {
 
   @NotNull @Valid
   RemotePlugin plugin;
+
+  public MonitorType getType() {
+    final ApplicableMonitorType applicableMonitorType = plugin.getClass()
+        .getAnnotation(ApplicableMonitorType.class);
+    if (applicableMonitorType == null) {
+      log.warn("monitorClass={} is missing ApplicableMonitorType", plugin.getClass());
+      throw new IllegalStateException("Missing ApplicableMonitorType");
+    }
+    return applicableMonitorType.value();
+  }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/RemoteMonitorDetails.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/RemoteMonitorDetails.java
@@ -16,7 +16,6 @@
 
 package com.rackspace.salus.monitor_management.web.model;
 
-import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -36,14 +35,4 @@ public class RemoteMonitorDetails extends MonitorDetails {
 
   @NotNull @Valid
   RemotePlugin plugin;
-
-  public MonitorType getType() {
-    final ApplicableMonitorType applicableMonitorType = plugin.getClass()
-        .getAnnotation(ApplicableMonitorType.class);
-    if (applicableMonitorType == null) {
-      log.warn("monitorClass={} is missing ApplicableMonitorType", plugin.getClass());
-      throw new IllegalStateException("Missing ApplicableMonitorType");
-    }
-    return applicableMonitorType.value();
-  }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Cpu.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Cpu.java
@@ -18,13 +18,16 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.cpu)
 public class Cpu extends LocalPlugin {
   boolean percpu;
   @JsonProperty(defaultValue = "true")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Disk.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Disk.java
@@ -18,8 +18,10 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.Arrays;
 import java.util.List;
 import lombok.Data;
@@ -27,6 +29,7 @@ import lombok.EqualsAndHashCode;
 
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.disk)
 public class Disk extends LocalPlugin {
   List<String> mountPoints;
   @JsonProperty(defaultValue = "[\"tmpfs\", \"devtmpfs\", \"devfs\", \"iso9660\", \"overlay\", \"aufs\", \"squashfs\"]")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIo.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIo.java
@@ -19,14 +19,17 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.diskio)
 @JsonInclude(Include.NON_NULL)
 public class DiskIo extends LocalPlugin {
   List<String> devices;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
@@ -19,9 +19,11 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidGoDuration;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.Map;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
@@ -30,6 +32,7 @@ import lombok.EqualsAndHashCode;
 
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.http_response)
 @JsonInclude(Include.NON_NULL)
 public class HttpResponse extends RemotePlugin {
   @NotEmpty

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Mem.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Mem.java
@@ -17,10 +17,13 @@
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 
 @ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.mem)
 public class Mem extends LocalPlugin {
 
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
@@ -18,14 +18,17 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.net)
 public class Net extends LocalPlugin {
   List<String> interfaces;
   @JsonProperty(defaultValue = "true")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
@@ -19,16 +19,19 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidGoDuration;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidHostAndPort;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.net_response)
 @JsonInclude(Include.NON_NULL)
 public class NetResponse extends RemotePlugin {
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
@@ -19,8 +19,10 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
 import javax.validation.constraints.NotEmpty;
 import lombok.Data;
@@ -28,6 +30,7 @@ import lombok.EqualsAndHashCode;
 
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.ping)
 @JsonInclude(Include.NON_NULL)
 public class Ping extends RemotePlugin {
   @NotEmpty

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Procstat.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Procstat.java
@@ -2,9 +2,11 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.monitor_management.web.validator.ProcstatValidator;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -13,6 +15,7 @@ import javax.validation.Constraint;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.procstat)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @ProcstatValidator.OneOf()
 public class Procstat extends LocalPlugin {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
@@ -19,9 +19,11 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidGoDuration;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
 import javax.validation.constraints.NotEmpty;
 import lombok.Data;
@@ -29,6 +31,7 @@ import lombok.EqualsAndHashCode;
 
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.x509_cert)
 @JsonInclude(Include.NON_NULL)
 public class X509Cert extends RemotePlugin {
   @NotEmpty

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -30,6 +30,7 @@ import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Cpu;
 import com.rackspace.salus.monitor_management.web.model.telegraf.DiskIo;
 import com.rackspace.salus.monitor_management.web.model.telegraf.HttpResponse;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Mem;
@@ -531,7 +532,8 @@ public class MonitorConversionServiceTest {
   @Test
   public void testConvertFrom_ResourceId() {
     DetailedMonitorInput input = new DetailedMonitorInput()
-        .setResourceId("r-1");
+        .setResourceId("r-1")
+        .setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
     final MonitorCU result = conversionService.convertFromInput(input);
     assertThat(result.getResourceId()).isEqualTo(input.getResourceId());
   }
@@ -565,7 +567,8 @@ public class MonitorConversionServiceTest {
   @Test
   public void testConvertFrom_LabelSelectorMethod() {
     DetailedMonitorInput input = new DetailedMonitorInput()
-        .setLabelSelectorMethod(LabelSelectorMethod.OR);
+        .setLabelSelectorMethod(LabelSelectorMethod.OR)
+        .setDetails(new LocalMonitorDetails().setPlugin(new Cpu()));
     final MonitorCU result = conversionService.convertFromInput(input);
     assertThat(result.getLabelSelectorMethod()).isEqualTo(input.getLabelSelectorMethod());
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
@@ -56,6 +56,7 @@ import com.rackspace.salus.telemetry.messaging.PolicyMonitorUpdateEvent;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
 import com.rackspace.salus.telemetry.repositories.MonitorPolicyRepository;
@@ -166,6 +167,7 @@ public class MonitorManagementPolicyTest {
     Monitor monitor = new Monitor()
         .setTenantId(POLICY_TENANT)
         .setMonitorName("policy_mon1")
+        .setMonitorType(MonitorType.ping)
         .setLabelSelector(Collections.singletonMap("os", "LINUX"))
         .setLabelSelectorMethod(LabelSelectorMethod.AND)
         .setContent("content1")
@@ -240,6 +242,7 @@ public class MonitorManagementPolicyTest {
     Monitor monitor = monitorRepository.save(
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content0")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -266,6 +269,7 @@ public class MonitorManagementPolicyTest {
     Monitor monitor = monitorRepository.save(
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content0")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -308,6 +312,7 @@ public class MonitorManagementPolicyTest {
     monitorRepository.save(
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content0")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -319,6 +324,7 @@ public class MonitorManagementPolicyTest {
     List<Monitor> monitors = Arrays.asList(
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content0")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -327,6 +333,7 @@ public class MonitorManagementPolicyTest {
             .setLabelSelectorMethod(LabelSelectorMethod.AND),
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content1")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -358,6 +365,7 @@ public class MonitorManagementPolicyTest {
   public void testCreatePolicyMonitor() {
     MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
     create.setSelectorScope(ConfigSelectorScope.LOCAL);
+    create.setMonitorType(MonitorType.cpu);
     create.setLabelSelectorMethod(LabelSelectorMethod.AND);
     create.setZones(null);
     create.setResourceId(null);
@@ -402,6 +410,7 @@ public class MonitorManagementPolicyTest {
     final Monitor monitor =
         monitorRepository.save(new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("original content")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -434,6 +443,7 @@ public class MonitorManagementPolicyTest {
             new Monitor()
                 .setId(monitor.getId())
                 .setAgentType(AgentType.TELEGRAF)
+                .setMonitorType(MonitorType.ping)
                 .setContent("new content")
                 .setTenantId(POLICY_TENANT)
                 .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -482,6 +492,7 @@ public class MonitorManagementPolicyTest {
     final Monitor monitor =
         monitorRepository.save(new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("{}")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1038,6 +1049,7 @@ public class MonitorManagementPolicyTest {
     List<Monitor> monitors = Lists.newArrayList(monitorRepository.saveAll(List.of(
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content0")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1046,6 +1058,7 @@ public class MonitorManagementPolicyTest {
             .setLabelSelectorMethod(LabelSelectorMethod.AND),
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content1")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1054,6 +1067,7 @@ public class MonitorManagementPolicyTest {
             .setLabelSelectorMethod(LabelSelectorMethod.AND),
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content2")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1062,6 +1076,7 @@ public class MonitorManagementPolicyTest {
             .setLabelSelectorMethod(LabelSelectorMethod.AND),
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content3")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1095,6 +1110,7 @@ public class MonitorManagementPolicyTest {
     List<Monitor> monitors = Lists.newArrayList(monitorRepository.saveAll(List.of(
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content0")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1103,6 +1119,7 @@ public class MonitorManagementPolicyTest {
             .setLabelSelectorMethod(LabelSelectorMethod.OR),
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content1")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1111,6 +1128,7 @@ public class MonitorManagementPolicyTest {
             .setLabelSelectorMethod(LabelSelectorMethod.OR),
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content2")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1119,6 +1137,7 @@ public class MonitorManagementPolicyTest {
             .setLabelSelectorMethod(LabelSelectorMethod.OR),
         new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("content3")
             .setTenantId(POLICY_TENANT)
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1154,6 +1173,7 @@ public class MonitorManagementPolicyTest {
       // limit to local/agent monitors only
       create.setSelectorScope(ConfigSelectorScope.LOCAL);
       create.setZones(Collections.emptyList());
+      create.setMonitorType(MonitorType.cpu);
       monitorManagement.createMonitor(tenantId, create);
     }
   }
@@ -1164,6 +1184,7 @@ public class MonitorManagementPolicyTest {
       create.setSelectorScope(ConfigSelectorScope.LOCAL);
       create.setLabelSelectorMethod(LabelSelectorMethod.AND);
       create.setZones(Collections.emptyList());
+      create.setMonitorType(MonitorType.cpu);
       monitorManagement.createMonitor(tenantId, create);
     }
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -67,6 +67,7 @@ import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
@@ -197,6 +198,7 @@ public class MonitorManagementTest {
     Monitor monitor = new Monitor()
         .setTenantId("abcde")
         .setMonitorName("mon1")
+        .setMonitorType(MonitorType.cpu)
         .setLabelSelector(Collections.singletonMap("os", "LINUX"))
         .setLabelSelectorMethod(LabelSelectorMethod.AND)
         .setContent("content1")
@@ -237,6 +239,7 @@ public class MonitorManagementTest {
       create.setSelectorScope(ConfigSelectorScope.LOCAL);
       create.setZones(Collections.emptyList());
       create.setLabelSelectorMethod(LabelSelectorMethod.AND);
+      create.setMonitorType(MonitorType.cpu);
       monitorManagement.createMonitor(tenantId, create);
     }
   }
@@ -247,6 +250,7 @@ public class MonitorManagementTest {
       create.setSelectorScope(ConfigSelectorScope.LOCAL);
       create.setZones(Collections.emptyList());
       create.setLabelSelectorMethod(LabelSelectorMethod.AND);
+      create.setMonitorType(MonitorType.cpu);
       monitorManagement.createMonitor(tenantId, create);
     }
   }
@@ -258,6 +262,7 @@ public class MonitorManagementTest {
       create.setZones(Collections.emptyList());
       create.setLabelSelectorMethod(LabelSelectorMethod.AND);
       create.setLabelSelector(labels);
+      create.setMonitorType(MonitorType.cpu);
       monitorManagement.createMonitor(tenantId, create);
     }
   }
@@ -276,6 +281,7 @@ public class MonitorManagementTest {
             .setLabelSelector(labelSelector)
             .setLabelSelectorMethod(LabelSelectorMethod.AND)
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.cpu)
             .setContent("{}")
     );
   }
@@ -654,6 +660,7 @@ public class MonitorManagementTest {
     oldLabelSelector.put("old", "yes");
     final Monitor monitor = new Monitor()
         .setAgentType(AgentType.TELEGRAF)
+        .setMonitorType(MonitorType.cpu)
         .setContent("{}")
         .setTenantId("t-1")
         .setSelectorScope(ConfigSelectorScope.LOCAL)
@@ -753,6 +760,7 @@ public class MonitorManagementTest {
 
     final Monitor monitor = new Monitor()
         .setAgentType(AgentType.TELEGRAF)
+        .setMonitorType(MonitorType.cpu)
         .setContent("{}")
         .setTenantId("t-1")
         .setSelectorScope(ConfigSelectorScope.LOCAL)
@@ -853,6 +861,7 @@ public class MonitorManagementTest {
         .setContent("address=${resource.metadata.ping_ip}")
         .setTenantId("t-1")
         .setSelectorScope(ConfigSelectorScope.REMOTE)
+        .setMonitorType(MonitorType.ping)
         .setLabelSelector(Collections.singletonMap("os", "linux"))
         .setLabelSelectorMethod(LabelSelectorMethod.AND);
     entityManager.persist(monitor);
@@ -902,6 +911,7 @@ public class MonitorManagementTest {
             new Monitor()
                 .setId(monitor.getId())
                 .setAgentType(AgentType.TELEGRAF)
+                .setMonitorType(MonitorType.ping)
                 .setContent("address=${resource.metadata.address}")
                 .setTenantId("t-1")
                 .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -944,6 +954,7 @@ public class MonitorManagementTest {
 
     final Monitor monitor = new Monitor()
         .setAgentType(AgentType.TELEGRAF)
+        .setMonitorType(MonitorType.ping)
         .setContent("address=${resource.metadata.ping_ip}")
         .setTenantId("t-1")
         .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1025,6 +1036,7 @@ public class MonitorManagementTest {
 
     final Monitor monitor = new Monitor()
         .setAgentType(AgentType.TELEGRAF)
+        .setMonitorType(MonitorType.cpu)
         .setContent("static content")
         .setTenantId("t-1")
         .setResourceId("r-1")
@@ -1060,6 +1072,7 @@ public class MonitorManagementTest {
             new Monitor()
                 .setId(monitor.getId())
                 .setAgentType(AgentType.TELEGRAF)
+                .setMonitorType(MonitorType.cpu)
                 .setContent("static content")
                 .setTenantId("t-1")
                 .setSelectorScope(ConfigSelectorScope.LOCAL)
@@ -1112,6 +1125,7 @@ public class MonitorManagementTest {
 
     final Monitor monitor = new Monitor()
         .setAgentType(AgentType.TELEGRAF)
+        .setMonitorType(MonitorType.ping)
         .setContent("{}")
         .setTenantId("t-1")
         .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1178,6 +1192,7 @@ public class MonitorManagementTest {
             new Monitor()
                 .setId(monitor.getId())
                 .setAgentType(AgentType.TELEGRAF)
+                .setMonitorType(MonitorType.ping)
                 .setContent("{}")
                 .setTenantId("t-1")
                 .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1229,6 +1244,7 @@ public class MonitorManagementTest {
 
     final Monitor monitor = new Monitor()
         .setAgentType(AgentType.TELEGRAF)
+        .setMonitorType(MonitorType.ping)
         .setContent("{}")
         .setTenantId("t-1")
         .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1261,6 +1277,7 @@ public class MonitorManagementTest {
             new Monitor()
                 .setId(monitor.getId())
                 .setAgentType(AgentType.TELEGRAF)
+                .setMonitorType(MonitorType.ping)
                 .setContent("{}")
                 .setTenantId("t-1")
                 .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1293,6 +1310,7 @@ public class MonitorManagementTest {
     final Monitor monitor =
         monitorRepository.save(new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("{}")
             .setTenantId("t-1")
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -1347,6 +1365,7 @@ public class MonitorManagementTest {
     final Monitor monitor =
         monitorRepository.save(new Monitor()
             .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
             .setContent("{}")
             .setTenantId("t-1")
             .setSelectorScope(ConfigSelectorScope.REMOTE)
@@ -2796,6 +2815,7 @@ public class MonitorManagementTest {
     final Monitor monitor = new Monitor()
         .setSelectorScope(monitorScope)
         .setTenantId(tenantId)
+        .setMonitorType(MonitorType.cpu)
         .setLabelSelector(labelSelector)
         .setLabelSelectorMethod(LabelSelectorMethod.AND)
         .setAgentType(AgentType.TELEGRAF)
@@ -2878,6 +2898,7 @@ public class MonitorManagementTest {
   public void testhandleResourceEvent_modifiedResource_reattachedEnvoy_sameContent() {
     final Monitor monitor = new Monitor()
         .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setMonitorType(MonitorType.cpu)
         .setTenantId("t-1")
         .setLabelSelector(Collections.singletonMap("env", "prod"))
         .setLabelSelectorMethod(LabelSelectorMethod.AND)
@@ -2958,6 +2979,7 @@ public class MonitorManagementTest {
 
     final Monitor monitor = new Monitor()
         .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setMonitorType(MonitorType.cpu)
         .setTenantId("t-1")
         .setLabelSelector(Collections.singletonMap("env", "prod"))
         .setLabelSelectorMethod(LabelSelectorMethod.AND)
@@ -3144,6 +3166,7 @@ public class MonitorManagementTest {
 
     final Monitor monitor = new Monitor()
         .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setMonitorType(MonitorType.cpu)
         .setTenantId("t-1")
         .setLabelSelector(Collections.singletonMap("env", "prod"))
         .setLabelSelectorMethod(LabelSelectorMethod.AND)

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -123,6 +124,7 @@ public class MonitorApiControllerTest {
 
     mockMvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
+        .andDo(print())
         .andExpect(content()
             .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id", is(monitor.getId().toString())));

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -52,6 +52,7 @@ import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
 import java.nio.charset.StandardCharsets;
@@ -651,6 +652,7 @@ public class MonitorApiControllerTest {
                 .setInterval(Duration.ofSeconds(30))
                 .setLabelSelector(Map.of("agent_environment", "localdev"))
                 .setSelectorScope(ConfigSelectorScope.LOCAL)
+                .setMonitorType(MonitorType.cpu)
                 .setAgentType(AgentType.TELEGRAF)
                 .setContent(readContent("MonitorApiControllerTest/converted_monitor_duration.json"))
         );


### PR DESCRIPTION
# What

When a monitor is created/updated, set the `monitorType` field.

# How

Added an annotation to each plugin that maps it to a `MonitorType` enum value, similar to what is done with AgentTypes.

When we see the DetailedMonitorInput, we can retrieve the monitor type from the plugin class and set it on the MonitorCU object, which will then be used to set it on the Monitor entity.

# Why

For Policy Mgmt we will want to query metadata by monitor type. Having this as a field on the monitor makes life a lot easier. Otherwise we'd have to parse the string content field.

# TODO

Approve https://github.com/racker/salus-telemetry-model/pull/73
