### PR TITLE
Support Logical OR processing for monitors

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -114,6 +114,7 @@ public class MonitorManagement {
   private final ZoneManagement zoneManagement;
   private final ZonesProperties zonesProperties;
   private final String labelMatchQuery;
+  private final String labelMatchOrQuery;
   private final MonitorRepository monitorRepository;
   private final MonitorConversionService monitorConversionService;
   private final MetadataUtils metadataUtils;
@@ -162,7 +163,7 @@ public class MonitorManagement {
     this.metadataUtils = metadataUtils;
     this.jdbcTemplate = jdbcTemplate;
     this.labelMatchQuery = SpringResourceUtils.readContent("sql-queries/monitor_label_matching_query.sql");
-
+    this.labelMatchOrQuery = SpringResourceUtils.readContent("sql-queries/monitor_label_matching_OR_query.sql");
     monitorMetadataContentUpdateErrors = meterRegistry.counter("errors",
         "operation", "updateMonitorContentWithPolicy");
     invalidTemplateErrors = meterRegistry.counter("errors",
@@ -1528,9 +1529,17 @@ public class MonitorManagement {
 
     //noinspection ConstantConditions
     NamedParameterJdbcTemplate namedParameterTemplate = new NamedParameterJdbcTemplate(jdbcTemplate.getDataSource());
+
+
     final List<UUID> monitorIds = namedParameterTemplate.query(String.format(labelMatchQuery, builder.toString()), paramSource,
         (resultSet, rowIndex) -> UUID.fromString(resultSet.getString(1))
     );
+
+    final List<UUID> monitorOrIds = namedParameterTemplate.query(String.format(labelMatchOrQuery, builder.toString()), paramSource,
+        (resultSet, rowIndex) -> UUID.fromString(resultSet.getString(1))
+    );
+
+    monitorIds.addAll(monitorOrIds);
 
     final List<Monitor> monitors = new ArrayList<>();
     // use JPA to retrieve and resolve the Monitor objects and then convert Iterable result to list

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -373,7 +373,7 @@ public class MonitorManagement {
       r.ifPresent(resource -> resources.add(new ResourceDTO(resource)));
     } else {
       resources = resourceApi.getResourcesWithLabels(
-          tenantId, monitor.getLabelSelector());
+          tenantId, monitor.getLabelSelector(), monitor.getLabelSelectorMethod());
     }
 
     log.debug("Distributing new monitor={} to resources={}", monitor, resources);
@@ -972,7 +972,7 @@ public class MonitorManagement {
         boundMonitorRepository.findResourceIdsBoundToMonitor(monitor.getId());
 
     final List<ResourceDTO> selectedResources = resourceApi
-        .getResourcesWithLabels(tenantId, updatedLabelSelector);
+        .getResourcesWithLabels(tenantId, updatedLabelSelector, monitor.getLabelSelectorMethod());
 
     final Set<String> selectedResourceIds = selectedResources.stream()
         .map(ResourceDTO::getResourceId)

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -241,8 +241,8 @@ public class MonitorApiController {
     @ApiOperation(value = "Gets all Monitors that match labels. All labels must match to retrieve relevant Monitors.")
     @JsonView(View.Public.class)
     public PagedContent<DetailedMonitorOutput> getMonitorsWithLabels(@PathVariable String tenantId,
-                                                 @RequestBody Map<String, String> labels, Pageable pageable) {
-        return PagedContent.fromPage(monitorManagement.getMonitorsFromLabels(labels, tenantId, pageable)
+                                                 @RequestBody Map<String, String> labels) {
+        return PagedContent.fromPage(monitorManagement.getMonitorsFromLabels(labels, tenantId, Pageable.unpaged())
             .map(monitor -> monitorConversionService.convertToOutput(monitor)));
     }
 

--- a/src/main/resources/sql-queries/monitor_label_matching_OR_query.sql
+++ b/src/main/resources/sql-queries/monitor_label_matching_OR_query.sql
@@ -9,27 +9,27 @@ AND      monitors.id IN
   FROM   monitor_label_selectors
   WHERE  monitors.id IN
   (
-    SELECT id
-    FROM   monitors
+    SELECT first_monitors.id
+    FROM   monitors AS first_monitors
     WHERE  tenant_id = :tenantId
   )
   AND monitors.id IN
     (
-      SELECT monitor_id
+      SELECT monitor_label_selectors.monitor_id
       FROM monitor_label_selectors
       WHERE
-      monitor_id IN
+      monitor_label_selectors.monitor_id IN
       (
-        SELECT id
-        FROM monitors
+        SELECT inner_monitors.id
+        FROM monitors AS inner_monitors
         WHERE tenant_id = :tenantId
       )
       AND monitors.id IN
       (
-        SELECT monitor_id
+        SELECT monitor_label_selectors.monitor_id
         FROM monitor_label_selectors
         WHERE %s
-        GROUP BY id
+        GROUP BY monitor_label_selectors.monitor_id
         HAVING COUNT(*) >= 1
       )
  ))

--- a/src/main/resources/sql-queries/monitor_label_matching_OR_query.sql
+++ b/src/main/resources/sql-queries/monitor_label_matching_OR_query.sql
@@ -15,10 +15,10 @@ AND      monitors.id IN
   )
   AND monitors.id IN
     (
-      SELECT id
+      SELECT monitor_id
       FROM monitor_label_selectors
       WHERE
-      id IN
+      monitor_id IN
       (
         SELECT id
         FROM monitors
@@ -26,7 +26,7 @@ AND      monitors.id IN
       )
       AND monitors.id IN
       (
-        SELECT id
+        SELECT monitor_id
         FROM monitor_label_selectors
         WHERE %s
         GROUP BY id

--- a/src/main/resources/sql-queries/monitor_label_matching_OR_query.sql
+++ b/src/main/resources/sql-queries/monitor_label_matching_OR_query.sql
@@ -1,0 +1,35 @@
+SELECT   monitors.id
+FROM     monitors
+JOIN     monitor_label_selectors AS ml
+where    monitors.id = ml.monitor_id
+AND      monitors.label_selector_method = 'OR'
+AND      monitors.id IN
+         (
+    SELECT monitor_id
+    FROM   monitor_label_selectors
+    WHERE  monitors.id IN
+       (
+          SELECT id
+          FROM   monitors
+          WHERE  tenant_id = :tenantId)
+    AND    monitors.id IN
+        (
+      SELECT id
+      FROM monitor_label_selectors
+      WHERE
+         id IN
+         (
+            SELECT id
+            FROM monitors
+            WHERE tenant_id = :tenantId
+         )
+         AND monitors.id IN
+         (
+            SELECT id
+            FROM monitor_label_selectors
+            WHERE %s
+            GROUP BY id
+            HAVING COUNT(*) >= 1
+         )
+   ))
+ORDER BY monitors.id

--- a/src/main/resources/sql-queries/monitor_label_matching_OR_query.sql
+++ b/src/main/resources/sql-queries/monitor_label_matching_OR_query.sql
@@ -4,32 +4,33 @@ JOIN     monitor_label_selectors AS ml
 where    monitors.id = ml.monitor_id
 AND      monitors.label_selector_method = 'OR'
 AND      monitors.id IN
-         (
-    SELECT monitor_id
-    FROM   monitor_label_selectors
-    WHERE  monitors.id IN
-       (
-          SELECT id
-          FROM   monitors
-          WHERE  tenant_id = :tenantId)
-    AND    monitors.id IN
-        (
+  (
+  SELECT monitor_id
+  FROM   monitor_label_selectors
+  WHERE  monitors.id IN
+  (
+    SELECT id
+    FROM   monitors
+    WHERE  tenant_id = :tenantId
+  )
+  AND monitors.id IN
+    (
       SELECT id
       FROM monitor_label_selectors
       WHERE
-         id IN
-         (
-            SELECT id
-            FROM monitors
-            WHERE tenant_id = :tenantId
-         )
-         AND monitors.id IN
-         (
-            SELECT id
-            FROM monitor_label_selectors
-            WHERE %s
-            GROUP BY id
-            HAVING COUNT(*) >= 1
-         )
-   ))
+      id IN
+      (
+        SELECT id
+        FROM monitors
+        WHERE tenant_id = :tenantId
+      )
+      AND monitors.id IN
+      (
+        SELECT id
+        FROM monitor_label_selectors
+        WHERE %s
+        GROUP BY id
+        HAVING COUNT(*) >= 1
+      )
+ ))
 ORDER BY monitors.id

--- a/src/main/resources/sql-queries/monitor_label_matching_query.sql
+++ b/src/main/resources/sql-queries/monitor_label_matching_query.sql
@@ -5,12 +5,12 @@ where    monitors.id = ml.monitor_id
 AND      monitors.label_selector_method = 'AND'
 AND      monitors.id IN
          (
-    SELECT monitor_id
-    FROM   monitor_label_selectors
+    SELECT first_ml.monitor_id
+    FROM   monitor_label_selectors AS first_ml
     WHERE  monitors.id IN
        (
-          SELECT id
-          FROM   monitors
+          SELECT first_monitors.id
+          FROM   monitors AS first_monitors
           WHERE  tenant_id = :tenantId)
     AND    monitors.id IN
         (

--- a/src/main/resources/sql-queries/monitor_label_matching_query.sql
+++ b/src/main/resources/sql-queries/monitor_label_matching_query.sql
@@ -2,6 +2,7 @@ SELECT   monitors.id
 FROM     monitors
 JOIN     monitor_label_selectors AS ml
 where    monitors.id = ml.monitor_id
+AND      monitors.label_selector_method = 'AND'
 AND      monitors.id IN
          (
     SELECT monitor_id

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -199,7 +200,7 @@ public class MonitorManagementPolicyTest {
         .setAssociatedWithEnvoy(true)
     );
 
-    when(resourceApi.getResourcesWithLabels(any(), any()))
+    when(resourceApi.getResourcesWithLabels(any(), any(), eq(LabelSelectorMethod.AND)))
         .thenReturn(resourceList);
 
     EnvoyResourcePair pair = new EnvoyResourcePair().setEnvoyId("e-new").setResourceId("r-new-1");
@@ -605,7 +606,7 @@ public class MonitorManagementPolicyTest {
     );
 
     // both resources are relevant to the policy
-    when(resourceApi.getResourcesWithLabels(any(), any()))
+    when(resourceApi.getResourcesWithLabels(any(), any(), eq(LabelSelectorMethod.AND)))
         .thenReturn(resourceList);
 
     // EXECUTE
@@ -700,7 +701,7 @@ public class MonitorManagementPolicyTest {
     );
 
     // both resources are relevant to the policy
-    when(resourceApi.getResourcesWithLabels(any(), any()))
+    when(resourceApi.getResourcesWithLabels(any(), any(), eq(LabelSelectorMethod.AND)))
         .thenReturn(resourceList);
 
     // define the bound monitors
@@ -787,7 +788,7 @@ public class MonitorManagementPolicyTest {
         .setAssociatedWithEnvoy(true)
     );
     // both resources are relevant to the policy
-    when(resourceApi.getResourcesWithLabels(any(), any()))
+    when(resourceApi.getResourcesWithLabels(any(), any(), eq(LabelSelectorMethod.AND)))
         .thenReturn(resourceList);
 
     List<BoundMonitor> existingBound = new ArrayList<>();
@@ -889,7 +890,7 @@ public class MonitorManagementPolicyTest {
         .setAssociatedWithEnvoy(true)
     );
     // both resources are relevant to the policy
-    when(resourceApi.getResourcesWithLabels(any(), any()))
+    when(resourceApi.getResourcesWithLabels(any(), any(), eq(LabelSelectorMethod.AND)))
         .thenReturn(resourceList);
 
     List<BoundMonitor> existingBound = new ArrayList<>();
@@ -986,7 +987,7 @@ public class MonitorManagementPolicyTest {
         .setAssociatedWithEnvoy(true)
     );
     // both resources are relevant to the policy
-    when(resourceApi.getResourcesWithLabels(any(), any()))
+    when(resourceApi.getResourcesWithLabels(any(), any(), eq(LabelSelectorMethod.AND)))
         .thenReturn(resourceList);
 
     // Define the bound monitors that will be removed
@@ -1008,7 +1009,7 @@ public class MonitorManagementPolicyTest {
         .thenReturn(existingBound);
 
     // All resources will be returned when rebinding
-    when(resourceApi.getResourcesWithLabels(any(), any()))
+    when(resourceApi.getResourcesWithLabels(any(), any(), eq(LabelSelectorMethod.AND)))
         .thenReturn(resourceList);
 
     // Various calls involved in finding the envoys to detach/attach to.
@@ -1057,7 +1058,7 @@ public class MonitorManagementPolicyTest {
     }
 
     // operations involved in binding the monitor to the two relevant resources
-    verify(resourceApi).getResourcesWithLabels(tenantId, monitor.getLabelSelector());
+    verify(resourceApi).getResourcesWithLabels(tenantId, monitor.getLabelSelector(), monitor.getLabelSelectorMethod());
     verify(zoneManagement).getAvailableZonesForTenant(tenantId, Pageable.unpaged());
     verify(boundMonitorRepository).saveAll(captorOfBoundMonitorList.capture());
     org.assertj.core.api.Assertions.assertThat(captorOfBoundMonitorList.getValue())

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -1656,7 +1656,7 @@ public class MonitorManagementTest {
     entityManager.flush();
 
     Page<Monitor> monitors = monitorManagement.getMonitorsFromLabels(labels, tenantId, Pageable.unpaged());
-    assertEquals(0L, monitors.getTotalElements()); //make sure we only returned the one value
+    assertEquals(0L, monitors.getTotalElements());
   }
 
   @Test
@@ -1668,19 +1668,25 @@ public class MonitorManagementTest {
     monitorLabels.put("region", "DFW");
     final Map<String, String> labels = new HashMap<>();
     labels.put("os", "DARWIN");
-    labels.put("env", "test");
+    labels.put("env", "prod");
 
     MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
     create.setLabelSelector(monitorLabels);
     create.setSelectorScope(ConfigSelectorScope.LOCAL);
     create.setZones(Collections.emptyList());
-    create.setLabelSelectorMethod(LabelSelectorMethod.AND);
+    create.setLabelSelectorMethod(LabelSelectorMethod.OR);
     String tenantId = RandomStringUtils.randomAlphanumeric(10);
     monitorManagement.createMonitor(tenantId, create);
     entityManager.flush();
 
     Page<Monitor> monitors = monitorManagement.getMonitorsFromLabels(labels, tenantId, Pageable.unpaged());
-    assertEquals(0L, monitors.getTotalElements()); //make sure we only returned the one value
+    assertEquals(1L, monitors.getTotalElements()); //make sure we only returned the one value
+    assertEquals(tenantId, monitors.getContent().get(0).getTenantId());
+    assertEquals(create.getAgentType(), monitors.getContent().get(0).getAgentType());
+    assertEquals(create.getContent(), monitors.getContent().get(0).getContent());
+    assertEquals(create.getMonitorName(), monitors.getContent().get(0).getMonitorName());
+    assertEquals(create.getSelectorScope(), monitors.getContent().get(0).getSelectorScope());
+    assertEquals(create.getLabelSelector(), monitors.getContent().get(0).getLabelSelector());
   }
 
   @Test
@@ -1769,7 +1775,7 @@ public class MonitorManagementTest {
     monitorLabels.put("env", "test");
     final Map<String, String> labels = new HashMap<>();
     labels.put("os", "DARWIN");
-    labels.put("env", "test");
+    labels.put("env", "prod");
     labels.put("architecture", "x86");
     labels.put("region", "DFW");
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -1622,6 +1622,7 @@ public class MonitorManagementTest {
     MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
     create.setLabelSelector(labels);
     create.setSelectorScope(ConfigSelectorScope.LOCAL);
+    create.setLabelSelectorMethod(LabelSelectorMethod.AND);
     create.setZones(Collections.emptyList());
     String tenantId = RandomStringUtils.randomAlphanumeric(10);
     monitorManagement.createMonitor(tenantId, create);
@@ -1646,6 +1647,7 @@ public class MonitorManagementTest {
     create.setLabelSelector(monitorLabels);
     create.setSelectorScope(ConfigSelectorScope.LOCAL);
     create.setZones(Collections.emptyList());
+    create.setLabelSelectorMethod(LabelSelectorMethod.AND);
     String tenantId = RandomStringUtils.randomAlphanumeric(10);
     monitorManagement.createMonitor(tenantId, create);
     entityManager.flush();
@@ -1669,6 +1671,7 @@ public class MonitorManagementTest {
     create.setLabelSelector(monitorLabels);
     create.setSelectorScope(ConfigSelectorScope.LOCAL);
     create.setZones(Collections.emptyList());
+    create.setLabelSelectorMethod(LabelSelectorMethod.AND);
     String tenantId = RandomStringUtils.randomAlphanumeric(10);
     monitorManagement.createMonitor(tenantId, create);
     entityManager.flush();

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
@@ -194,7 +194,7 @@ public class MonitorManagement_MetadataPolicyTest {
     when(envoyResourceManagement.getOne(anyString(), anyString()))
         .thenReturn(CompletableFuture.completedFuture(resourceInfo));
 
-    when(resourceApi.getResourcesWithLabels(any(), any()))
+    when(resourceApi.getResourcesWithLabels(any(), any(), LabelSelectorMethod.AND))
         .thenReturn(resourceList);
 
     EnvoyResourcePair pair = new EnvoyResourcePair().setEnvoyId("e-new").setResourceId("r-new-1");


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-606

# What

Support logical OR as well as logical AND processing for matching labels. This label matching is more complex than for resource management because we need to figure out which objects in the database are configured for OR and apply that query to them and which are configured for AND and apply that query to them.

# How

I duplicated the AND query and modified it for handling OR processing. 

I then query the database separately for both and combine the results together for returning.

## How to test

Run the unit tests. The specific functions that test this have the function ending in "UsingOr"

# Why

We considered handling this in a hybrid approach through JPA or Hibernate. Neither of those places seemed to have a good way of querying map values. 

Another hybrid option of doing this through JDBC still required the writing of the OR based query and then handling the rest of the processing server side. Since we already have the AND query it seems more logical to me to just handle this all at query time, since we need both queries.
