### PR TITLE
Fix monitor label matching when resource has no labels

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
@@ -52,7 +52,10 @@ public class MonitorContentRenderer {
     try {
       return template.execute(context);
     } catch (MustacheException e) {
-      throw new InvalidTemplateException("Unable to render monitor content template", e);
+      throw new InvalidTemplateException(
+          String.format("Unable to render monitor content template, content=%s, resource=%s",
+              rawContent, resource),
+          e);
     }
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1622,9 +1622,9 @@ public class MonitorManagement {
    * @return the list of Monitor's that match the labels
    */
   @SuppressWarnings("Duplicates")
-  public Page<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId, Pageable page) throws IllegalArgumentException {
+  public Page<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId, Pageable page) {
     if(labels.size() == 0) {
-      throw new IllegalArgumentException("Labels must be provided for search");
+      return monitorRepository.findByTenantIdAndResourceIdIsNullAndLabelSelectorIsNull(tenantId, page);
     }
 
     MapSqlParameterSource paramSource = new MapSqlParameterSource();


### PR DESCRIPTION
# What

Fixes `getMonitorsFromLabels` so it doesn't throw an exception when a resource has no labels.

# How / Why

If a resource has no labels it is still a valid case and should not see an exception.  Instead, all monitors should be returned that have an empty label selector and no resourceId set. i.e. all monitors that match all resources.

resourceId monitors are handled separately by 
```
monitorsWithResourceId = monitorRepository.findByTenantIdAndResourceId(tenantId, resourceId);
```

The new repository method `findByTenantIdAndResourceIdIsNullAndLabelSelectorIsNull` converts to:

```sql
 SELECT monitor0_.id                    AS id1_13_,
       monitor0_.agent_type            AS agent_ty2_13_,
       monitor0_.content               AS content3_13_,
       monitor0_.created_timestamp     AS created_4_13_,
       monitor0_.monitoring_interval   AS monitori5_13_,
       monitor0_.label_selector_method AS label_se6_13_,
       monitor0_.monitor_name          AS monitor_7_13_,
       monitor0_.monitor_type          AS monitor_8_13_,
       monitor0_.resource_id           AS resource9_13_,
       monitor0_.selector_scope        AS selecto10_13_,
       monitor0_.tenant_id             AS tenant_11_13_,
       monitor0_.updated_timestamp     AS updated12_13_
FROM   monitors monitor0_
       LEFT OUTER JOIN monitor_label_selectors labelselec1_
                    ON monitor0_.id = labelselec1_.monitor_id
WHERE  monitor0_.tenant_id = ?
       AND ( monitor0_.resource_id IS NULL )
       AND ( labelselec1_.label_selector IS NULL )  
```

# TODO

There might be a similar change needed to the agent installer service.  I'm creating a jira for that.
