### PR TITLE
Update disk monitors and add metrics to translate errors

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Disk.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Disk.java
@@ -16,14 +16,12 @@
 
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
-import java.util.Arrays;
-import java.util.List;
+import javax.validation.constraints.NotBlank;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -31,7 +29,6 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.disk)
 public class Disk extends LocalPlugin {
+  @NotBlank
   String mount;
-  @JsonProperty(defaultValue = "[\"tmpfs\", \"devtmpfs\", \"devfs\", \"iso9660\", \"overlay\", \"aufs\", \"squashfs\"]")
-  List<String> ignoreFs = Arrays.asList("tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs");
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIo.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIo.java
@@ -21,7 +21,6 @@ import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
-import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -31,6 +30,4 @@ import lombok.EqualsAndHashCode;
 public class DiskIo extends LocalPlugin {
   String device;
   Boolean skipSerialNumber;
-  List<String> deviceTags;
-  List<String> nameTemplates;
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MeterRegistryTestConfig.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MeterRegistryTestConfig.java
@@ -16,20 +16,17 @@
 
 package com.rackspace.salus.monitor_management.services;
 
-import com.rackspace.salus.telemetry.entities.BoundMonitor;
-import com.rackspace.salus.telemetry.translators.MonitorTranslator;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 
-/**
- * Indicates that an issue was encountered with either a {@link MonitorTranslator} or the
- * {@link BoundMonitor}'s rendered content that prevented translation.
- */
-class MonitorContentTranslationException extends Exception {
+@TestConfiguration
+public class MeterRegistryTestConfig {
 
-  MonitorContentTranslationException(String message) {
-    super(message);
+  @Bean
+  public MeterRegistry meterRegistry() {
+    return new SimpleMeterRegistry();
   }
 
-  MonitorContentTranslationException(String message, Throwable cause) {
-    super(message, cause);
-  }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
@@ -50,7 +50,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {
-    MonitorContentTranslationService.class
+    MonitorContentTranslationService.class,
+    MeterRegistryTestConfig.class
 })
 @AutoConfigureJson
 public class MonitorContentTranslationServiceTest {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskConversionTest.java
@@ -82,7 +82,6 @@ public class DiskConversionTest {
         assertCommon(result, monitor, Disk.class, "convertToOutput");
 
     assertThat(specificPlugin.getMount()).isEqualTo("/var/lib");
-    assertThat(specificPlugin.getIgnoreFs()).contains("/dev");
   }
 
   @Test
@@ -98,8 +97,6 @@ public class DiskConversionTest {
         assertCommon(result, monitor, Disk.class, "convertToOutput_defaults");
 
     assertThat(specificPlugin.getMount()).isNull();
-    assertThat(specificPlugin.getIgnoreFs()).containsExactly(
-        "tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs");
   }
 
   @Test
@@ -110,7 +107,6 @@ public class DiskConversionTest {
 
     final Disk plugin = new Disk();
     plugin.setMount("/var/lib");
-    plugin.setIgnoreFs(Collections.singletonList("/dev"));
 
     final LocalMonitorDetails details = new LocalMonitorDetails();
     details.setPlugin(plugin);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIoConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIoConversionTest.java
@@ -99,9 +99,6 @@ public class DiskIoConversionTest {
     final DiskIo specificPlugin = (DiskIo) plugin;
     assertThat(specificPlugin.getDevice()).isEqualTo("sda");
     assertThat(specificPlugin.getSkipSerialNumber()).isTrue();
-    assertThat(specificPlugin.getDeviceTags()).contains("ID_FS_TYPE");
-    assertThat(specificPlugin.getNameTemplates()).contains("$ID_FS_LABEL");
-
   }
 
   @Test
@@ -114,9 +111,6 @@ public class DiskIoConversionTest {
     final DiskIo plugin = new DiskIo();
     plugin.setDevice("sda");
     plugin.setSkipSerialNumber(true);
-    plugin.setDeviceTags(Collections.singletonList("ID_FS_TYPE"));
-    plugin.setNameTemplates(Collections.singletonList("$ID_FS_LABEL"));
-
 
     final LocalMonitorDetails details = new LocalMonitorDetails();
     details.setPlugin(plugin);

--- a/src/test/resources/ConversionTests/MonitorConversionServiceTest_disk.json
+++ b/src/test/resources/ConversionTests/MonitorConversionServiceTest_disk.json
@@ -1,5 +1,4 @@
 {
   "type": "disk",
-  "mount": "/var/lib",
-  "ignoreFs": ["/dev"]
+  "mount": "/var/lib"
 }

--- a/src/test/resources/ConversionTests/MonitorConversionServiceTest_diskio.json
+++ b/src/test/resources/ConversionTests/MonitorConversionServiceTest_diskio.json
@@ -1,7 +1,5 @@
 {
   "type": "diskio",
   "device": "sda",
-  "skipSerialNumber": true,
-  "deviceTags": ["ID_FS_TYPE"],
-  "nameTemplates": ["$ID_FS_LABEL"]
+  "skipSerialNumber": true
 }


### PR DESCRIPTION
# What

Branched off of https://github.com/racker/salus-telemetry-monitor-management/pull/118

Removes some disk/diskio fields we shouldn't need to expose and handled the exceptions thrown by https://github.com/racker/salus-telemetry-model/pull/95

# Why

By logging metrics for the exceptions we'll be able to know whether something has gone wrong and can look deeper into the logs if needed.  When it comes to setting up monitoring we'll have to decide on an adequate threshold of errors.  Currently any errors in the translator will occur silently - the monitor will not be bound but no one would be aware unless they really looked.

Also, `@NotBlank` was added to the disk mount because if an empty value is provided the telegraf plugin would monitor all disks.  We have made the decision where each individual monitor will monitor one target only.
