### PR TITLE
Remove @JsonInclude from Monitors

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIo.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIo.java
@@ -16,8 +16,6 @@
 
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
@@ -30,7 +28,6 @@ import lombok.EqualsAndHashCode;
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.diskio)
-@JsonInclude(Include.NON_NULL)
 public class DiskIo extends LocalPlugin {
   List<String> devices;
   Boolean skipSerialNumber;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
@@ -16,8 +16,6 @@
 
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
@@ -33,7 +31,6 @@ import lombok.EqualsAndHashCode;
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.http_response)
-@JsonInclude(Include.NON_NULL)
 public class HttpResponse extends RemotePlugin {
   @NotEmpty
   String address;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
@@ -16,8 +16,6 @@
 
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
@@ -32,7 +30,6 @@ import lombok.EqualsAndHashCode;
 @Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.net_response)
-@JsonInclude(Include.NON_NULL)
 public class NetResponse extends RemotePlugin {
 
   public enum Protocol {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
@@ -16,8 +16,6 @@
 
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
@@ -31,7 +29,6 @@ import lombok.EqualsAndHashCode;
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.ping)
-@JsonInclude(Include.NON_NULL)
 public class Ping extends RemotePlugin {
   @NotEmpty
   List<String> urls;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
@@ -16,8 +16,6 @@
 
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
@@ -32,7 +30,6 @@ import lombok.EqualsAndHashCode;
 @Data @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.x509_cert)
-@JsonInclude(Include.NON_NULL)
 public class X509Cert extends RemotePlugin {
   @NotEmpty
   List<String> sources;

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
@@ -517,7 +517,10 @@ public class MonitorManagement_MetadataPolicyTest {
     // The below tests that the "count" was updated where applicable.
     // Interval is not updated even though it is a policy field since this metadata event did not relate to it.
 
-    String expectedPolicyUpdateContent = "{\"type\":\"ping\",\"urls\":[\"localhost\"],\"count\":" + UPDATED_COUNT_VALUE + "}";
+    String expectedPolicyUpdateContent = "{\"type\":\"ping\",\"urls\":[\"localhost\"],\"count\":" + UPDATED_COUNT_VALUE
+        + ",\"pingInterval\":null,\"timeout\":null,\"deadline\":null,\"interfaceOrAddress\":null}";
+    // due to content being stored as a string and the details of unmodified monitors are not regenerated,
+    // for the purpose of this test all the `null` values seen in te updated monitor are excluded here.
     String expectedOriginalContent = "{\"type\":\"ping\",\"urls\":[\"localhost\"],\"count\":72}";
 
     // monitor 1 had a custom count value, but count was in its pluginMetadata so it should now be

--- a/src/test/resources/DetailedMonitorOutputTest/remote.json
+++ b/src/test/resources/DetailedMonitorOutputTest/remote.json
@@ -17,7 +17,8 @@
       "count": 5,
       "deadline": 10,
       "pingInterval": 15,
-      "timeout": 20
+      "timeout": 20,
+      "interfaceOrAddress": null
     }
   },
   "createdTimestamp": "1970-01-01T00:00:00Z",

--- a/src/test/resources/MonitorConversionServiceTest_patch_with_policy.json
+++ b/src/test/resources/MonitorConversionServiceTest_patch_with_policy.json
@@ -3,5 +3,7 @@
   "urls": ["localhost"],
   "count": 63,
   "pingInterval": 2,
-  "timeout": 33
+  "timeout": 33,
+  "deadline": null,
+  "interfaceOrAddress": null
 }

--- a/src/test/resources/MonitorConversionServiceTest_ping.json
+++ b/src/test/resources/MonitorConversionServiceTest_ping.json
@@ -1,4 +1,9 @@
 {
   "type": "ping",
-  "urls": ["localhost"]
+  "urls": ["localhost"],
+  "count": null,
+  "deadline": null,
+  "interfaceOrAddress": null,
+  "pingInterval": null,
+  "timeout": null
 }

--- a/src/test/resources/MonitorConversionServiceTest_ping_with_policy.json
+++ b/src/test/resources/MonitorConversionServiceTest_ping_with_policy.json
@@ -2,5 +2,8 @@
   "type": "ping",
   "urls": ["localhost"],
   "count": 63,
-  "pingInterval": 2
+  "pingInterval": 2,
+  "deadline": null,
+  "interfaceOrAddress": null,
+  "timeout": null
 }


### PR DESCRIPTION
Following on from https://github.com/racker/salus-telemetry-monitor-management/pull/98

We realized that we probably want to send any fields that can be input by the user back to them (even if they are null).  This will help make the behavior more consistent/intuitive for intelligence.

The logic from https://github.com/racker/salus-telemetry-monitor-management/pull/98 to ignore fields with these annotations is going to remain in place until we have got further along with the translation layer since I'm unsure if it could be beneficial there at all.