### PR TITLE
Fix tests & a couple other things

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1126,6 +1126,15 @@ public class MonitorManagement {
       monitor.setPluginMetadataFields(new ArrayList<>(monitor.getPluginMetadataFields()));
       monitor.setZones(new ArrayList<>(monitor.getZones()));
 
+      /**
+       * The above stuff makes tests work, but fails when run for real due to
+       * Caused by: org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: com.rackspace.salus.telemetry.entities.Monitor.pluginMetadataFields, could not initialize proxy
+       *
+       * If we remove the above it will work for real but tests will fail.
+       *
+       * We need to solve this.
+       */
+
       monitorRepository.save(monitor);
 
       // Rebind the monitor to any relevant resources

--- a/src/main/java/com/rackspace/salus/monitor_management/services/PolicyEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/PolicyEventListener.java
@@ -75,7 +75,7 @@ public class PolicyEventListener {
 
   @KafkaHandler
   public void consumeMetadataPolicyUpdateEvents(MetadataPolicyEvent policyEvent) {
-    if (!policyEvent.getTenantId().equals(POLICY_TENANT)) {
+    if (policyEvent.getTenantId().equals(POLICY_TENANT)) {
       // Policy Monitors should not contain metadata.
       log.error("Received MetadataPolicyEvent={} for policy tenant", policyEvent);
     } else {

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
@@ -23,7 +23,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlConversionTest.java
@@ -21,6 +21,8 @@ import static com.rackspace.salus.monitor_management.web.model.telegraf.Conversi
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
@@ -29,30 +31,41 @@ import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @JsonTest
-@Import({MonitorConversionService.class})
+@Import({MonitorConversionService.class, MetadataUtils.class})
 public class MysqlConversionTest {
   @Configuration
   public static class TestConfig { }
 
+  @MockBean
+  PolicyApi policyApi;
+
+  @MockBean
+  MonitorRepository monitorRepository;
+
   @Autowired
   MonitorConversionService conversionService;
+
+  @Autowired
+  MetadataUtils metadataUtils;
 
   @Test
   public void convertToOutput_mysql() throws IOException {
@@ -167,7 +180,10 @@ public class MysqlConversionTest {
         .setName("name-a")
         .setLabelSelector(labels)
         .setDetails(details);
-    final MonitorCU result = conversionService.convertFromInput(input);
+    final MonitorCU result = conversionService.convertFromInput(
+        RandomStringUtils.randomAlphabetic(10),
+        null,
+        input);
 
     assertThat(result).isNotNull();
     assertThat(result.getLabelSelector()).isEqualTo(labels);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlRemoteConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlRemoteConversionTest.java
@@ -21,6 +21,8 @@ import static com.rackspace.salus.monitor_management.web.model.telegraf.Conversi
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
@@ -29,30 +31,41 @@ import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @JsonTest
-@Import({MonitorConversionService.class})
+@Import({MonitorConversionService.class, MetadataUtils.class})
 public class MysqlRemoteConversionTest {
   @Configuration
   public static class TestConfig { }
 
+  @MockBean
+  PolicyApi policyApi;
+
+  @MockBean
+  MonitorRepository monitorRepository;
+
   @Autowired
   MonitorConversionService conversionService;
+
+  @Autowired
+  MetadataUtils metadataUtils;
 
   @Test
   public void convertToOutput_mysqlremote() throws IOException {
@@ -167,7 +180,10 @@ public class MysqlRemoteConversionTest {
         .setName("name-a")
         .setLabelSelector(labels)
         .setDetails(details);
-    final MonitorCU result = conversionService.convertFromInput(input);
+    final MonitorCU result = conversionService.convertFromInput(
+        RandomStringUtils.randomAlphabetic(10),
+        null,
+        input);
 
     assertThat(result).isNotNull();
     assertThat(result.getLabelSelector()).isEqualTo(labels);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlConversionTest.java
@@ -21,6 +21,8 @@ import static com.rackspace.salus.monitor_management.web.model.telegraf.Conversi
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
@@ -29,30 +31,41 @@ import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @JsonTest
-@Import({MonitorConversionService.class})
+@Import({MonitorConversionService.class, MetadataUtils.class})
 public class PostgresqlConversionTest {
   @Configuration
   public static class TestConfig { }
 
+  @MockBean
+  PolicyApi policyApi;
+
+  @MockBean
+  MonitorRepository monitorRepository;
+
   @Autowired
   MonitorConversionService conversionService;
+
+  @Autowired
+  MetadataUtils metadataUtils;
 
   @Test
   public void convertToOutput_postgresql() throws IOException {
@@ -115,7 +128,10 @@ public class PostgresqlConversionTest {
         .setName("name-a")
         .setLabelSelector(labels)
         .setDetails(details);
-    final MonitorCU result = conversionService.convertFromInput(input);
+    final MonitorCU result = conversionService.convertFromInput(
+        RandomStringUtils.randomAlphabetic(10),
+        null,
+        input);
 
     assertThat(result).isNotNull();
     assertThat(result.getLabelSelector()).isEqualTo(labels);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlRemoteConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlRemoteConversionTest.java
@@ -21,6 +21,8 @@ import static com.rackspace.salus.monitor_management.web.model.telegraf.Conversi
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
@@ -29,30 +31,41 @@ import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @JsonTest
-@Import({MonitorConversionService.class})
+@Import({MonitorConversionService.class, MetadataUtils.class})
 public class PostgresqlRemoteConversionTest {
   @Configuration
   public static class TestConfig { }
 
+  @MockBean
+  PolicyApi policyApi;
+
+  @MockBean
+  MonitorRepository monitorRepository;
+
   @Autowired
   MonitorConversionService conversionService;
+
+  @Autowired
+  MetadataUtils metadataUtils;
 
   @Test
   public void convertToOutput_postgresql_remote() throws IOException {
@@ -115,7 +128,10 @@ public class PostgresqlRemoteConversionTest {
         .setName("name-a")
         .setLabelSelector(labels)
         .setDetails(details);
-    final MonitorCU result = conversionService.convertFromInput(input);
+    final MonitorCU result = conversionService.convertFromInput(
+        RandomStringUtils.randomAlphabetic(10),
+        null,
+        input);
 
     assertThat(result).isNotNull();
     assertThat(result.getLabelSelector()).isEqualTo(labels);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerConversionTest.java
@@ -21,6 +21,8 @@ import static com.rackspace.salus.monitor_management.web.model.telegraf.Conversi
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
@@ -29,30 +31,41 @@ import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @JsonTest
-@Import({MonitorConversionService.class})
+@Import({MonitorConversionService.class, MetadataUtils.class})
 public class SqlServerConversionTest {
   @Configuration
   public static class TestConfig { }
 
+  @MockBean
+  PolicyApi policyApi;
+
+  @MockBean
+  MonitorRepository monitorRepository;
+
   @Autowired
   MonitorConversionService conversionService;
+
+  @Autowired
+  MetadataUtils metadataUtils;
 
   @Test
   public void convertToOutput_sql_server() throws IOException {
@@ -112,7 +125,10 @@ public class SqlServerConversionTest {
         .setName("name-a")
         .setLabelSelector(labels)
         .setDetails(details);
-    final MonitorCU result = conversionService.convertFromInput(input);
+    final MonitorCU result = conversionService.convertFromInput(
+        RandomStringUtils.randomAlphabetic(10),
+        null,
+        input);
 
     assertThat(result).isNotNull();
     assertThat(result.getLabelSelector()).isEqualTo(labels);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerRemoteConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerRemoteConversionTest.java
@@ -21,6 +21,8 @@ import static com.rackspace.salus.monitor_management.web.model.telegraf.Conversi
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
@@ -29,30 +31,41 @@ import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @JsonTest
-@Import({MonitorConversionService.class})
+@Import({MonitorConversionService.class, MetadataUtils.class})
 public class SqlServerRemoteConversionTest {
   @Configuration
   public static class TestConfig { }
 
+  @MockBean
+  PolicyApi policyApi;
+
+  @MockBean
+  MonitorRepository monitorRepository;
+
   @Autowired
   MonitorConversionService conversionService;
+
+  @Autowired
+  MetadataUtils metadataUtils;
 
   @Test
   public void convertToOutput_sql_server() throws IOException {
@@ -112,7 +125,10 @@ public class SqlServerRemoteConversionTest {
         .setName("name-a")
         .setLabelSelector(labels)
         .setDetails(details);
-    final MonitorCU result = conversionService.convertFromInput(input);
+    final MonitorCU result = conversionService.convertFromInput(
+        RandomStringUtils.randomAlphabetic(10),
+        null,
+        input);
 
     assertThat(result).isNotNull();
     assertThat(result.getLabelSelector()).isEqualTo(labels);


### PR DESCRIPTION
# What

Added a comment to the Metadata handling method.  They are currently in a state that will work for tests but will fail if you use the api to update policy metadata.  I doubt anyone will run into this problem until we're able to find a solution.  I'm going to continue looking into it.

Flipped the condition in `consumeMetadataPolicyUpdateEvents`.  I started writing that logic one way and decided to change it but never flipped the if statement.  This also shows why I was wrong not to add tests for that kafka consumer (I've still left them off here, but will add them in future).

My recent PR led to recent test additions by George to fail due to the method signature being changed.  I've fixed all those tests so the build should now pass.