### PR TITLE
Removing object mapper options for ignoring JsonInclude annotations

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/config/JsonConfig.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/JsonConfig.java
@@ -16,12 +16,8 @@
 
 package com.rackspace.salus.monitor_management.config;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.introspect.Annotated;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.datatype.jsr353.JSR353Module;
-import java.lang.annotation.Annotation;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -33,25 +29,4 @@ public class JsonConfig {
     // Register ability to handle Json Merge Patch conversions.
     return new JSR353Module();
   }
-
-  /**
-   * This can be used when (de)serialization of an object is required but the ignored properties
-   * should be included.
-   *
-   * e.g. If some fields of an object are configured with @JsonInclude(Include.NON_NULL)
-   * this can be used on the object mapper to ensure they are not ignored during conversion.
-   *
-   *    objectMapper.setAnnotationIntrospector(IGNORE_JSON_INCLUDE_ANNOTATIONS);
-   *    objectMapper.convertValue(targetBean, JsonStructure.class);
-   *
-   */
-  public static final JacksonAnnotationIntrospector IGNORE_JSON_INCLUDE_ANNOTATIONS = new JacksonAnnotationIntrospector() {
-    @Override
-    protected <A extends Annotation> A _findAnnotation(final Annotated annotated, final Class<A> annoClass) {
-      if (!annotated.hasAnnotation(JsonInclude.class)) {
-        return super._findAnnotation(annotated, annoClass);
-      }
-      return null;
-    }
-  };
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/converter/PatchHelper.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/converter/PatchHelper.java
@@ -16,10 +16,7 @@
 
 package com.rackspace.salus.monitor_management.web.converter;
 
-import static com.rackspace.salus.monitor_management.config.JsonConfig.IGNORE_JSON_INCLUDE_ANNOTATIONS;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr353.JSR353Module;
 import java.util.Set;
 import javax.json.JsonMergePatch;
 import javax.json.JsonPatch;
@@ -38,19 +35,12 @@ public class PatchHelper {
   public static final String JSON_PATCH_TYPE = "application/json-patch+json";
 
   private final ObjectMapper objectMapper;
-  private final ObjectMapper objectMapperAllowNulls;
   private final Validator validator;
 
   @Autowired
   public PatchHelper(ObjectMapper objectMapper, Validator validator) {
     this.objectMapper = objectMapper;
     this.validator = validator;
-    // A custom object mapper is required for patches to ensure fields that are normally
-    // excluded if nullare not excluded here.
-    // These null fields must be available to allow new values to be set.
-    this.objectMapperAllowNulls = new ObjectMapper()
-        .setAnnotationIntrospector(IGNORE_JSON_INCLUDE_ANNOTATIONS)
-        .registerModule(new JSR353Module());
   }
 
   /**
@@ -63,7 +53,7 @@ public class PatchHelper {
    * @return patched object
    */
   public <T> T patch(JsonPatch patch, T targetBean, Class<T> beanClass, Class<?>... groups) {
-    JsonStructure target = objectMapperAllowNulls.convertValue(targetBean, JsonStructure.class);
+    JsonStructure target = objectMapper.convertValue(targetBean, JsonStructure.class);
     JsonValue patched = applyPatch(patch, target);
     return convertAndValidate(patched, beanClass, groups);
   }


### PR DESCRIPTION
Per our conversations around https://github.com/racker/salus-telemetry-monitor-management/pull/98 and https://github.com/racker/salus-telemetry-monitor-management/pull/99 we shouldn't need this logic, as whatever fields we are sending back to the user should be the same as a field that can be sent to us in the payload (with exception of auto things like id and create/update timestamps).