### PR TITLE
Convert merge-patch to patch

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/config/JsonConfig.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/JsonConfig.java
@@ -16,8 +16,12 @@
 
 package com.rackspace.salus.monitor_management.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.datatype.jsr353.JSR353Module;
+import java.lang.annotation.Annotation;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -29,4 +33,25 @@ public class JsonConfig {
     // Register ability to handle Json Merge Patch conversions.
     return new JSR353Module();
   }
+
+  /**
+   * This can be used when (de)serialization of an object is required but the ignored properties
+   * should be included.
+   *
+   * e.g. If some fields of an object are configured with @JsonInclude(Include.NON_NULL)
+   * this can be used on the object mapper to ensure they are not ignored during conversion.
+   *
+   *    objectMapper.setAnnotationIntrospector(IGNORE_JSON_INCLUDE_ANNOTATIONS);
+   *    objectMapper.convertValue(targetBean, JsonStructure.class);
+   *
+   */
+  public static final JacksonAnnotationIntrospector IGNORE_JSON_INCLUDE_ANNOTATIONS = new JacksonAnnotationIntrospector() {
+    @Override
+    protected <A extends Annotation> A _findAnnotation(final Annotated annotated, final Class<A> annoClass) {
+      if (!annotated.hasAnnotation(JsonInclude.class)) {
+        return super._findAnnotation(annotated, annoClass);
+      }
+      return null;
+    }
+  };
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -34,7 +34,6 @@ import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import com.rackspace.salus.monitor_management.web.model.ValidationGroups;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
 import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.telemetry.errors.MissingRequirementException;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
@@ -152,9 +151,10 @@ public class MonitorConversionService {
     } catch (ConstraintViolationException e) {
       throw new IllegalArgumentException(e.getMessage());
     } catch (JsonException e) {
-      // This occurs when the PATCH "test" operation fails.
-      throw new MissingRequirementException(e.getMessage());
-      // change this to do this for test failures but an Illegal Argument for anything else?
+      // This can occur when the PATCH "test" operation fails or if an invalid value is provided.
+      // A 422 is more accurate for the "test" failure, but there is not a way to distinguish
+      // between them other than the message contents, so we'll stick with a 400.
+      throw new IllegalArgumentException(e.getMessage());
     }
 
     return convertFromInput(tenantId, monitorId, patchedInput, true);

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -16,7 +16,7 @@
 
 package com.rackspace.salus.monitor_management.web.controller;
 
