### PR TITLE
Add create endpoint to api client

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
@@ -17,10 +17,12 @@
 package com.rackspace.salus.monitor_management.web.client;
 
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.telemetry.model.AgentType;
 import java.util.List;
 import java.util.Map;
+import org.springframework.util.MultiValueMap;
 
 public interface MonitorApi {
 
@@ -28,4 +30,6 @@ public interface MonitorApi {
                                          Map<AgentType, String> installedAgentVersions);
 
   DetailedMonitorOutput getPolicyMonitorById(String monitorId);
+
+  DetailedMonitorOutput createMonitor(String tenantId, DetailedMonitorInput input, MultiValueMap<String, String> headers);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -20,6 +20,7 @@ import static com.rackspace.salus.common.web.RemoteOperations.mapRestClientExcep
 
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorsRequest;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.telemetry.model.AgentType;
 import java.util.List;
@@ -27,10 +28,14 @@ import java.util.Map;
 import java.util.Objects;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * This client component provides a small subset of Monitor Management REST operations that
@@ -112,5 +117,27 @@ public class MonitorApiClient implements MonitorApi {
           }
         }
     );
+  }
+
+  @Override
+  public DetailedMonitorOutput createMonitor(String tenantId, DetailedMonitorInput input, MultiValueMap<String, String> headers) {
+    String uriString = UriComponentsBuilder
+        .fromUriString("/api/tenant/{tenantId}/monitors")
+        .buildAndExpand(tenantId)
+        .toUriString();
+
+    HttpHeaders reqHeaders = new HttpHeaders();
+    reqHeaders.setContentType(MediaType.APPLICATION_JSON);
+    if (headers != null) {
+      reqHeaders.addAll(headers);
+    }
+
+    return mapRestClientExceptions(
+        SERVICE_NAME,
+        () -> restTemplate.postForEntity(
+            uriString,
+            new HttpEntity<>(input, reqHeaders),
+            DetailedMonitorOutput.class
+        ).getBody());
   }
 }


### PR DESCRIPTION
# What

Adds a create endpoint to the api client.

# How

I included `MultiValueMap<String, String> headers` so that this can be used against the public api and provide an `x-auth-token`.  I spoke to @itzg briefly about that before and if the need arises we might want to add that to all the api client methods (or at least any we add from here on) so that it is more of a comprehensive client that can be used for multiple purposes and not just internal service-to-service requests.

# Why

I'm utilizing this client in the migration app.