### PR TITLE
Invert MetadataField Logic

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -20,7 +20,7 @@ import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
 import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.telemetry.model.MetadataField;
+import com.rackspace.salus.telemetry.model.NonMetadataField;
 import com.rackspace.salus.telemetry.model.TargetClassName;
 import java.lang.reflect.Field;
 import java.time.Duration;
@@ -42,7 +42,7 @@ public class MetadataUtils {
   }
 
   /**
-   * Gets all fields that have MetadataField annotation and are set to null.
+   * Gets all fields that don't have a NonMetadataField annotation and are set to null.
    *
    * @param object The object to inspect for metadata fields.
    * @return The list of metadata fields found.
@@ -52,7 +52,7 @@ public class MetadataUtils {
     for (Field f : object.getClass().getDeclaredFields()) {
       try {
         f.setAccessible(true); // since these fields are private, we must set this first
-        if (f.getAnnotationsByType(MetadataField.class).length > 0 && f.get(object) == null) {
+        if (f.getAnnotationsByType(NonMetadataField.class).length == 0 && f.get(object) == null) {
           metadataFields.add(f.getName());
         }
       } catch(IllegalAccessException|IllegalArgumentException e) {
@@ -63,9 +63,9 @@ public class MetadataUtils {
   }
 
   /**
-   * Gets all fields that have MetadataField annotation and are set to null
-   * and all fields that have the MetadataField annotation, were previously using the metadata value
-   * and still have the same value as the corresponding policy.
+   * Gets all fields that don't have a NonMetadataField annotation and are set to null
+   * and all fields that don't have the NonMetadataField annotation which were previously using the
+   * metadata value and still have the same value as the corresponding policy.
    *
    * @param object The object to inspect for metadata fields.
    * @param previousMetadataFields A list of fields that were previously using metadata policy values.
@@ -77,7 +77,7 @@ public class MetadataUtils {
     for (Field f : object.getClass().getDeclaredFields()) {
       try {
         f.setAccessible(true); // since these fields are private, we must set this first
-        if (f.getAnnotationsByType(MetadataField.class).length > 0) {
+        if (f.getAnnotationsByType(NonMetadataField.class).length == 0) {
           if (f.get(object) == null) {
             metadataFields.add(f.getName());
           } else if (previousMetadataFields.contains(f.getName()) && policies.containsKey(f.getName())) {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
@@ -22,7 +22,6 @@ import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
-import com.rackspace.salus.telemetry.model.MetadataField;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
 import javax.validation.constraints.NotEmpty;
@@ -36,15 +35,10 @@ import lombok.EqualsAndHashCode;
 public class Ping extends RemotePlugin {
   @NotEmpty
   List<String> urls;
-  @MetadataField
   Integer count;
-  @MetadataField
   Integer pingInterval;
-  @MetadataField
   Integer timeout;
-  @MetadataField
   Integer deadline;
-  @MetadataField
   String interfaceOrAddress;
 
   // DO NOT include 'binary' or 'arguments' from telegraf raw config since those would expose an

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -937,7 +937,7 @@ public class MonitorManagementTest {
                 .setAgentType(AgentType.TELEGRAF)
                 .setMonitorType(MonitorType.ping)
                 .setContent("address=${resource.metadata.address}")
-                .setMonitorMetadataFields(List.of("zones"))
+                .setMonitorMetadataFields(List.of("monitorName", "zones"))
                 .setTenantId("t-1")
                 .setSelectorScope(ConfigSelectorScope.REMOTE)
                 .setLabelSelector(Collections.singletonMap("os", "linux"))
@@ -1101,7 +1101,7 @@ public class MonitorManagementTest {
                 .setAgentType(AgentType.TELEGRAF)
                 .setMonitorType(MonitorType.cpu)
                 .setContent("static content")
-                .setMonitorMetadataFields(List.of("zones"))
+                .setMonitorMetadataFields(List.of("monitorName", "zones"))
                 .setTenantId("t-1")
                 .setSelectorScope(ConfigSelectorScope.LOCAL)
                 .setResourceId("r-2")
@@ -1229,7 +1229,7 @@ public class MonitorManagementTest {
                 .setZones(Arrays.asList("z-2", "z-3"))
                 .setLabelSelector(Collections.singletonMap("os", "linux"))
                 .setLabelSelectorMethod(LabelSelectorMethod.AND)
-                .setMonitorMetadataFields(Collections.emptyList())
+                .setMonitorMetadataFields(List.of("monitorName"))
                 .setInterval(Duration.ofSeconds(60)));
 
     verify(resourceApi).getResourcesWithLabels("t-1", Collections.singletonMap("os", "linux"), LabelSelectorMethod.AND);
@@ -1312,7 +1312,7 @@ public class MonitorManagementTest {
                 .setAgentType(AgentType.TELEGRAF)
                 .setMonitorType(MonitorType.ping)
                 .setContent("{}")
-                .setMonitorMetadataFields(Collections.emptyList())
+                .setMonitorMetadataFields(List.of("monitorName"))
                 .setTenantId("t-1")
                 .setSelectorScope(ConfigSelectorScope.REMOTE)
                 .setZones(Arrays.asList("z-1", "z-2"))

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -221,24 +221,25 @@ public class MetadataUtilsTest {
     assertThat(monitor.getMonitorMetadataFields()).isNull();
 
     metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor);
-    assertThat(monitor.getMonitorMetadataFields()).hasSize(2);
-    assertThat(monitor.getMonitorMetadataFields()).containsExactlyInAnyOrder("interval", "zones");
+    assertThat(monitor.getMonitorMetadataFields()).hasSize(3);
+    assertThat(monitor.getMonitorMetadataFields())
+        .containsExactlyInAnyOrder("interval", "monitorName", "zones");
 
     // set a value different from the policy to remove it from metadata fields
     monitor.setInterval(Duration.ofSeconds(10));
     metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor);
-    assertThat(monitor.getMonitorMetadataFields()).hasSize(1);
-    assertThat(monitor.getMonitorMetadataFields()).containsExactly("zones");
+    assertThat(monitor.getMonitorMetadataFields()).hasSize(2);
+    assertThat(monitor.getMonitorMetadataFields()).containsExactly("monitorName", "zones");
 
     // set a value the same as the policy and it should remain in metadata fields.
     monitor.setZones(List.of("zone1", "zone2"));
     metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor);
-    assertThat(monitor.getMonitorMetadataFields()).hasSize(1);
+    assertThat(monitor.getMonitorMetadataFields()).hasSize(2);
 
     // set a value different from the policy to remove it from metadata fields
     monitor.setZones(List.of("zone"));
     metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor);
-    assertThat(monitor.getMonitorMetadataFields()).hasSize(0);
+    assertThat(monitor.getMonitorMetadataFields()).hasSize(1);
 
     verify(policyApi, times(4)).getEffectiveMonitorMetadataMap(tenantId, TargetClassName.Monitor, null);
   }


### PR DESCRIPTION
Relates to https://github.com/racker/salus-telemetry-model/pull/77

> Rather than setting @MetadataField on almost all of our fields, we are going to do the reverse and only set @NonMetadataField on fields that we know will never be replaced by metadata.
>
> This doesn't really relate to the monitors defined in monitor management, but does affect the high level Monitor class.


Previously I had only set it on the Ping monitor since I knew this change was coming, so there isn't much that needs to change in this PR.