### PR TITLE
Fix resourceId/labelSelector changes in PUT/PATCH

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -48,6 +48,7 @@ import javax.json.JsonMergePatch;
 import javax.validation.ConstraintDeclarationException;
 import javax.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
@@ -84,12 +85,20 @@ public class MonitorConversionService {
     final DetailedMonitorOutput detailedMonitorOutput = new DetailedMonitorOutput()
         .setId(monitor.getId().toString())
         .setName(monitor.getMonitorName())
-        .setLabelSelector(monitor.getLabelSelector())
         .setLabelSelectorMethod(monitor.getLabelSelectorMethod())
         .setResourceId(monitor.getResourceId())
         .setInterval(monitor.getInterval())
         .setCreatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(monitor.getCreatedTimestamp()))
         .setUpdatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(monitor.getUpdatedTimestamp()));
+
+    // ElementCollections return an empty collection if it was previously set to null
+    // We want this to display null to a customer instead of {}.
+    // This helps keep all API responses consistent.
+    if (StringUtils.isNotBlank(monitor.getResourceId())) {
+      detailedMonitorOutput.setLabelSelector(null);
+    } else {
+      detailedMonitorOutput.setLabelSelector(monitor.getLabelSelector());
+    }
 
     final ConfigSelectorScope selectorScope = monitor.getSelectorScope();
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -657,44 +657,7 @@ public class MonitorManagement {
     final Set<String> affectedEnvoys = new HashSet<>();
 
     affectedEnvoys.addAll(handleResourceIdChange(monitor, updatedValues.getResourceId(), patchOperation));
-
-    boolean labelSelectorChanged = labelSelectorChanged(monitor, updatedValues, patchOperation);
-    boolean methodChanged = labelSelectorMethodChanged(monitor, updatedValues);
-    if (labelSelectorChanged || methodChanged) {
-      // Process potential changes to resource selection and therefore bindings
-      // ...only need to process removed and new bindings
-
-      // Set the new label selector
-      if (methodChanged) {
-        monitor.setLabelSelectorMethod(updatedValues.getLabelSelectorMethod());
-      }
-
-      // Determine what the newest labels are
-      Map<String, String> labels;
-      if (labelSelectorChanged) {
-        labels = updatedValues.getLabelSelector();
-      } else {
-        labels = monitor.getLabelSelector();
-      }
-
-      affectedEnvoys.addAll(
-          processMonitorLabelSelectorModified(tenantId, monitor, labels)
-      );
-
-      // Finally, update the monitors labels
-      if (labels == null) {
-        monitor.setLabelSelector(null);
-      } else {
-        monitor.setLabelSelector(new HashMap<>(labels));
-      }
-    }
-    else if (monitor.getLabelSelector() != null) {
-      // JPA's EntityManager is a little strange with re-saving (aka merging) an entity
-      // that has a field of type Map. It wants to clear the loaded map value, which is
-      // disallowed by the org.hibernate.collection.internal.PersistentMap it uses for
-      // retrieved maps.
-      monitor.setLabelSelector(new HashMap<>(monitor.getLabelSelector()));
-    }
+    affectedEnvoys.addAll(handleLabelSelectorChange(tenantId, monitor, updatedValues, patchOperation));
 
     if (updatedValues.getContent() != null &&
         !updatedValues.getContent().equals(monitor.getContent())) {
@@ -757,6 +720,47 @@ public class MonitorManagement {
     sendMonitorBoundEvents(affectedEnvoys);
 
     return monitor;
+  }
+
+  private Set<String> handleLabelSelectorChange(String tenantId, Monitor monitor, MonitorCU updatedValues, boolean patchOperation) {
+    Set<String> envoyIds = new HashSet<>();
+    boolean labelSelectorChanged = labelSelectorChanged(monitor, updatedValues, patchOperation);
+    boolean methodChanged = labelSelectorMethodChanged(monitor, updatedValues);
+
+    if (labelSelectorChanged || methodChanged) {
+      // Process potential changes to resource selection and therefore bindings
+      // ...only need to process removed and new bindings
+
+      // Set the new label selector
+      if (methodChanged) {
+        monitor.setLabelSelectorMethod(updatedValues.getLabelSelectorMethod());
+      }
+
+      // Determine what the newest labels are
+      Map<String, String> labels;
+      if (labelSelectorChanged) {
+        labels = updatedValues.getLabelSelector();
+      } else {
+        labels = monitor.getLabelSelector();
+      }
+
+      envoyIds = processMonitorLabelSelectorModified(tenantId, monitor, labels);
+
+      // Finally, update the monitors labels
+      if (labels == null) {
+        monitor.setLabelSelector(null);
+      } else {
+        monitor.setLabelSelector(new HashMap<>(labels));
+      }
+    }
+    else if (monitor.getLabelSelector() != null) {
+      // JPA's EntityManager is a little strange with re-saving (aka merging) an entity
+      // that has a field of type Map. It wants to clear the loaded map value, which is
+      // disallowed by the org.hibernate.collection.internal.PersistentMap it uses for
+      // retrieved maps.
+      monitor.setLabelSelector(new HashMap<>(monitor.getLabelSelector()));
+    }
+    return envoyIds;
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -336,9 +336,9 @@ public class MonitorManagement {
     if (!patchOperation) {
       // if the resource id is set the label selector must be empty & vice versa
       if ((StringUtils.isNotBlank(updatedValues.getResourceId()) &&
-          !CollectionUtils.isEmpty(monitor.getLabelSelector())) ||
+          monitor.getLabelSelector() != null) ||
           (StringUtils.isNotBlank(monitor.getResourceId()) &&
-              !CollectionUtils.isEmpty(updatedValues.getLabelSelector())))
+              updatedValues.getLabelSelector() != null))
       {
         throw new IllegalArgumentException(ValidUpdateMonitor.DEFAULT_MESSAGE);
       }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1080,7 +1080,9 @@ public class MonitorManagement {
       if (r.isPresent()) {
         selectedResources.add(new ResourceDTO(r.get()));
       } else {
-        log.error("Resource not found for monitor configured with resourceId, monitor={}", monitor);
+        // It is possible to create monitors for resources that do not yet exist so this
+        // is only a warning, but many of them may signal a problem.
+        log.warn("Resource not found for monitor configured with resourceId, monitor={}", monitor);
       }
     } else {
       selectedResources = resourceApi

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDTO.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 @Data
 @NoArgsConstructor
@@ -57,7 +58,16 @@ public class MonitorDTO {
   public MonitorDTO(Monitor monitor) {
     this.id = monitor.getId();
     this.monitorName = monitor.getMonitorName();
-    this.labelSelector = monitor.getLabelSelector();
+
+    // ElementCollections return an empty collection if it was previously set to null
+    // We want this to display null to a customer instead of {}.
+    // This helps keep all API responses consistent.
+    if (StringUtils.isNotBlank(monitor.getResourceId())) {
+      this.labelSelector = null;
+    } else {
+      this.labelSelector = monitor.getLabelSelector();
+    }
+
     this.labelSelectorMethod = monitor.getLabelSelectorMethod();
     this.resourceId = monitor.getResourceId();
     this.tenantId = monitor.getTenantId();

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidUpdateMonitor.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidUpdateMonitor.java
@@ -32,7 +32,7 @@ import javax.validation.Payload;
 @Documented
 @Constraint(validatedBy = ValidUpdateMonitorValidator.class)
 public @interface ValidUpdateMonitor {
-  String DEFAULT_MESSAGE = "The label selector field and resourceId field should not both be set.";
+  String DEFAULT_MESSAGE = "Exactly one of the label selector field or resourceId field must be set, but not both.";
   String message() default DEFAULT_MESSAGE;
   Class<?>[] groups() default {};
   @SuppressWarnings("unused")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidUpdateMonitorValidator.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidUpdateMonitorValidator.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.CollectionUtils;
 
 @Slf4j
 public class ValidUpdateMonitorValidator implements ConstraintValidator<ValidUpdateMonitor, DetailedMonitorInput> {
@@ -32,7 +32,7 @@ public class ValidUpdateMonitorValidator implements ConstraintValidator<ValidUpd
    static boolean bothResourceAndLabelsSet(DetailedMonitorInput monitorInput) {
       Map<String, String > labelSelector = monitorInput.getLabelSelector();
       String resourceId = monitorInput.getResourceId();
-      return (StringUtils.isNotBlank(resourceId) && labelSelector != null);
+      return StringUtils.isNotBlank(resourceId) && !CollectionUtils.isEmpty(labelSelector);
    }
 
    public boolean isValid(DetailedMonitorInput monitorInput, ConstraintValidatorContext context) {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidUpdateMonitorValidator.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidUpdateMonitorValidator.java
@@ -32,7 +32,7 @@ public class ValidUpdateMonitorValidator implements ConstraintValidator<ValidUpd
    static boolean bothResourceAndLabelsSet(DetailedMonitorInput monitorInput) {
       Map<String, String > labelSelector = monitorInput.getLabelSelector();
       String resourceId = monitorInput.getResourceId();
-      return StringUtils.isNotBlank(resourceId) && !CollectionUtils.isEmpty(labelSelector);
+      return StringUtils.isNotBlank(resourceId) && labelSelector != null;
    }
 
    public boolean isValid(DetailedMonitorInput monitorInput, ConstraintValidatorContext context) {

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -1293,7 +1293,7 @@ public class MonitorManagementTest {
   }
 
   @Test
-  public void testUpdateExistingMonitor_removeLabelsSetResourceId() {
+  public void testPatchExistingMonitor_removeLabelsSetResourceId() {
     // Starts with one monitor-with-label-selector bound to two resources
     // updates it to use a resourceId
     // confirms monitor is updated, old bindings are removed, new binding is added

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -686,9 +686,24 @@ public class MonitorApiControllerTest {
         .content(objectMapper.writeValueAsString(create))
         .contentType(MediaType.APPLICATION_JSON)
         .characterEncoding(StandardCharsets.UTF_8.name()))
-        .andExpect(status().isBadRequest())
-        .andExpect(classValidationError(ValidCreateMonitor.DEFAULT_MESSAGE));
+        .andExpect(status().isCreated());
   }
+
+  @Test
+  public void testCreateMonitor_BothResourceIdAndNullLabels() throws Exception {
+    DetailedMonitorInput create = setupCreateMonitorTest();
+    String tenantId = RandomStringUtils.randomAlphabetic(8);
+    String url = String.format("/api/tenant/%s/monitors", tenantId);
+    create.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
+    create.setLabelSelector(null);
+
+    mockMvc.perform(post(url)
+        .content(objectMapper.writeValueAsString(create))
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andExpect(status().isCreated());
+  }
+
   @Test
   public void testCreateMonitor_NeitherResourceIdNorLabels() throws Exception {
     DetailedMonitorInput create = setupCreateMonitorTest();

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -725,7 +725,8 @@ public class MonitorApiControllerTest {
         .content(objectMapper.writeValueAsString(create))
         .contentType(MediaType.APPLICATION_JSON)
         .characterEncoding(StandardCharsets.UTF_8.name()))
-        .andExpect(status().isCreated());
+        .andExpect(status().isBadRequest())
+        .andExpect(classValidationError(ValidCreateMonitor.DEFAULT_MESSAGE));
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -508,6 +508,45 @@ public class MonitorApiControllerTest {
   }
 
   @Test
+  public void testPatchPolicyMonitor() throws Exception {
+    Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
+    monitor.setId(UUID.randomUUID());
+    monitor.setTenantId(POLICY_TENANT);
+    monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
+    monitor.setAgentType(AgentType.TELEGRAF);
+    monitor.setContent("{\"type\":\"mem\"}");
+    // ensure only one of these is set
+    monitor.setResourceId(null);
+    monitor.setLabelSelector(Map.of("os", "linux"));
+    monitor.setInterval(Duration.ofSeconds(60));
+
+    when(monitorManagement.getPolicyMonitor(any()))
+        .thenReturn(Optional.of(monitor));
+    when(monitorManagement.updatePolicyMonitor(any(), any(), anyBoolean()))
+        .thenReturn(monitor);
+
+    UUID id = monitor.getId();
+    String url = String.format("/api/admin/policy-monitors/%s", id);
+
+    // send an update with a null name and a new interva
+    String update = "{\"name\":null,\"interval\":234}";
+
+    mockMvc.perform(patch(url)
+        .content(update)
+        .contentType(MediaType.valueOf(JSON_MERGE_PATCH_TYPE))
+        .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+
+    // Basic verification that the expected method was called with the patchOperation value provided.
+    // In this case mockito had issues when argThat was used to validate params, so I opted
+    // for even more generic validation.
+    verify(monitorManagement).updatePolicyMonitor(any(), any(), anyBoolean());
+  }
+
+  @Test
   public void testGetAll() throws Exception {
     int numberOfMonitors = 20;
     // Use the APIs default Pageable settings
@@ -643,7 +682,7 @@ public class MonitorApiControllerTest {
   }
 
   @Test
-  public void testCreateMonitor_ResourceId() throws Exception {
+  public void testCreateMonitor_ResourceIdAndNullLabels() throws Exception {
     DetailedMonitorInput create = setupCreateMonitorTest();
     String tenantId = RandomStringUtils.randomAlphabetic(8);
     String url = String.format("/api/tenant/%s/monitors", tenantId);
@@ -681,21 +720,6 @@ public class MonitorApiControllerTest {
     String url = String.format("/api/tenant/%s/monitors", tenantId);
     create.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
     create.setLabelSelector(Collections.emptyMap());
-
-    mockMvc.perform(post(url)
-        .content(objectMapper.writeValueAsString(create))
-        .contentType(MediaType.APPLICATION_JSON)
-        .characterEncoding(StandardCharsets.UTF_8.name()))
-        .andExpect(status().isCreated());
-  }
-
-  @Test
-  public void testCreateMonitor_BothResourceIdAndNullLabels() throws Exception {
-    DetailedMonitorInput create = setupCreateMonitorTest();
-    String tenantId = RandomStringUtils.randomAlphabetic(8);
-    String url = String.format("/api/tenant/%s/monitors", tenantId);
-    create.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
-    create.setLabelSelector(null);
 
     mockMvc.perform(post(url)
         .content(objectMapper.writeValueAsString(create))


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-644

# What

Corrects the behavior related to updating a monitors resourceId or labelSelector.  Only one of these should ever be non-empty at a time.

# How

More validation steps.

Also, I've updated MonitorDTO/DetailedMonitorOutput so that if a `resourceId` is set on the monitor it will set the `labelSelector` to null.  Without that change if you do an update providing:

```
{
	"resourceId": "test",
	"labelSelector": null
}
```
That response would come back with `"labelSelector": null` but then if you did a GET it would show `"labelSelector": {}` since in a CollectionTable/ElementCollection a null response is the same as an empty response.

# Why

> **PUT**
>
> Currently if you have a monitor with a labelSelector set and then perform a PUT to set it to null and instead set a resourceId, the end result will be a monitor with both resourceId and labelSelector set.
>
>
> **PATCH**
>
> For the PATCH, it will not allow you to set a resourceId if the labelSelector is non-null, but if you also provide a null labelSelector in the payload it will pass validation but then be ignored by the logic in updateMonitor.


# TODO

We still need to move to consolidating DetailedMonitorOutput and MonitorDTO.

During these changes I made this a valid request
```
{
	"resourceId": "test",
	"labelSelector": {}
}
```
That was before I updated the output DTO to convert the labelSelector to `null`.  We could change it back so this is an invalid request.  However, one advantage of this is that a PUT can be used with this payload to set the resource id and unset the labelSelector.  If `null` had to be set you would have to use PATCH.

I don't really have a strong opinion so I'm going to leave it as is and wait for feedback.