### PR TITLE
Add unit test of DetailedMonitorOutput json serialization

### DIFF
--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rackspace.salus.monitor_management.web.model.telegraf.Cpu;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@JsonTest
+public class DetailedMonitorOutputTest {
+
+  @Autowired
+  private JacksonTester<DetailedMonitorOutput> json;
+
+  @Test
+  public void testLocalMonitor() throws IOException {
+    final DetailedMonitorOutput detailedMonitorOutput = new DetailedMonitorOutput()
+        .setId("m-1")
+        .setResourceId("r-1")
+        .setName("name-1")
+        .setLabelSelector(
+            Map.of("key1", "val1", "key2", "val2")
+        )
+        .setLabelSelectorMethod(LabelSelectorMethod.AND)
+        .setInterval(Duration.ofSeconds(90))
+        .setDetails(new LocalMonitorDetails()
+            .setPlugin(new Cpu()
+                .setCollectCpuTime(false)
+                .setPercpu(true)
+                .setReportActive(false)
+                .setTotalcpu(true)
+            )
+        )
+        .setCreatedTimestamp(Instant.EPOCH.toString())
+        .setUpdatedTimestamp(Instant.EPOCH.plusSeconds(1).toString());
+
+    assertThat(json.write(detailedMonitorOutput))
+        .isEqualToJson("/DetailedMonitorOutputTest/local.json", JSONCompareMode.STRICT);
+  }
+
+  @Test
+  public void testRemoteMonitor() throws IOException {
+    final DetailedMonitorOutput detailedMonitorOutput = new DetailedMonitorOutput()
+        .setId("m-1")
+        .setResourceId("r-1")
+        .setName("name-1")
+        .setLabelSelector(
+            Map.of("key1", "val1", "key2", "val2")
+        )
+        .setLabelSelectorMethod(LabelSelectorMethod.AND)
+        .setInterval(Duration.ofSeconds(90))
+        .setDetails(new RemoteMonitorDetails()
+            .setMonitoringZones(List.of("z-1"))
+            .setPlugin(new Ping()
+                .setUrls(List.of("localhost:22"))
+                .setCount(5)
+                .setDeadline(10)
+                .setPingInterval(15)
+                .setTimeout(20)
+            )
+        )
+        .setCreatedTimestamp(Instant.EPOCH.toString())
+        .setUpdatedTimestamp(Instant.EPOCH.plusSeconds(1).toString());
+
+    assertThat(json.write(detailedMonitorOutput))
+        .isEqualToJson("/DetailedMonitorOutputTest/remote.json", JSONCompareMode.STRICT);
+  }
+}

--- a/src/test/resources/DetailedMonitorOutputTest/local.json
+++ b/src/test/resources/DetailedMonitorOutputTest/local.json
@@ -1,0 +1,23 @@
+{
+  "id": "m-1",
+  "resourceId": "r-1",
+  "name": "name-1",
+  "labelSelector": {
+    "key1": "val1",
+    "key2": "val2"
+  },
+  "labelSelectorMethod": "AND",
+  "interval": "PT1M30S",
+  "details": {
+    "type": "local",
+    "plugin": {
+      "type": "cpu",
+      "collectCpuTime": false,
+      "percpu": true,
+      "reportActive": false,
+      "totalcpu": true
+    }
+  },
+  "createdTimestamp": "1970-01-01T00:00:00Z",
+  "updatedTimestamp": "1970-01-01T00:00:01Z"
+}

--- a/src/test/resources/DetailedMonitorOutputTest/remote.json
+++ b/src/test/resources/DetailedMonitorOutputTest/remote.json
@@ -1,0 +1,25 @@
+{
+  "id": "m-1",
+  "resourceId": "r-1",
+  "name": "name-1",
+  "labelSelector": {
+    "key1": "val1",
+    "key2": "val2"
+  },
+  "labelSelectorMethod": "AND",
+  "interval": "PT1M30S",
+  "details": {
+    "type": "remote",
+    "monitoringZones": ["z-1"],
+    "plugin": {
+      "type": "ping",
+      "urls": ["localhost:22"],
+      "count": 5,
+      "deadline": 10,
+      "pingInterval": 15,
+      "timeout": 20
+    }
+  },
+  "createdTimestamp": "1970-01-01T00:00:00Z",
+  "updatedTimestamp": "1970-01-01T00:00:01Z"
+}


### PR DESCRIPTION
# What

While reviewing https://github.com/racker/salus-telemetry-monitor-management/pull/83 I realized we didn't have any unit tests for the overall serialization of `DetailedMonitorOutput` which involves two layers of polymorphic data types.

# How

This is the proper use of `@JsonTest`, which was a test slice I had started over-using elsewhere.