### PR TITLE
Use flyway for schema management

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/config/DatabaseConfig.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/DatabaseConfig.java
@@ -16,12 +16,10 @@
 
 package com.rackspace.salus.monitor_management.config;
 
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import com.rackspace.salus.telemetry.EnableSalusJpa;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@EntityScan("com.rackspace.salus.telemetry.entities")
-@EnableJpaRepositories("com.rackspace.salus.telemetry.repositories")
+@EnableSalusJpa
 @Configuration
 public class DatabaseConfig {
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ salus:
       http://localhost:8091
 spring:
   jpa:
-    database-platform: org.hibernate.dialect.MySQL5Dialect
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     properties:
       hibernate:
         generate_statistics: false

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,8 +10,6 @@ salus:
       http://localhost:8091
 spring:
   jpa:
-    hibernate:
-      ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL5Dialect
     properties:
       hibernate:


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-684

# What

Uses flyway for schema management by switching over to the `@EnableSalusJpa` config annotation and removing explicit setting of hibernate auto ddl.

## How to test

Existing unit tests

# Depends on

- https://github.com/racker/salus-telemetry-model/pull/85