### PR TITLE
Make tests act the same way as prod

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1117,24 +1117,6 @@ public class MonitorManagement {
           monitorMetadataContentUpdateErrors.increment();
         }
       }
-
-      // JPA's EntityManager is a little strange with re-saving (aka merging) an entity
-      // that has a field of type List/Map. It wants to clear the loaded value, which is
-      // disallowed by the object it uses for retrieved lists/maps.
-      monitor.setLabelSelector(new HashMap<>(monitor.getLabelSelector()));
-      monitor.setMonitorMetadataFields(new ArrayList<>(monitor.getMonitorMetadataFields()));
-      monitor.setPluginMetadataFields(new ArrayList<>(monitor.getPluginMetadataFields()));
-      monitor.setZones(new ArrayList<>(monitor.getZones()));
-
-      /**
-       * The above stuff makes tests work, but fails when run for real due to
-       * Caused by: org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: com.rackspace.salus.telemetry.entities.Monitor.pluginMetadataFields, could not initialize proxy
-       *
-       * If we remove the above it will work for real but tests will fail.
-       *
-       * We need to solve this.
-       */
-
       monitorRepository.save(monitor);
 
       // Rebind the monitor to any relevant resources


### PR DESCRIPTION
# What

Convert the test to a SpringBootTest instead of DataJPATest

# How

Once converting the test definition the "weird" JPA steps were removed from MonitorManagement.  

The change from asserting on monitors to monitor ids in `assertThat(m, isOneOf(monitorsThatUseMetadata.toArray()));` was needed because the interval value is now different in `monitorsThatUseMetadata` compared to `m`.  With `DataJPATest`, the monitors stored in `monitorsThatUseMetadata` would be updated when the `handle...` method was ran.  These are now separated with `SpringBootTest`.

Additionally, the exception we assert on had to be changed since a different layer is now being tested.

Assertions for `getPluginMetadataFields` and `getMonitorMetadataFields` were removed since they would fail due to the lazily loaded exception now.

# Why

This change makes the test act the same way as production, which is much more ideal.  We do not have to do any workarounds to make the test work.

Those line removals had to be done to get things to work in prod, but would previously cause tests to fail.  With the change to `@SpringBootTest` the `LazyInitializationException` would occur when running tests if those lines were not removed.