### PR TITLE
Allow metadata to be used in host fields

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -35,7 +35,6 @@ import com.rackspace.salus.monitor_management.web.model.ValidationGroups;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
-import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import java.io.IOException;
 import java.io.InvalidClassException;
@@ -68,7 +67,6 @@ public class MonitorConversionService {
   @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
   @Autowired
   public MonitorConversionService(ObjectMapper objectMapper, MonitorConversionProperties properties,
-      PolicyApi policyApi,
       MonitorRepository monitorRepository,
       MetadataUtils metadataUtils,
       PatchHelper patchHelper) {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidHostAndPortValidator.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidHostAndPortValidator.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.web.model.validator;
 
 import com.google.common.net.HostAndPort;
+import java.util.regex.Pattern;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,10 @@ public class ValidHostAndPortValidator implements ConstraintValidator<ValidHostA
    public boolean isValid(String value, ConstraintValidatorContext context) {
       if (value == null) {
          // to allow for optional fields
+         return true;
+      }
+
+      if (isValidMetadata(value)) {
          return true;
       }
 
@@ -53,6 +58,11 @@ public class ValidHostAndPortValidator implements ConstraintValidator<ValidHostA
          return false;
       }
       return true;
+   }
+
+   private boolean isValidMetadata(String value) {
+      Pattern metadataRegex = Pattern.compile("^\\$\\{(.+?)}$");
+      return metadataRegex.matcher(value).matches();
    }
 
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidHostAndPortValidatorTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidHostAndPortValidatorTest.java
@@ -145,4 +145,56 @@ public class ValidHostAndPortValidatorTest {
         equalTo(ValidHostAndPort.class)
     );
   }
+
+  @Test
+  public void testValidation_validMetadata() {
+    final WithRequiredAddress obj = new WithRequiredAddress("${resource.metadata.ping_ip}");
+
+    final Set<ConstraintViolation<WithRequiredAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(0));
+  }
+
+  @Test
+  public void testValidation_invalidMetadata() {
+    final WithRequiredAddress obj = new WithRequiredAddress("start${resource.metadata.ping_ip}end");
+
+    final Set<ConstraintViolation<WithRequiredAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(1));
+    assertThat(
+        result.iterator().next().getConstraintDescriptor().getAnnotation().annotationType(),
+        equalTo(ValidHostAndPort.class)
+    );
+  }
+
+  @Test
+  public void testValidation_invalidMetadata_notClosed() {
+    final WithRequiredAddress obj = new WithRequiredAddress("${resource.metadata.ping_ip");
+
+    final Set<ConstraintViolation<WithRequiredAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(1));
+    assertThat(
+        result.iterator().next().getConstraintDescriptor().getAnnotation().annotationType(),
+        equalTo(ValidHostAndPort.class)
+    );
+  }
+
+  @Test
+  public void testValidation_invalidMetadata_missingDollar() {
+    final WithRequiredAddress obj = new WithRequiredAddress("{resource.metadata.ping_ip}");
+
+    final Set<ConstraintViolation<WithRequiredAddress>> result = validatorFactoryBean
+        .validate(obj);
+
+    assertThat(result, hasSize(1));
+    assertThat(
+        result.iterator().next().getConstraintDescriptor().getAnnotation().annotationType(),
+        equalTo(ValidHostAndPort.class)
+    );
+  }
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-714

# What

Allows metadata to be used for fields that have the `@ValidHostAndPort` annotation.

What is fails to do is validate that the metadata value is actually a valid host/port.  i.e. it is only used for api input validation, not for monitor binding validation.

# How

Do a basic regex match as part of the existing validation.

# Why

Currently if you try to create a `NetResponse` plugin with metadata the api request will fail with a 400.  This allows it to succeed and then monitor binding can be attempted.