### PR TITLE
Add monitorType to BoundMonitorDTO

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.telemetry.entities.BoundMonitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.View;
 import java.time.Duration;
 import java.time.format.DateTimeFormatter;
@@ -37,7 +38,9 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class BoundMonitorDTO {
+
   UUID monitorId;
+  MonitorType monitorType;
   @JsonView(View.Admin.class)
   String tenantId;
   @JsonInclude(Include.NON_EMPTY)
@@ -53,6 +56,7 @@ public class BoundMonitorDTO {
 
   public BoundMonitorDTO(BoundMonitor boundMonitor) {
     this.monitorId = boundMonitor.getMonitor().getId();
+    this.monitorType = boundMonitor.getMonitor().getMonitorType();
     this.tenantId = boundMonitor.getTenantId();
     this.zoneName = boundMonitor.getZoneName();
     this.resourceId = boundMonitor.getResourceId();

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOJsonTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOJsonTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.UUID;
@@ -48,6 +49,7 @@ public class BoundMonitorDTOJsonTest {
     final BoundMonitorDTO dto = new BoundMonitorDTO()
         .setZoneName("")
         .setMonitorId(UUID.fromString("00000000-0000-0000-0001-000000000000"))
+        .setMonitorType(MonitorType.cpu)
         .setTenantId("t-1")
         .setResourceId("r-1")
         .setSelectorScope(ConfigSelectorScope.LOCAL)
@@ -68,6 +70,7 @@ public class BoundMonitorDTOJsonTest {
     final BoundMonitorDTO dto = new BoundMonitorDTO()
         .setZoneName("")
         .setMonitorId(UUID.fromString("00000000-0000-0000-0001-000000000000"))
+        .setMonitorType(MonitorType.cpu)
         .setTenantId("t-1")
         .setResourceId("r-1")
         .setSelectorScope(ConfigSelectorScope.LOCAL)
@@ -88,6 +91,7 @@ public class BoundMonitorDTOJsonTest {
     final BoundMonitorDTO dto = new BoundMonitorDTO()
         .setZoneName("z-1")
         .setMonitorId(UUID.fromString("00000000-0000-0000-0001-000000000000"))
+        .setMonitorType(MonitorType.cpu)
         .setTenantId("t-1")
         .setResourceId("r-1")
         .setSelectorScope(ConfigSelectorScope.REMOTE)

--- a/src/test/resources/BoundMonitorDTOJsonTest/testAllPopulated.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testAllPopulated.json
@@ -1,5 +1,6 @@
 {
   "monitorId": "00000000-0000-0000-0001-000000000000",
+  "monitorType": "cpu",
   "tenantId": "t-1",
   "resourceId": "r-1",
   "selectorScope": "REMOTE",

--- a/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nonNullEnvoy.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nonNullEnvoy.json
@@ -1,5 +1,6 @@
 {
   "monitorId": "00000000-0000-0000-0001-000000000000",
+  "monitorType": "cpu",
   "tenantId": "t-1",
   "resourceId": "r-1",
   "selectorScope": "LOCAL",

--- a/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nullEnvoy.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nullEnvoy.json
@@ -1,5 +1,6 @@
 {
   "monitorId": "00000000-0000-0000-0001-000000000000",
+  "monitorType": "cpu",
   "tenantId": "t-1",
   "resourceId": "r-1",
   "selectorScope": "LOCAL",


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-643

# What

In order for Ambassador to pass the monitor type along for metrics inclusion, the bound monitor DTO needs to convey the type.

# How

Add the `monitorType` to the DTO builder.

## How to test

Updated applicable tests