### PR TITLE
Switching to maven's version parsing class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,10 @@
       <version>1.6</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+    </dependency>
+    <dependency>
         <groupId>com.rackspace.salus</groupId>
         <artifactId>salus-telemetry-etcd-adapter</artifactId>
         <version>0.1.0-SNAPSHOT</version>


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-724

# What

The java-semver library is too strict with its version parsing, since it only handles compliant semantic versions.

# How

Switch over to the version parsing included in [maven's artifact library](https://maven.apache.org/ref/3.3.3/maven-artifact/apidocs/org/apache/maven/artifact/versioning/package-frame.html)

## How to test

Unit test tweaked with the maven supported version-range syntax.

# Depends on

https://github.com/racker/salus-app-base/pull/19