### PR TITLE
Use tcp as default protocol in NetResponse

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
@@ -40,6 +40,7 @@ public class NetResponse extends RemotePlugin {
   Protocol protocol = Protocol.tcp;
 
   @NotNull
+  @ValidHostAndPort
   String address;
 
   @ValidGoDuration

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
@@ -37,10 +37,9 @@ public class NetResponse extends RemotePlugin {
   }
 
   @NotNull
-  Protocol protocol;
+  Protocol protocol = Protocol.tcp;
 
   @NotNull
-  @ValidHostAndPort
   String address;
 
   @ValidGoDuration


### PR DESCRIPTION
I've had this change sitting locally for a while.

udp is not a common choice - I don't think ele even supports it?

Let's default to tcp if it nothing is specified.