### PR TITLE
Adam9500/salus 433 hide internal endpoints

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorEventProducer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorEventProducer.java
@@ -45,9 +45,7 @@ public class MonitorEventProducer {
         log.debug("Sending policyMonitorUpdateEvent={} on topic={}", event, topic);
         try {
             kafkaTemplate.send(topic, buildMessageKey(event), event).get();
-        } catch (InterruptedException e) {
-            throw new RuntimeKafkaException(e);
-        } catch (ExecutionException e) {
+        } catch (InterruptedException|ExecutionException e) {
             throw new RuntimeKafkaException(e);
         }
     }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorEventProducer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorEventProducer.java
@@ -32,9 +32,7 @@ public class MonitorEventProducer {
         log.debug("Sending monitorBoundEvent={} on topic={}", event, topic);
         try {
             kafkaTemplate.send(topic, event.getEnvoyId(), event).get();
-        } catch (InterruptedException e) {
-            throw new RuntimeKafkaException(e);
-        } catch (ExecutionException e) {
+        } catch (InterruptedException|ExecutionException e) {
             throw new RuntimeKafkaException(e);
         }
     }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorEventProducer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorEventProducer.java
@@ -2,9 +2,11 @@ package com.rackspace.salus.monitor_management.services;
 
 import static com.rackspace.salus.common.messaging.KafkaMessageKeyBuilder.buildMessageKey;
 
+import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
 import com.rackspace.salus.telemetry.messaging.PolicyMonitorUpdateEvent;
+import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -28,13 +30,25 @@ public class MonitorEventProducer {
         final String topic = properties.getMonitors();
 
         log.debug("Sending monitorBoundEvent={} on topic={}", event, topic);
-        kafkaTemplate.send(topic, event.getEnvoyId(), event);
+        try {
+            kafkaTemplate.send(topic, event.getEnvoyId(), event).get();
+        } catch (InterruptedException e) {
+            throw new RuntimeKafkaException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeKafkaException(e);
+        }
     }
 
     public void sendPolicyMonitorUpdateEvent(PolicyMonitorUpdateEvent event) {
         final String topic = properties.getPolicies();
 
         log.debug("Sending policyMonitorUpdateEvent={} on topic={}", event, topic);
-        kafkaTemplate.send(topic, buildMessageKey(event), event);
+        try {
+            kafkaTemplate.send(topic, buildMessageKey(event), event).get();
+        } catch (InterruptedException e) {
+            throw new RuntimeKafkaException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeKafkaException(e);
+        }
     }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorEventProducer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorEventProducer.java
@@ -46,9 +46,7 @@ public class TestMonitorEventProducer {
     //noinspection unchecked
     try {
       kafkaTemplate.send(topic, event).get();
-    } catch (InterruptedException e) {
-      throw new RuntimeKafkaException(e);
-    } catch (ExecutionException e) {
+    } catch (InterruptedException|ExecutionException e) {
       throw new RuntimeKafkaException(e);
     }
   }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorEventProducer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorEventProducer.java
@@ -16,8 +16,10 @@
 
 package com.rackspace.salus.monitor_management.services;
 
+import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.TestMonitorRequestEvent;
+import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -42,7 +44,13 @@ public class TestMonitorEventProducer {
 
     log.debug("Sending test-monitor request event={} on topic={}", event, topic);
     //noinspection unchecked
-    kafkaTemplate.send(topic, event);
+    try {
+      kafkaTemplate.send(topic, event).get();
+    } catch (InterruptedException e) {
+      throw new RuntimeKafkaException(e);
+    } catch (ExecutionException e) {
+      throw new RuntimeKafkaException(e);
+    }
   }
 
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/RestExceptionHandler.java
@@ -79,13 +79,13 @@ public class RestExceptionHandler extends
   @ExceptionHandler({JDBCException.class})
   public ResponseEntity<?> handleJDBCException(
       HttpServletRequest request) {
-    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.jdbcExceptionMessage);
+    return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.jdbcExceptionMessage);
   }
 
   @ExceptionHandler({RuntimeKafkaException.class})
   public ResponseEntity<?> handleKafkaExceptions(
       HttpServletRequest request) {
-    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.kafkaExceptionMessage);
+    return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.kafkaExceptionMessage);
   }
 
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/RestExceptionHandler.java
@@ -17,10 +17,13 @@
 package com.rackspace.salus.monitor_management.web.controller;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.rackspace.salus.common.errors.ResponseMessages;
+import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.errors.MissingRequirementException;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import javax.servlet.http.HttpServletRequest;
+import org.hibernate.JDBCException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
 import org.springframework.http.HttpStatus;
@@ -71,6 +74,18 @@ public class RestExceptionHandler extends
   public ResponseEntity<?> handleUnprocessable(
       HttpServletRequest request) {
     return respondWith(request, HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+
+  @ExceptionHandler({JDBCException.class})
+  public ResponseEntity<?> handleJDBCException(
+      HttpServletRequest request) {
+    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.jdbcExceptionMessage);
+  }
+
+  @ExceptionHandler({RuntimeKafkaException.class})
+  public ResponseEntity<?> handleKafkaExceptions(
+      HttpServletRequest request) {
+    return respondWith(request, HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessages.kafkaExceptionMessage);
   }
 
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-433

# What

This PR is trying to catch the error when the API nodes are up but a service behind the API node isn't. 

# How

I am catching the particular error that gets thrown when another service isn't running. 

## How to test

Start this service after starting all of the docker containers. 
After this has started shut down mysql.
Send a creation request in.
Bring mysql back up and shut down kafka.
send the same creation request.

# Why

For unknown reasons Spring Boot doesn't seem to appreciate using the configuration options for not including the exception or the stack trace.

Instead I decided to utilize the pattern we are already using for catching exceptions and responding with HTTP status codes to give a friendly message.