### PR TITLE
Add PATCH method to Monitor Management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,11 @@
       <artifactId>javax.json-api</artifactId>
       <version>1.1.4</version>
     </dependency>
-    <!-- JSR-353 (JSON Processing): Johnzon implementation -->
+    <!-- JSR-353 (JSON Processing): Implementation -->
     <dependency>
-      <groupId>org.apache.johnzon</groupId>
-      <artifactId>johnzon-core</artifactId>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+      <version>1.1</version>
     </dependency>
     <!-- Jackson module for the JSR-353 (JSON Processing) -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,23 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <!-- JSR-353 (JSON Processing): API -->
+    <dependency>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
+      <version>1.1.4</version>
+    </dependency>
+    <!-- JSR-353 (JSON Processing): Johnzon implementation -->
+    <dependency>
+      <groupId>org.apache.johnzon</groupId>
+      <artifactId>johnzon-core</artifactId>
+    </dependency>
+    <!-- Jackson module for the JSR-353 (JSON Processing) -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr353</artifactId>
+      <version>2.9.9</version>
+    </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-protocol</artifactId>

--- a/src/main/java/com/rackspace/salus/monitor_management/config/JsonConfig.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/JsonConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.config;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.datatype.jsr353.JSR353Module;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JsonConfig {
+
+  @Bean
+  public Module jsr353Module() {
+    // Register ability to handle Json Merge Patch conversions.
+    return new JSR353Module();
+  }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -123,7 +123,13 @@ public class MonitorConversionService {
     return detailedMonitorOutput;
   }
 
-  public MonitorCU convertFromInput(String tenantId, UUID monitorId, DetailedMonitorInput input) {
+  public MonitorCU convertFromInput(String tenantId, UUID monitorId,
+      DetailedMonitorInput input) {
+    return convertFromInput(tenantId, monitorId, input, false);
+  }
+
+  public MonitorCU convertFromInput(String tenantId, UUID monitorId,
+                                    DetailedMonitorInput input, boolean patchOperation) {
 
     validateInterval(input.getInterval());
 
@@ -150,7 +156,7 @@ public class MonitorConversionService {
 
       final LocalPlugin plugin = ((LocalMonitorDetails) details).getPlugin();
       populateMonitorType(monitor, plugin);
-      populateAgentConfigContent(tenantId, input, monitor, plugin);
+      populateAgentConfigContent(tenantId, input, monitor, plugin, patchOperation);
     } else if (details instanceof RemoteMonitorDetails) {
       final RemoteMonitorDetails remoteMonitorDetails = (RemoteMonitorDetails) details;
 
@@ -159,7 +165,7 @@ public class MonitorConversionService {
 
       final RemotePlugin plugin = remoteMonitorDetails.getPlugin();
       populateMonitorType(monitor, plugin);
-      populateAgentConfigContent(tenantId, input, monitor, plugin);
+      populateAgentConfigContent(tenantId, input, monitor, plugin, patchOperation);
     }
 
     return monitor;
@@ -184,7 +190,7 @@ public class MonitorConversionService {
   }
 
   private void populateAgentConfigContent(String tenantId, DetailedMonitorInput input, MonitorCU monitor,
-                                          Object plugin) {
+                                          Object plugin, boolean patchOperation) {
     final ApplicableAgentType applicableAgentType = plugin.getClass()
         .getAnnotation(ApplicableAgentType.class);
     if (applicableAgentType == null) {
@@ -197,7 +203,7 @@ public class MonitorConversionService {
 
     // Policy monitors should not use metadata
     if (!tenantId.equals(Monitor.POLICY_TENANT)) {
-      metadataUtils.setMetadataFieldsForPlugin(tenantId, monitor, plugin);
+      metadataUtils.setMetadataFieldsForPlugin(tenantId, monitor, plugin, patchOperation);
     }
 
     try {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -75,9 +75,6 @@ public class MonitorConversionService {
     this.monitorRepository = monitorRepository;
     this.metadataUtils = metadataUtils;
     this.patchHelper = patchHelper;
-
-    // Register ability to handle Json Merge Patch conversions.
-    this.objectMapper.registerModule(new JSR353Module());
   }
 
   public DetailedMonitorOutput convertToOutput(Monitor monitor) {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -133,8 +133,19 @@ public class MonitorConversionService {
     return detailedMonitorOutput;
   }
 
+  /**
+   * Helper method for updates to perform a patch.
+   *
+   * @param tenantId  The tenant the monitor relates to.
+   * @param monitorId The id of the monitor if an update is being performed.
+   * @param monitor   The existing monitor object that will be updated
+   * @param patch     The individual changes to be made to the Monitor
+   * @return A MonitorCU object used to construct a Monitor
+   */
   public MonitorCU convertFromPatchInput(String tenantId, UUID monitorId,
                                         Monitor monitor, JsonMergePatch patch) {
+    // To apply a patch we must convert the existing monitor to a DetailedMonitorInput
+    // then write any new values we've received to that.
     DetailedMonitorOutput output = convertToOutput(monitor);
     DetailedMonitorInput input = new DetailedMonitorInput(output);
 
@@ -143,11 +154,31 @@ public class MonitorConversionService {
     return convertFromInput(tenantId, monitorId, patchedInput, true);
   }
 
+  /**
+   * Helper method for updates that defaults to a non-patch update.
+   *
+   * @param tenantId  The tenant the monitor relates to.
+   * @param monitorId The id of the monitor if an update is being performed.
+   * @param input     The details provided to set on the Monitor
+   *
+   * @return A MonitorCU object used to construct a Monitor
+   */
   public MonitorCU convertFromInput(String tenantId, UUID monitorId,
       DetailedMonitorInput input) {
     return convertFromInput(tenantId, monitorId, input, false);
   }
 
+  /**
+   * Generates a monitor's string content from an input plugin object.
+   *
+   * @param tenantId       The tenant the monitor relates to.
+   * @param monitorId      The id of the monitor if an update is being performed.
+   * @param input          The details provided to set on the Monitor
+   * @param patchOperation Whether a patch or update/put is being performed. True for patch.
+   *                       null values are ignored for updates but utilized in patches.
+   *
+   * @return A MonitorCU object used to construct a Monitor
+   */
   public MonitorCU convertFromInput(String tenantId, UUID monitorId,
                                     DetailedMonitorInput input, boolean patchOperation) {
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -779,7 +779,13 @@ public class MonitorManagement {
     if (zonesChanged(updatedValues.getZones(), monitor.getZones(), patchOperation)) {
       // See above regarding:
       // JPA's EntityManager is a little strange with re-saving (aka merging) an entity
-      monitor.setZones(new ArrayList<>(updatedValues.getZones()));
+      if (updatedValues.getZones() == null) {
+        // policy monitors cannot use metadata, so this value cannot be null.
+        // ignore the change and keep the original zones.
+        monitor.setZones(new ArrayList<>(monitor.getZones()));
+      } else {
+        monitor.setZones(new ArrayList<>(updatedValues.getZones()));
+      }
     } else if (monitor.getZones() != null) {
       monitor.setZones(new ArrayList<>(monitor.getZones()));
     }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -606,9 +606,12 @@ public class MonitorManagement {
   /**
    * Update an existing monitor.
    *
-   * @param tenantId      The tenant to update the monitor for.
-   * @param id            The id of the existing monitor.
-   * @param updatedValues The new monitor parameters to store.
+   * @param tenantId       The tenant to update the monitor for.
+   * @param id             The id of the existing monitor.
+   * @param updatedValues  The new monitor parameters to store.
+   * @param patchOperation Whether a patch or update/put is being performed. True for patch.
+   *                       null values are ignored for updates but utilized in patches.
+   *
    * @return The newly updated monitor.
    */
   public Monitor updateMonitor(String tenantId, UUID id, @Valid MonitorCU updatedValues, boolean patchOperation) {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -693,8 +693,7 @@ public class MonitorManagement {
 
     // Detect zone changes
     List<String> originalZones = monitor.getZones();
-    boolean zonesChanged = zonesChanged(updatedValues.getZones(), originalZones, patchOperation);
-    if (zonesChanged) {
+    if (zonesChanged(updatedValues.getZones(), originalZones, patchOperation)) {
       // give JPA a modifiable copy of the given list
       if (updatedValues.getZones() == null) {
         monitor.setZones(null);
@@ -710,7 +709,8 @@ public class MonitorManagement {
     metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, patchOperation);
     monitor.setPluginMetadataFields(updatedValues.getPluginMetadataFields());
 
-    if (zonesChanged) {
+    // test things again once metadata has been put in place
+    if (zonesChanged(monitor.getZones(), originalZones, patchOperation)) {
       // Process potential changes to bound zones
       // we must perform this after the metadata has been set in case zones was set to null
       // and the default must first be populated.

--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -47,7 +47,7 @@ public class MetadataUtils {
    * @param object The object to inspect for metadata fields.
    * @return The list of metadata fields found.
    */
-  public static List<String> getMetadataFieldsForCreate(Object object) {
+  static List<String> getMetadataFieldsForCreate(Object object) {
     List<String> metadataFields = new ArrayList<>();
     for (Field f : object.getClass().getDeclaredFields()) {
       try {
@@ -72,7 +72,8 @@ public class MetadataUtils {
    * @param policies A map of relevant policies.
    * @return The list of metadata fields found.
    */
-  public static List<String> getMetadataFieldsForUpdate(Object object, List<String> previousMetadataFields, Map<String, MonitorMetadataPolicyDTO> policies) {
+  @SuppressWarnings("unchecked")
+  static List<String> getMetadataFieldsForUpdate(Object object, List<String> previousMetadataFields, Map<String, MonitorMetadataPolicyDTO> policies) {
     List<String> metadataFields = new ArrayList<>();
     for (Field f : object.getClass().getDeclaredFields()) {
       try {
@@ -129,7 +130,7 @@ public class MetadataUtils {
    * @param metadataFields The metadata fields that should attempt to be updated.
    * @param policyMetadata The relevant policies for this object.
    */
-  public static void setNewMetadataValues(Object object, List<String> metadataFields, Map<String, MonitorMetadataPolicyDTO> policyMetadata) {
+  static void setNewMetadataValues(Object object, List<String> metadataFields, Map<String, MonitorMetadataPolicyDTO> policyMetadata) {
     for (String key : metadataFields) {
       if (policyMetadata.containsKey(key)) {
         MonitorMetadataPolicyDTO policy = policyMetadata.get(key);
@@ -180,12 +181,14 @@ public class MetadataUtils {
    * @param tenantId The tenant id the monitor is created under.
    * @param monitor The monitor object to update.
    */
-  public void setMetadataFieldsForMonitor(String tenantId, Monitor monitor) {
+  public void setMetadataFieldsForMonitor(String tenantId, Monitor monitor, boolean patchOperation) {
     Map<String, MonitorMetadataPolicyDTO> policyMetadata = null;
     List<String> metadataFields;
     TargetClassName className = TargetClassName.getTargetClassName(monitor);
 
-    if (monitor.getMonitorMetadataFields() != null && !monitor.getMonitorMetadataFields().isEmpty()) {
+    if (!patchOperation &&
+        monitor.getMonitorMetadataFields() != null &&
+        !monitor.getMonitorMetadataFields().isEmpty()) {
       policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType());
       metadataFields = MetadataUtils
           .getMetadataFieldsForUpdate(monitor, monitor.getMonitorMetadataFields(), policyMetadata);
@@ -224,12 +227,14 @@ public class MetadataUtils {
    * @param monitor The parent MonitorCU object being constructed.
    * @param plugin The plugin to set metadata values on.
    */
-  public void setMetadataFieldsForPlugin(String tenantId, MonitorCU monitor, Object plugin) {
+  public void setMetadataFieldsForPlugin(String tenantId, MonitorCU monitor, Object plugin, boolean patchOperation) {
     Map<String, MonitorMetadataPolicyDTO> policyMetadata = null;
     List<String> metadataFields;
     TargetClassName className = TargetClassName.getTargetClassName(plugin);
 
-    if (monitor.getPluginMetadataFields() != null && !monitor.getPluginMetadataFields().isEmpty()) {
+    if (!patchOperation &&
+        monitor.getPluginMetadataFields() != null &&
+        !monitor.getPluginMetadataFields().isEmpty()) {
       policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType());
       metadataFields = MetadataUtils
           .getMetadataFieldsForUpdate(plugin, monitor.getPluginMetadataFields(), policyMetadata);

--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -154,7 +154,7 @@ public class MetadataUtils {
           break;
         case STRING_LIST:
           List<String> listValue = Arrays.asList(policy.getValue().split("\\s*,\\s*"));
-          f.set(object, listValue);
+          f.set(object, new ArrayList<>(listValue));
           break;
         case INT:
           f.set(object, Integer.parseInt(policy.getValue()));

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -179,7 +179,6 @@ public class MonitorApiController {
   @ApiOperation(value = "Patch specific Policy Monitor")
   @JsonView(View.Admin.class)
   public DetailedMonitorOutput patchPolicyMonitor(@PathVariable UUID uuid,
-                                                  @Validated(ValidationGroups.Patch.class)
                                                   @RequestBody final JsonMergePatch input)
       throws IllegalArgumentException {
 
@@ -276,7 +275,6 @@ public class MonitorApiController {
   @JsonView(View.Public.class)
   public DetailedMonitorOutput patch(@PathVariable String tenantId,
       @PathVariable UUID uuid,
-      @Validated(ValidationGroups.Patch.class)
       @RequestBody final JsonMergePatch input)
       throws IllegalArgumentException {
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -175,7 +175,7 @@ public class MonitorApiController {
         ));
   }
 
-  @PatchMapping("/admin/policy-monitors/{uuid}")
+  @PatchMapping(path = "/admin/policy-monitors/{uuid}", consumes = JSON_MERGE_PATCH_TYPE)
   @ApiOperation(value = "Patch specific Policy Monitor")
   @JsonView(View.Admin.class)
   public DetailedMonitorOutput patchPolicyMonitor(@PathVariable UUID uuid,

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -46,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.util.MultiValueMap;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -175,7 +176,8 @@ public class MonitorApiController {
         ));
   }
 
-  @PatchMapping(path = "/admin/policy-monitors/{uuid}", consumes = JSON_MERGE_PATCH_TYPE)
+  @PatchMapping(path = "/admin/policy-monitors/{uuid}",
+                consumes = {MediaType.APPLICATION_JSON_VALUE, JSON_MERGE_PATCH_TYPE})
   @ApiOperation(value = "Patch specific Policy Monitor")
   @JsonView(View.Admin.class)
   public DetailedMonitorOutput patchPolicyMonitor(@PathVariable UUID uuid,
@@ -270,7 +272,8 @@ public class MonitorApiController {
         ));
   }
 
-  @PatchMapping(path = "/tenant/{tenantId}/monitors/{uuid}", consumes = JSON_MERGE_PATCH_TYPE)
+  @PatchMapping(path = "/tenant/{tenantId}/monitors/{uuid}",
+                consumes = {MediaType.APPLICATION_JSON_VALUE, JSON_MERGE_PATCH_TYPE})
   @ApiOperation(value = "Updates specific Monitor for Tenant")
   @JsonView(View.Public.class)
   public DetailedMonitorOutput patch(@PathVariable String tenantId,

--- a/src/main/java/com/rackspace/salus/monitor_management/web/converter/JsonMergePatchHttpMessageConverter.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/converter/JsonMergePatchHttpMessageConverter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.converter;
+
+import static com.rackspace.salus.monitor_management.web.converter.PatchHelper.JSON_MERGE_PATCH_TYPE;
+
+import javax.json.Json;
+import javax.json.JsonMergePatch;
+import javax.json.JsonReader;
+import javax.json.JsonWriter;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsonMergePatchHttpMessageConverter extends AbstractHttpMessageConverter<JsonMergePatch> {
+
+  public JsonMergePatchHttpMessageConverter() {
+    super(MediaType.valueOf(JSON_MERGE_PATCH_TYPE));
+  }
+
+  @Override
+  protected boolean supports(Class<?> clazz) {
+    return JsonMergePatch.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  protected JsonMergePatch readInternal(Class<? extends JsonMergePatch> clazz, HttpInputMessage inputMessage)
+      throws HttpMessageNotReadableException {
+
+    try (JsonReader reader = Json.createReader(inputMessage.getBody())) {
+      return Json.createMergePatch(reader.readValue());
+    } catch (Exception e) {
+      throw new HttpMessageNotReadableException(e.getMessage(), inputMessage);
+    }
+  }
+
+  @Override
+  protected void writeInternal(JsonMergePatch jsonMergePatch, HttpOutputMessage outputMessage)
+      throws HttpMessageNotWritableException {
+
+    try (JsonWriter writer = Json.createWriter(outputMessage.getBody())) {
+      writer.write(jsonMergePatch.toJsonValue());
+    } catch (Exception e) {
+      throw new HttpMessageNotWritableException(e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/converter/PatchHelper.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/converter/PatchHelper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Set;
+import javax.json.JsonMergePatch;
+import javax.json.JsonPatch;
+import javax.json.JsonStructure;
+import javax.json.JsonValue;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PatchHelper {
+
+  public static final String JSON_MERGE_PATCH_TYPE = "application/json-patch+json";
+
+  private final ObjectMapper objectMapper;
+  private final Validator validator;
+
+  /**
+   * Performs a JSON Patch operation.
+   *
+   * @param patch      JSON Patch document
+   * @param targetBean object that will be patched
+   * @param beanClass  class of the object the will be patched
+   * @param <T>
+   * @return patched object
+   */
+  public <T> T patch(JsonPatch patch, T targetBean, Class<T> beanClass) {
+    JsonStructure target = objectMapper.convertValue(targetBean, JsonStructure.class);
+    JsonValue patched = applyPatch(patch, target);
+    return convertAndValidate(patched, beanClass);
+  }
+
+  /**
+   * Performs a JSON Merge Patch operation
+   *
+   * @param mergePatch JSON Merge Patch document
+   * @param targetBean object that will be patched
+   * @param beanClass  class of the object the will be patched
+   * @param <T>
+   * @return patched object
+   */
+  public <T> T mergePatch(JsonMergePatch mergePatch, T targetBean, Class<T> beanClass) {
+    JsonValue target = objectMapper.convertValue(targetBean, JsonValue.class);
+    JsonValue patched = applyMergePatch(mergePatch, target);
+    return convertAndValidate(patched, beanClass);
+  }
+
+  private JsonValue applyPatch(JsonPatch patch, JsonStructure target) {
+    try {
+      return patch.apply(target);
+    } catch (Exception e) {
+      throw e;
+    }
+  }
+
+  private JsonValue applyMergePatch(JsonMergePatch mergePatch, JsonValue target) {
+    try {
+      return mergePatch.apply(target);
+    } catch (Exception e) {
+      throw e;
+    }
+  }
+
+  private <T> T convertAndValidate(JsonValue jsonValue, Class<T> beanClass) {
+    T bean = objectMapper.convertValue(jsonValue, beanClass);
+    validate(bean);
+    return bean;
+  }
+
+  private <T> void validate(T bean) {
+    Set<ConstraintViolation<T>> violations = validator.validate(bean);
+    if (!violations.isEmpty()) {
+      throw new ConstraintViolationException(violations);
+    }
+  }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/converter/PatchHelper.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/converter/PatchHelper.java
@@ -63,13 +63,14 @@ public class PatchHelper {
    * @param mergePatch JSON Merge Patch document
    * @param targetBean object that will be patched
    * @param beanClass  class of the object the will be patched
+   * @param groups     validation groups for the operation
    * @param <T>
    * @return patched object
    */
-  public <T> T mergePatch(JsonMergePatch mergePatch, T targetBean, Class<T> beanClass) {
+  public <T> T mergePatch(JsonMergePatch mergePatch, T targetBean, Class<T> beanClass, Class<?>... groups) {
     JsonValue target = objectMapper.convertValue(targetBean, JsonValue.class);
     JsonValue patched = applyMergePatch(mergePatch, target);
-    return convertAndValidate(patched, beanClass);
+    return convertAndValidate(patched, beanClass, groups);
   }
 
   private JsonValue applyPatch(JsonPatch patch, JsonStructure target) {
@@ -88,14 +89,14 @@ public class PatchHelper {
     }
   }
 
-  private <T> T convertAndValidate(JsonValue jsonValue, Class<T> beanClass) {
+  private <T> T convertAndValidate(JsonValue jsonValue, Class<T> beanClass, Class<?>... groups) {
     T bean = objectMapper.convertValue(jsonValue, beanClass);
-    validate(bean);
+    validate(bean, groups);
     return bean;
   }
 
-  private <T> void validate(T bean) {
-    Set<ConstraintViolation<T>> violations = validator.validate(bean);
+  private <T> void validate(T bean, Class<?>... groups) {
+    Set<ConstraintViolation<T>> violations = validator.validate(bean, groups);
     if (!violations.isEmpty()) {
       throw new ConstraintViolationException(violations);
     }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/converter/PatchHelper.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/converter/PatchHelper.java
@@ -25,17 +25,22 @@ import javax.json.JsonValue;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validator;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class PatchHelper {
 
   public static final String JSON_MERGE_PATCH_TYPE = "application/json-patch+json";
 
   private final ObjectMapper objectMapper;
   private final Validator validator;
+
+  @Autowired
+  public PatchHelper(ObjectMapper objectMapper, Validator validator) {
+    this.objectMapper = objectMapper;
+    this.validator = validator;
+  }
 
   /**
    * Performs a JSON Patch operation.

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
@@ -55,6 +55,7 @@ public class DetailedMonitorInput {
 
   public DetailedMonitorInput(DetailedMonitorOutput output) {
     this.name = output.getName();
+    this.labelSelector = output.getLabelSelector();
     this.labelSelectorMethod = output.getLabelSelectorMethod();
     this.resourceId = output.getResourceId();
     this.interval = output.getInterval();

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
@@ -30,7 +30,7 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-@ValidCreateMonitor(groups = {ValidationGroups.Create.class})
+@ValidCreateMonitor(groups = {ValidationGroups.Create.class, ValidationGroups.Patch.class})
 @ValidUpdateMonitor(groups = {ValidationGroups.Update.class})
 public class DetailedMonitorInput {
   String name;
@@ -49,7 +49,7 @@ public class DetailedMonitorInput {
   Duration interval;
 
   @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\",\"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false,\"reportActive\": false, \"totalcpu\": true}}")
-  @NotNull(groups = ValidationGroups.Create.class)
+  @NotNull(groups = {ValidationGroups.Create.class, ValidationGroups.Patch.class})
   @Valid
   MonitorDetails details;
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ValidationGroups.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ValidationGroups.java
@@ -32,5 +32,6 @@ public class ValidationGroups {
    */
   public interface Create extends Default { }
   public interface Update extends Default { }
+  public interface Patch extends Default { }
 
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -472,7 +472,7 @@ public class MonitorConversionServiceTest {
         .setUpdatedTimestamp(Instant.EPOCH);
 
     // Create the patch payload which only contains the fields to change
-    // Urls has non-null validation and should trigger an exception
+    // Details has non-null validation and should trigger an exception
     JsonMergePatch mergePatch = Json.createMergePatch(Json.createObjectBuilder()
         .add("interval", JsonValue.NULL)
         .add("details", JsonValue.NULL)
@@ -517,7 +517,7 @@ public class MonitorConversionServiceTest {
         .setUpdatedTimestamp(Instant.EPOCH);
 
     // Create the patch payload which only contains the fields to change
-    // Urls has non-null validation and should trigger an exception
+    // Urls has non-empty validation and should trigger an exception
     JsonMergePatch mergePatch = Json.createMergePatch(Json.createObjectBuilder()
         .add("interval", JsonValue.NULL)
         .add("details", Json.createObjectBuilder()

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.monitor_management.config.JsonConfig;
 import com.rackspace.salus.monitor_management.config.MonitorConversionProperties;
-import com.rackspace.salus.monitor_management.services.MonitorConversionServiceTest.TestConfig;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
 import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
@@ -70,7 +70,6 @@ import javax.json.Json;
 import javax.json.JsonMergePatch;
 import javax.json.JsonValue;
 import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.json.JSONException;
 import org.junit.Assert;
@@ -79,31 +78,24 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.json.AutoConfigureJson;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = {MonitorConversionService.class, MetadataUtils.class, PatchHelper.class,
-    TestConfig.class})
+@SpringBootTest(classes = {MonitorConversionService.class, MetadataUtils.class,
+    PatchHelper.class, JsonConfig.class})
 @AutoConfigureJson
+@ImportAutoConfiguration(ValidationAutoConfiguration.class)
 public class MonitorConversionServiceTest {
 
   private static final Duration MIN_INTERVAL = Duration.ofSeconds(10);
   private static final Duration DEFAULT_LOCAL_INTERVAL = Duration.ofSeconds(30);
   private static final Duration DEFAULT_REMOTE_INTERVAL = Duration.ofMinutes(5);
-
-  @TestConfiguration
-  static class TestConfig {
-    @Bean
-    public Validator localValidatorFactoryBean() {
-      return new LocalValidatorFactoryBean();
-    }
-  }
 
   @Autowired
   MonitorConversionService conversionService;

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
@@ -41,6 +41,7 @@ import com.rackspace.salus.monitor_management.config.MonitorContentProperties;
 import com.rackspace.salus.monitor_management.config.ServicesProperties;
 import com.rackspace.salus.monitor_management.config.ZonesProperties;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
@@ -141,6 +142,9 @@ public class MonitorManagementPolicyTest {
 
   @MockBean
   PolicyApi policyApi;
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @MockBean
   ZoneManagement zoneManagement;

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
@@ -511,6 +511,28 @@ public class MonitorManagementPolicyTest {
   }
 
   @Test
+  public void testUpdatePolicyMonitor_setResourceId() {
+    final Monitor monitor =
+        monitorRepository.save(new Monitor()
+            .setAgentType(AgentType.TELEGRAF)
+            .setContent("original content")
+            .setTenantId(POLICY_TENANT)
+            .setSelectorScope(ConfigSelectorScope.REMOTE)
+            .setZones(Collections.singletonList("z-1"))
+            .setLabelSelector(Collections.singletonMap("os", "linux"))
+            .setLabelSelectorMethod(LabelSelectorMethod.AND));
+
+    MonitorCU update = new MonitorCU()
+        .setContent("new content")
+        .setZones(Collections.singletonList("z-2"))
+        .setResourceId(RandomStringUtils.randomAlphabetic(10));
+
+    exceptionRule.expect(IllegalArgumentException.class);
+    exceptionRule.expectMessage("Policy Monitors must use label selectors and not a resourceId");
+    monitorManagement.updatePolicyMonitor(monitor.getId(), update);
+  }
+
+  @Test
   public void testPatchPolicyMonitor_withMetadata() {
     // make sure the zone we're setting is allowed to be used by this tenant
     List<Zone> zones = Collections.singletonList(new Zone().setName("public/z-1"));

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -50,6 +50,7 @@ import com.rackspace.salus.monitor_management.config.MonitorContentProperties;
 import com.rackspace.salus.monitor_management.config.ServicesProperties;
 import com.rackspace.salus.monitor_management.config.ZonesProperties;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.monitor_management.web.model.ZoneAssignmentCount;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
@@ -185,6 +186,9 @@ public class MonitorManagementTest {
 
   @MockBean
   ZoneManagement zoneManagement;
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @Autowired
   ObjectMapper objectMapper;

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.monitor_management.services;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -47,6 +48,7 @@ import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.entities.BoundMonitor;
 import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
@@ -92,6 +94,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -297,6 +300,7 @@ public class MonitorManagement_MetadataPolicyTest {
     Optional<Monitor> retrieved = monitorManagement.getMonitor(tenantId, updatedMonitor.getId());
     assertTrue(retrieved.isPresent());
     assertThat(retrieved.get().getInterval(), equalTo(Duration.ofSeconds(42)));
+    assertThat(retrieved.get().getZones(), containsInAnyOrder("public/defaultZone1", "public/defaultZone2"));
 
     verify(boundMonitorRepository).findAllByMonitor_Id(monitor.getId());
     verify(boundMonitorRepository, times(1)).saveAll(any());
@@ -309,6 +313,152 @@ public class MonitorManagement_MetadataPolicyTest {
     );
 
     verifyNoMoreInteractions(monitorEventProducer);
+  }
+
+  @Test
+  public void testPatchExistingMonitor_someValueSetSomeValueNull() {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+
+    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
+        .thenReturn(Map.of("zones",
+            (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+                .setKey("zones")
+                .setValue("public/defaultZone1,public/defaultZone2")
+                .setValueType(MetadataValueType.STRING_LIST),
+            "interval",
+            (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+                .setKey("interval")
+                .setValue("42")
+                .setValueType(MetadataValueType.DURATION)));
+
+    final Monitor monitor = saveAssortmentOfPingMonitors(tenantId).get(0);
+
+    final BoundMonitor bound1 = new BoundMonitor()
+        .setMonitor(monitor)
+        .setTenantId(tenantId)
+        .setResourceId("r-1")
+        .setEnvoyId("e-new")
+        .setZoneName("z-1")
+        .setRenderedContent("address=something_else");
+
+    when(boundMonitorRepository.findAllByMonitor_Id(monitor.getId()))
+        .thenReturn(List.of(bound1));
+
+    // EXECUTE
+
+    // update will contain null zones but a new interval
+    final MonitorCU update = getBaseMonitorCUFromMonitor(monitor);
+
+    final Duration newInterval = monitor.getInterval().plusSeconds(120L);
+    update.setInterval(newInterval);
+    update.setZones(null);
+
+    final Monitor updatedMonitor = monitorManagement.updateMonitor(
+        tenantId, monitor.getId(), update, true);
+
+    // VERIFY
+
+    // new interval is set using provided value, not metadata
+    assertThat(updatedMonitor.getInterval(), equalTo(newInterval));
+    assertThat(updatedMonitor.getMonitorName(), nullValue());
+    assertThat(updatedMonitor.getLabelSelectorMethod(), equalTo(LabelSelectorMethod.AND));
+    assertThat(updatedMonitor.getZones(), hasSize(2));
+    // zones are set with metadata policy info
+    assertThat(updatedMonitor.getZones(), containsInAnyOrder("public/defaultZone1", "public/defaultZone2"));
+
+    // and verify the stored entity
+    Optional<Monitor> retrieved = monitorManagement.getMonitor(tenantId, updatedMonitor.getId());
+    assertTrue(retrieved.isPresent());
+    assertThat(retrieved.get().getInterval(), equalTo(newInterval));
+    assertThat(retrieved.get().getZones(), containsInAnyOrder("public/defaultZone1", "public/defaultZone2"));
+
+    verify(boundMonitorRepository).findAllByMonitor_Id(monitor.getId());
+    verify(boundMonitorRepository, times(1)).saveAll(any());
+
+    // only one event is sent
+    // since the same envoy is used in the existing bound monitor
+    // and in the new binding, it alone will be told to update its config.
+    verify(monitorEventProducer).sendMonitorEvent(
+        new MonitorBoundEvent().setEnvoyId("e-new")
+    );
+
+    verifyNoMoreInteractions(monitorEventProducer);
+  }
+
+  @Test
+  public void testPatchExistingMonitor_allValuesSet() {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+
+    // ensure the provided zone is available to this tenant
+    when(zoneManagement.getAvailableZonesForTenant(any(), any()))
+        .thenReturn(new PageImpl<>(List.of(new Zone().setName("public/newZone1")), Pageable.unpaged(), 1));
+
+    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
+        .thenReturn(Map.of("zones",
+            (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+                .setKey("zones")
+                .setValue("public/defaultZone1,public/defaultZone2")
+                .setValueType(MetadataValueType.STRING_LIST),
+            "interval",
+            (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+                .setKey("interval")
+                .setValue("42")
+                .setValueType(MetadataValueType.DURATION)));
+
+    final Monitor monitor = saveAssortmentOfPingMonitors(tenantId).get(0);
+
+    final BoundMonitor bound1 = new BoundMonitor()
+        .setMonitor(monitor)
+        .setTenantId(tenantId)
+        .setResourceId("r-1")
+        .setEnvoyId("e-new")
+        .setZoneName("z-1")
+        .setRenderedContent("address=something_else");
+
+    when(boundMonitorRepository.findAllByMonitor_Id(monitor.getId()))
+        .thenReturn(List.of(bound1));
+
+    // EXECUTE
+
+    // update will contain new zones and a new interval
+    final MonitorCU update = getBaseMonitorCUFromMonitor(monitor);
+
+    final Duration newInterval = monitor.getInterval().plusSeconds(120L);
+    update.setInterval(newInterval);
+    update.setZones(List.of("public/newZone1"));
+
+    final Monitor updatedMonitor = monitorManagement.updateMonitor(
+        tenantId, monitor.getId(), update, true);
+
+    // VERIFY
+
+    // new interval is set using provided value, not metadata
+    assertThat(updatedMonitor.getInterval(), equalTo(newInterval));
+    assertThat(updatedMonitor.getMonitorName(), nullValue());
+    assertThat(updatedMonitor.getLabelSelectorMethod(), equalTo(LabelSelectorMethod.AND));
+    assertThat(updatedMonitor.getZones(), hasSize(1));
+    // new zones are set with provided value, not metadata
+    assertThat(updatedMonitor.getZones(), contains("public/newZone1"));
+
+    // and verify the stored entity
+    Optional<Monitor> retrieved = monitorManagement.getMonitor(tenantId, updatedMonitor.getId());
+    assertTrue(retrieved.isPresent());
+    assertThat(retrieved.get().getInterval(), equalTo(newInterval));
+    assertThat(retrieved.get().getZones(), contains("public/newZone1"));
+
+    verify(boundMonitorRepository).findAllByMonitor_Id(monitor.getId());
+    verify(boundMonitorRepository, times(1)).saveAll(any());
+
+    // only one event is sent
+    // since the same envoy is used in the existing bound monitor
+    // and in the new binding, it alone will be told to update its config.
+    verify(monitorEventProducer).sendMonitorEvent(
+        new MonitorBoundEvent().setEnvoyId("e-new")
+    );
+
+    verify(zoneManagement).getAvailableZonesForTenant(eq(tenantId), any());
+
+    verifyNoMoreInteractions(monitorEventProducer, zoneManagement);
   }
 
   @Test
@@ -458,6 +608,21 @@ public class MonitorManagement_MetadataPolicyTest {
         .setResourceId(null)
         .setZones(null)
         .setInterval(null);
+  }
+
+  private MonitorCU getBaseMonitorCUFromMonitor(Monitor monitor) {
+    return new MonitorCU()
+        .setResourceId(monitor.getResourceId())
+        .setMonitorName(monitor.getMonitorName())
+        .setMonitorType(monitor.getMonitorType())
+        .setLabelSelector(monitor.getLabelSelector())
+        .setLabelSelectorMethod(monitor.getLabelSelectorMethod())
+        .setContent(monitor.getContent())
+        .setInterval(monitor.getInterval())
+        .setAgentType(monitor.getAgentType())
+        .setSelectorScope(monitor.getSelectorScope())
+        .setZones(monitor.getZones())
+        .setPluginMetadataFields(monitor.getPluginMetadataFields());
   }
 
   private List<Monitor> saveAssortmentOfPingMonitors(String tenantId) {

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
@@ -279,12 +279,8 @@ public class MonitorManagement_MetadataPolicyTest {
 
     // EXECUTE
 
-    // need to update this object to have all fields populated?
-    final MonitorCU update = new MonitorCU()
-        .setMonitorName(null)
-        .setInterval(null)
-        .setLabelSelectorMethod(null)
-        .setZones(null);
+    // update will contain all null values
+    final MonitorCU update = new MonitorCU();
     final Monitor updatedMonitor = monitorManagement.updateMonitor(
         tenantId, monitor.getId(), update, true);
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
@@ -39,6 +39,7 @@ import com.rackspace.salus.monitor_management.config.ServicesProperties;
 import com.rackspace.salus.monitor_management.config.ZonesProperties;
 import com.rackspace.salus.monitor_management.services.MonitorManagement_MetadataPolicyTest.TestConfig;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
@@ -162,6 +163,9 @@ public class MonitorManagement_MetadataPolicyTest {
 
   @MockBean
   ZoneManagement zoneManagement;
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @Autowired
   ObjectMapper objectMapper;

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.any;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.monitor_management.config.DatabaseConfig;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.monitor_management.errors.DeletionNotAllowedException;
@@ -49,6 +50,9 @@ public class ZoneManagementTest {
 
     @MockBean
     MonitorManagement monitorManagement;
+
+    @MockBean
+    PatchHelper patchHelper;
 
     @MockBean
     ZoneStorage zoneStorage;

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -220,24 +220,24 @@ public class MetadataUtilsTest {
     Monitor monitor = new Monitor();
     assertThat(monitor.getMonitorMetadataFields()).isNull();
 
-    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor);
+    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
     assertThat(monitor.getMonitorMetadataFields()).hasSize(2);
     assertThat(monitor.getMonitorMetadataFields()).containsExactlyInAnyOrder("interval", "zones");
 
     // set a value different from the policy to remove it from metadata fields
     monitor.setInterval(Duration.ofSeconds(10));
-    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor);
+    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
     assertThat(monitor.getMonitorMetadataFields()).hasSize(1);
     assertThat(monitor.getMonitorMetadataFields()).containsExactly("zones");
 
     // set a value the same as the policy and it should remain in metadata fields.
     monitor.setZones(List.of("zone1", "zone2"));
-    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor);
+    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
     assertThat(monitor.getMonitorMetadataFields()).hasSize(1);
 
     // set a value different from the policy to remove it from metadata fields
     monitor.setZones(List.of("zone"));
-    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor);
+    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
     assertThat(monitor.getMonitorMetadataFields()).hasSize(0);
 
     verify(policyApi, times(4)).getEffectiveMonitorMetadataMap(tenantId, TargetClassName.Monitor, null);

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -221,29 +221,8 @@ public class MetadataUtilsTest {
     assertThat(monitor.getMonitorMetadataFields()).isNull();
 
     metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
-    assertThat(monitor.getMonitorMetadataFields()).hasSize(2);
-    assertThat(monitor.getMonitorMetadataFields()).containsExactlyInAnyOrder("interval", "zones");
-
-    // set a value different from the policy to remove it from metadata fields
-    monitor.setInterval(Duration.ofSeconds(10));
-    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
-    assertThat(monitor.getMonitorMetadataFields()).hasSize(1);
-    assertThat(monitor.getMonitorMetadataFields()).containsExactly("zones");
-
-    // set a value the same as the policy and it should remain in metadata fields.
-    monitor.setZones(List.of("zone1", "zone2"));
-    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
-    assertThat(monitor.getMonitorMetadataFields()).hasSize(1);
-
-    // set a value different from the policy to remove it from metadata fields
-    monitor.setZones(List.of("zone"));
-    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
-    assertThat(monitor.getMonitorMetadataFields()).hasSize(0);
-
-    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
     assertThat(monitor.getMonitorMetadataFields()).hasSize(3);
-    assertThat(monitor.getMonitorMetadataFields())
-        .containsExactlyInAnyOrder("interval", "monitorName", "zones");
+    assertThat(monitor.getMonitorMetadataFields()).containsExactlyInAnyOrder("monitorName", "interval", "zones");
 
     // set a value different from the policy to remove it from metadata fields
     monitor.setInterval(Duration.ofSeconds(10));

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -455,6 +455,9 @@ public class MonitorApiControllerTest {
     monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
     monitor.setAgentType(AgentType.TELEGRAF);
     monitor.setContent("{\"type\":\"mem\"}");
+    // ensure only one of these is set
+    monitor.setResourceId(RandomStringUtils.randomAlphabetic(10));
+    monitor.setLabelSelector(null);
 
     when(monitorManagement.getMonitor(anyString(), any()))
         .thenReturn(Optional.of(monitor));

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -42,6 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.monitor_management.config.JsonConfig;
 import com.rackspace.salus.monitor_management.services.MonitorContentTranslationService;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.services.MonitorManagement;
@@ -102,7 +103,7 @@ import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(controllers = MonitorApiController.class)
-@Import({MonitorConversionService.class, MetadataUtils.class, PatchHelper.class})
+@Import({MonitorConversionService.class, MetadataUtils.class, PatchHelper.class, JsonConfig.class})
 public class MonitorApiControllerTest {
 
   private PodamFactory podamFactory = new PodamFactoryImpl();

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -471,6 +471,25 @@ public class MonitorApiControllerTest {
   }
 
   @Test
+  public void testPatchNonExistentMonitor() throws Exception {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+    UUID id = UUID.randomUUID();
+    String url = String.format("/api/tenant/%s/monitors/%s", tenantId, id);
+
+    DetailedMonitorInput update = podamFactory.manufacturePojo(DetailedMonitorInput.class);
+    update.setDetails(new LocalMonitorDetails().setPlugin(new Mem()))
+        .setResourceId("");
+
+    mockMvc.perform(patch(url)
+        .content(objectMapper.writeValueAsString(update))
+        .contentType(MediaType.valueOf(JSON_MERGE_PATCH_TYPE))
+        .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andExpect(status().isNotFound())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+  }
+
+  @Test
   public void testGetAll() throws Exception {
     int numberOfMonitors = 20;
     // Use the APIs default Pageable settings

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/CpuConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/CpuConversionTest.java
@@ -22,6 +22,7 @@ import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
@@ -53,6 +54,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class CpuConversionTest {
   @Configuration
   public static class TestConfig { }
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @MockBean
   PolicyApi policyApi;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskConversionTest.java
@@ -22,6 +22,7 @@ import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
@@ -52,6 +53,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class DiskConversionTest {
   @Configuration
   public static class TestConfig { }
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @MockBean
   PolicyApi policyApi;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlConversionTest.java
@@ -22,6 +22,7 @@ import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
@@ -54,6 +55,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class MysqlConversionTest {
   @Configuration
   public static class TestConfig { }
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @MockBean
   PolicyApi policyApi;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlRemoteConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlRemoteConversionTest.java
@@ -22,6 +22,7 @@ import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
@@ -54,6 +55,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class MysqlRemoteConversionTest {
   @Configuration
   public static class TestConfig { }
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @MockBean
   PolicyApi policyApi;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetConversionTest.java
@@ -20,6 +20,7 @@ import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
@@ -58,6 +59,9 @@ public class NetConversionTest {
 
   // A timestamp to be used in tests that translates to "1970-01-02T03:46:40Z"
   private static final Instant DEFAULT_TIMESTAMP = Instant.ofEpochSecond(100000);
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @MockBean
   PolicyApi policyApi;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponseConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponseConversionTest.java
@@ -20,6 +20,7 @@ import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
@@ -58,6 +59,9 @@ public class NetResponseConversionTest {
 
   // A timestamp to be used in tests that translates to "1970-01-02T03:46:40Z"
   private static final Instant DEFAULT_TIMESTAMP = Instant.ofEpochSecond(100000);
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @MockBean
   PolicyApi policyApi;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlConversionTest.java
@@ -22,6 +22,7 @@ import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
@@ -54,6 +55,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class PostgresqlConversionTest {
   @Configuration
   public static class TestConfig { }
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @MockBean
   PolicyApi policyApi;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlRemoteConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlRemoteConversionTest.java
@@ -22,6 +22,7 @@ import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
@@ -54,6 +55,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class PostgresqlRemoteConversionTest {
   @Configuration
   public static class TestConfig { }
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @MockBean
   PolicyApi policyApi;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerConversionTest.java
@@ -22,6 +22,7 @@ import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
@@ -54,6 +55,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class SqlServerConversionTest {
   @Configuration
   public static class TestConfig { }
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @MockBean
   PolicyApi policyApi;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerRemoteConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerRemoteConversionTest.java
@@ -22,6 +22,7 @@ import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
@@ -54,6 +55,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class SqlServerRemoteConversionTest {
   @Configuration
   public static class TestConfig { }
+
+  @MockBean
+  PatchHelper patchHelper;
 
   @MockBean
   PolicyApi policyApi;

--- a/src/test/resources/MonitorConversionServiceTest_patch_with_policy.json
+++ b/src/test/resources/MonitorConversionServiceTest_patch_with_policy.json
@@ -1,0 +1,7 @@
+{
+  "type": "ping",
+  "urls": ["localhost"],
+  "count": 63,
+  "pingInterval": 2,
+  "timeout": 33
+}


### PR DESCRIPTION
# What

Adds a PATCH method to Monitor Management API to be able to perform individual updates to a Monitor, including resetting a value to `null`.

# How
Followed this as a guide - https://cassiomolin.com/2019/06/10/using-http-patch-in-spring/

Utilizes the JsonMergePatch from the JSON-P API.

1. Receive a `JsonMergePatch` in the body of the request in the controller
    * A custom `AbstractHttpMessageConverter` was introduced to be able to generate this
1. Get the stored Monitor with the id in the request path
1. Convert that Monitor to a `DetailedMonitorInput`
1. Merge the `JsonMergePatch` onto the `DetailedMonitorInput` to replace any values provided
1. Continue in a similar way to a PUT request, except if a `null` is seen use it instead of ignoring it.
    * This is handled by the `boolean patchOperation` flag

## How to test

Run tests.

In `MonitorManagementTest.java` we have a lot of specific tests for updating monitors, such as `testUpdateExistingMonitor_labelsChanged()`.  Should I recreate all of those but for PATCH?  Since intelligence will be using PATCH it seems like I should even with how tedious and repetitive it is?

# Why

We need to be able to reset set values to their default.  This is done by passing a `null` value in the request.  But we also need to distinguish between what was a provided null vs. what is unset.  If we were to map the request immediately to a `DetailedMonitorInput` both the fields purposely set to null and those that were not set at all would come through as null, which is not helpful.

I looked into a couple other solutions.

1. Setting all parameters in the request to `Optional`.  We would then have to evaluate each one to see whether it was `null` or whether it was an optional that contained `null`.
    * This would have required large changes across our code to change how those are treated
1. Add a boolean or bit fields alongside each field in the input and set it to true in the setter for that field.  If the field has a value provided it will get set to true, if it doesn't it will be left as false.
    * This would have been OK for the top level Monitor fields but it gets messy for all the input plugins
    * We would have to analyze every field on the plugin to see if it was set.
    * We'd probably need an individual handler for each plugin to do this
    * It would be a large amount of code changes required

# TODO

* The question in the **how to test** section?
* I'll update Insomnia and play around with it a bit to make sure no other issues show up