-import static com.rackspace.salus.monitor_management.web.converter.PatchHelper.JSON_MERGE_PATCH_TYPE;
+import static com.rackspace.salus.monitor_management.web.converter.PatchHelper.JSON_PATCH_TYPE;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.monitor_management.services.MonitorContentTranslationService;
@@ -41,7 +41,7 @@ import io.swagger.annotations.AuthorizationScope;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import javax.json.JsonMergePatch;
+import javax.json.JsonPatch;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -177,11 +177,11 @@ public class MonitorApiController {
   }
 
   @PatchMapping(path = "/admin/policy-monitors/{uuid}",
-                consumes = {MediaType.APPLICATION_JSON_VALUE, JSON_MERGE_PATCH_TYPE})
+                consumes = {MediaType.APPLICATION_JSON_VALUE, JSON_PATCH_TYPE})
   @ApiOperation(value = "Patch specific Policy Monitor")
   @JsonView(View.Admin.class)
   public DetailedMonitorOutput patchPolicyMonitor(@PathVariable UUID uuid,
-                                                  @RequestBody final JsonMergePatch input)
+                                                  @RequestBody final JsonPatch input)
       throws IllegalArgumentException {
 
     Monitor monitor = monitorManagement.getPolicyMonitor(uuid).orElseThrow(() ->
@@ -273,12 +273,12 @@ public class MonitorApiController {
   }
 
   @PatchMapping(path = "/tenant/{tenantId}/monitors/{uuid}",
-                consumes = {MediaType.APPLICATION_JSON_VALUE, JSON_MERGE_PATCH_TYPE})
+                consumes = {MediaType.APPLICATION_JSON_VALUE, JSON_PATCH_TYPE})
   @ApiOperation(value = "Updates specific Monitor for Tenant")
   @JsonView(View.Public.class)
   public DetailedMonitorOutput patch(@PathVariable String tenantId,
       @PathVariable UUID uuid,
-      @RequestBody final JsonMergePatch input)
+      @RequestBody final JsonPatch input)
       throws IllegalArgumentException {
 
     Monitor monitor = monitorManagement.getMonitor(tenantId, uuid).orElseThrow(

--- a/src/main/java/com/rackspace/salus/monitor_management/web/converter/JsonPatchHttpMessageConverter.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/converter/JsonPatchHttpMessageConverter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.converter;
+
+import static com.rackspace.salus.monitor_management.web.converter.PatchHelper.JSON_PATCH_TYPE;
+
+import javax.json.Json;
+import javax.json.JsonPatch;
+import javax.json.JsonReader;
+import javax.json.JsonWriter;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsonPatchHttpMessageConverter extends AbstractHttpMessageConverter<JsonPatch> {
+
+  public JsonPatchHttpMessageConverter() {
+    super(MediaType.valueOf(JSON_PATCH_TYPE));
+  }
+
+  @Override
+  protected boolean supports(Class<?> clazz) {
+    return JsonPatch.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  protected JsonPatch readInternal(Class<? extends JsonPatch> clazz, HttpInputMessage inputMessage)
+      throws HttpMessageNotReadableException {
+
+    try (JsonReader reader = Json.createReader(inputMessage.getBody())) {
+      return Json.createPatch(reader.readArray());
+    } catch (Exception e) {
+      throw new HttpMessageNotReadableException(e.getMessage(), inputMessage);
+    }
+  }
+
+  @Override
+  protected void writeInternal(JsonPatch jsonPatch, HttpOutputMessage outputMessage)
+      throws HttpMessageNotWritableException {
+
+    try (JsonWriter writer = Json.createWriter(outputMessage.getBody())) {
+      writer.write(jsonPatch.toJsonArray());
+    } catch (Exception e) {
+      throw new HttpMessageNotWritableException(e.getMessage(), e);
+    }
+  }
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -17,7 +17,7 @@
 package com.rackspace.salus.monitor_management.web.controller;
 
 import static com.rackspace.salus.common.util.SpringResourceUtils.readContent;
-import static com.rackspace.salus.monitor_management.web.converter.PatchHelper.JSON_MERGE_PATCH_TYPE;
+import static com.rackspace.salus.monitor_management.web.converter.PatchHelper.JSON_PATCH_TYPE;
 import static com.rackspace.salus.telemetry.entities.Monitor.POLICY_TENANT;
 import static com.rackspace.salus.test.WebTestUtils.classValidationError;
 import static com.rackspace.salus.test.WebTestUtils.httpMessageNotReadable;
@@ -469,11 +469,12 @@ public class MonitorApiControllerTest {
     String url = String.format("/api/tenant/%s/monitors/%s", tenantId, id);
 
     // send an update with a new name and a null interval
-    String update = "{\"name\":\"newName1234\",\"interval\":null}";
+    String update = "[{\"op\":\"replace\",\"path\": \"/name\",\"value\":\"newName\"},"
+        + "{\"op\":\"replace\",\"path\": \"/interval\",\"value\":null}]";
 
     mockMvc.perform(patch(url)
         .content(update)
-        .contentType(MediaType.valueOf(JSON_MERGE_PATCH_TYPE))
+        .contentType(MediaType.valueOf(JSON_PATCH_TYPE))
         .characterEncoding(StandardCharsets.UTF_8.name()))
         .andDo(print())
         .andExpect(status().isOk())
@@ -492,12 +493,12 @@ public class MonitorApiControllerTest {
     UUID id = UUID.randomUUID();
     String url = String.format("/api/tenant/%s/monitors/%s", tenantId, id);
 
-    // send an update with a new name and a null interval
-    String update = "{\"name\":\"newName1234\",\"interval\":null}";
+    // send an update with a new name
+    String update = "[{\"op\":\"replace\",\"path\": \"/name\",\"value\":\"newName\"}]";
 
     mockMvc.perform(patch(url)
         .content(update)
-        .contentType(MediaType.valueOf(JSON_MERGE_PATCH_TYPE))
+        .contentType(MediaType.valueOf(JSON_PATCH_TYPE))
         .characterEncoding(StandardCharsets.UTF_8.name()))
         .andExpect(status().isNotFound())
         .andExpect(content()
@@ -528,12 +529,13 @@ public class MonitorApiControllerTest {
     UUID id = monitor.getId();
     String url = String.format("/api/admin/policy-monitors/%s", id);
 
-    // send an update with a null name and a new interva
-    String update = "{\"name\":null,\"interval\":234}";
+    // send an update with a null name and a new interval
+    String update = "[{\"op\":\"replace\",\"path\": \"/name\",\"value\":null},"
+        + "{\"op\":\"replace\",\"path\": \"/interval\",\"value\":234}]";
 
     mockMvc.perform(patch(url)
         .content(update)
-        .contentType(MediaType.valueOf(JSON_MERGE_PATCH_TYPE))
+        .contentType(MediaType.valueOf(JSON_PATCH_TYPE))
         .characterEncoding(StandardCharsets.UTF_8.name()))
         .andDo(print())
         .andExpect(status().isOk())


### PR DESCRIPTION
# What

Convert the existing JsonMergePatch method into a JsonPatch.

# How

* Updated `PatchHelper` to include null values when converting to the JsonStructure
   * Uses JacksonAnnotationIntrospector
      * This was the hardest thing to figure out
   * Without this an exception would be thrown when things like `pingInterval` were provided in the payload but were set to null in the existing monitor.
* Added a `convertToInput` method
   * Was originally for other reasons that never ended up being needed, but in the end it saves converting to an Output object first for any patches
* A little cleanup in `MonitorConversionService` for shared methods
* Update tests to use the Patch payload format.

# Why

MergePatch ended up having some issues.  Since it was a merge if you provided `{}` as the payload to something that currently was set to `{"key": "value"}` no change would occur since it was actually merging the keys from the payload into the object... and since there were no keys in there, nothing would be done.

That meant a PUT would be needed if you ever wanted to set something to `{}`, but with PUT you cannot set things to `null` so then the PATCH would be needed.

That behavior would make it difficult for something like Intelligence to develop against... this new PATCH functionality should cover all scenarios simply by using the `replace` operation.

# TODO

I'm pushing this to get eyes on it and because nothing much needs to change, but I want to look into the `JsonException` a little more to see if we can determine why it was triggered.  In some cases we'd probably want to return a 400 but in others a 422.  The 400 is probably more likely so that may end up being the default if I can't find a way to distinguish between them all.