### PR TITLE
Add a name field to MonitorTranslationOperator

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
@@ -72,6 +72,7 @@ public class MonitorContentTranslationService {
 
   public MonitorTranslationOperator create(MonitorTranslationOperatorCreate in) {
     final MonitorTranslationOperator operator = new MonitorTranslationOperator()
+        .setName(in.getName())
         .setAgentType(in.getAgentType())
         .setAgentVersions(in.getAgentVersions())
         .setTranslatorSpec(in.getTranslatorSpec());

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorCreate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorCreate.java
@@ -21,6 +21,7 @@ import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.translators.MonitorTranslator;
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -28,6 +29,9 @@ import lombok.Data;
 public class MonitorTranslationOperatorCreate {
   @NotNull
   AgentType agentType;
+
+  @NotBlank
+  String name;
 
   /**
    * Optional field that conveys applicable version ranges

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorDTO.java
@@ -29,6 +29,8 @@ import lombok.NoArgsConstructor;
 public class MonitorTranslationOperatorDTO {
   UUID id;
 
+  String name;
+
   AgentType agentType;
 
   String agentVersions;
@@ -41,6 +43,7 @@ public class MonitorTranslationOperatorDTO {
 
   public MonitorTranslationOperatorDTO(MonitorTranslationOperator entity) {
     this.id = entity.getId();
+    this.name = entity.getName();
     this.agentType = entity.getAgentType();
     this.agentVersions = entity.getAgentVersions();
     this.monitorType = entity.getMonitorType();

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
@@ -200,12 +200,14 @@ public class MonitorContentTranslationServiceTest {
   public void testTranslate_match_byMonitorType() throws JsonProcessingException {
     final List<MonitorTranslationOperator> operators = List.of(
         new MonitorTranslationOperator()
+            .setName("match")
             .setAgentType(AgentType.TELEGRAF)
             .setAgentVersions(null)
             .setTranslatorSpec(buildRenameSpec("matches", "afterMatch"))
             // TEST matching monitor type
             .setMonitorType(MonitorType.cpu),
         new MonitorTranslationOperator()
+            .setName("dontMatch")
             .setAgentType(AgentType.TELEGRAF)
             .setAgentVersions(null)
             .setTranslatorSpec(buildRenameSpec("dontMatch", "neverUsed"))
@@ -248,12 +250,14 @@ public class MonitorContentTranslationServiceTest {
   public void testTranslate_match_bySelectorScope() throws JsonProcessingException {
     final List<MonitorTranslationOperator> operators = List.of(
         new MonitorTranslationOperator()
+            .setName("match")
             .setAgentType(AgentType.TELEGRAF)
             .setAgentVersions(null)
             .setTranslatorSpec(buildRenameSpec("matches", "afterMatch"))
             // TEST matching selector scope
             .setSelectorScope(ConfigSelectorScope.LOCAL),
         new MonitorTranslationOperator()
+            .setName("dontMatch")
             .setAgentType(AgentType.TELEGRAF)
             .setAgentVersions(null)
             .setTranslatorSpec(buildRenameSpec("dontMatch", "neverUsed"))
@@ -381,6 +385,7 @@ public class MonitorContentTranslationServiceTest {
                                                              String renameFromField) {
     return List.of(
         new MonitorTranslationOperator()
+            .setName("rename-"+renameFromField)
             .setAgentType(agentType)
             .setAgentVersions(agentVersions)
             .setTranslatorSpec(buildRenameSpec(renameFromField, "new_field"))

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorTranslationApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorTranslationApiControllerTest.java
@@ -173,6 +173,7 @@ public class MonitorTranslationApiControllerTest {
 
     verify(monitorContentTranslationService).create(
         new MonitorTranslationOperatorCreate()
+        .setName("rename-cpu")
         .setAgentType(AgentType.TELEGRAF)
         .setAgentVersions(">= 1.12.0")
         .setMonitorType(MonitorType.cpu)
@@ -214,6 +215,7 @@ public class MonitorTranslationApiControllerTest {
                                                    MonitorType monitorType,
                                                    ConfigSelectorScope selectorScope, UUID id) {
     return new MonitorTranslationOperator()
+        .setName("rename-"+monitorType.toString())
         .setAgentType(AgentType.TELEGRAF)
         .setAgentVersions(agentVersions)
         .setMonitorType(monitorType)

--- a/src/test/resources/MonitorTranslationApiControllerTest/create_req.json
+++ b/src/test/resources/MonitorTranslationApiControllerTest/create_req.json
@@ -1,4 +1,5 @@
 {
+  "name": "rename-cpu",
   "agentType": "TELEGRAF",
   "agentVersions": ">= 1.12.0",
   "monitorType": "cpu",

--- a/src/test/resources/MonitorTranslationApiControllerTest/create_resp.json
+++ b/src/test/resources/MonitorTranslationApiControllerTest/create_resp.json
@@ -1,5 +1,6 @@
 {
   "id": "00000001-ffcf-40d2-8684-95cb0362ae6d",
+  "name": "rename-cpu",
   "agentType": "TELEGRAF",
   "agentVersions": ">= 1.12.0",
   "monitorType": "cpu",

--- a/src/test/resources/MonitorTranslationApiControllerTest/getAll_resp.json
+++ b/src/test/resources/MonitorTranslationApiControllerTest/getAll_resp.json
@@ -2,6 +2,7 @@
   "content": [
     {
       "id": "00000001-ffcf-40d2-8684-95cb0362ae6d",
+      "name": "rename-cpu",
       "agentType": "TELEGRAF",
       "agentVersions": ">= 1.12.0",
       "monitorType": "cpu",
@@ -14,6 +15,7 @@
     },
     {
       "id": "00000002-ffcf-40d2-8684-95cb0362ae6d",
+      "name": "rename-http_response",
       "agentType": "TELEGRAF",
       "agentVersions": "< 1.12.0",
       "monitorType": "http_response",

--- a/src/test/resources/MonitorTranslationApiControllerTest/getById_resp.json
+++ b/src/test/resources/MonitorTranslationApiControllerTest/getById_resp.json
@@ -1,5 +1,6 @@
 {
   "id": "00000001-ffcf-40d2-8684-95cb0362ae6d",
+  "name": "rename-cpu",
   "agentType": "TELEGRAF",
   "agentVersions": ">= 1.12.0",
   "monitorType": "cpu",


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-671

# What

For the data loader mechanism we need a stable and unique way to refer to monitor translation operators that have already been loaded.

# How

Add `name` field to the corresponding DTOs.

## How to test

Updated existing unit tests

# Depends on

- https://github.com/racker/salus-telemetry-model/pull/83