### PR TITLE
Add exclude resources option during monitor binding

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,7 @@ public class MonitorConversionService {
         .setInterval(monitor.getInterval())
         .setLabelSelectorMethod(monitor.getLabelSelectorMethod())
         .setResourceId(monitor.getResourceId())
+        .setExcludedResourceIds(monitor.getExcludedResourceIds())
         .setDetails(convertContentToDetails(monitor));
 
     if (StringUtils.isNotBlank(monitor.getResourceId())) {
@@ -106,6 +107,7 @@ public class MonitorConversionService {
         .setName(monitor.getMonitorName())
         .setLabelSelectorMethod(monitor.getLabelSelectorMethod())
         .setResourceId(monitor.getResourceId())
+        .setExcludedResourceIds(monitor.getExcludedResourceIds())
         .setInterval(monitor.getInterval())
         .setDetails(convertContentToDetails(monitor))
         .setCreatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(monitor.getCreatedTimestamp()))
@@ -193,6 +195,7 @@ public class MonitorConversionService {
         .setLabelSelector(input.getLabelSelector())
         .setLabelSelectorMethod(input.getLabelSelectorMethod())
         .setResourceId(input.getResourceId())
+        .setExcludedResourceIds(input.getExcludedResourceIds())
         .setInterval(input.getInterval());
 
     // Policy monitors should not use metadata

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1023,10 +1023,15 @@ public class MonitorManagement {
   }
 
   private static boolean excludedResourceIdsChanged(Set<String> updated, Set<String> prev, boolean patchOperation) {
-    if (patchOperation) {
-      return updated == null || !updated.equals(prev);
+    // JPA will populate the absence of values as an empty set
+    if (prev != null && prev.isEmpty()) {
+      // ...but let's simplify comparison by treating as null
+      prev = null;
     }
-    return updated != null && !updated.equals(prev);
+    if (patchOperation) {
+      return !Objects.equals(updated, prev);
+    }
+    return updated != null && !Objects.equals(updated, prev);
   }
 
   private boolean labelSelectorChanged(Monitor original, MonitorCU newValues, boolean patchOperation) {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1467,8 +1467,13 @@ public class MonitorManagement {
       }
 
       // Get all relevant account monitors
-      List<Monitor> labelMonitors = getMonitorsFromLabels(resource.get().getLabels(), tenantId, Pageable.unpaged()).getContent();
-      selectedMonitors = new ArrayList<>(labelMonitors);
+      selectedMonitors = getMonitorsFromLabels(
+          resource.get().getLabels(), tenantId, Pageable.unpaged()).getContent()
+          .stream()
+          // but filter to include only monitors that don't exclude this resource
+          .filter(monitor -> monitor.getExcludedResourceIds() == null ||
+              !monitor.getExcludedResourceIds().contains(resourceId))
+          .collect(Collectors.toList());
       selectedMonitors.addAll(monitorsWithResourceId);
       // Append all relevant policy monitors
       selectedMonitors.addAll(getPolicyMonitorsForResource(resource.get()));

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1207,15 +1207,13 @@ public class MonitorManagement {
                                                   Map<String, String> labelSelector,
                                                   @NotNull LabelSelectorMethod labelSelectorMethod,
                                                   Set<String> excludedResourceIds) {
-    List<ResourceDTO> selectedResources;
-    selectedResources = resourceApi
+    return resourceApi
         .getResourcesWithLabels(tenantId, labelSelector, labelSelectorMethod)
         .stream()
         // filter to keep resources that are not in the given exclusion set
         .filter(resourceDTO -> excludedResourceIds == null ||
             !excludedResourceIds.contains(resourceDTO.getResourceId()))
         .collect(Collectors.toList());
-    return selectedResources;
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.rackspace.salus.telemetry.model.ValidLabelKeys;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -46,6 +47,12 @@ public class DetailedMonitorInput {
 
   String resourceId;
 
+  /**
+   * Resource IDs specified will be excluded from binding of this monitor. This can be used in
+   * combination with more specific monitors that select the resource IDs excluded here.
+   */
+  Set<String> excludedResourceIds;
+
   Duration interval;
 
   @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\",\"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false,\"reportActive\": false, \"totalcpu\": true}}")
@@ -58,6 +65,7 @@ public class DetailedMonitorInput {
     this.labelSelector = output.getLabelSelector();
     this.labelSelectorMethod = output.getLabelSelectorMethod();
     this.resourceId = output.getResourceId();
+    this.excludedResourceIds = output.getExcludedResourceIds();
     this.interval = output.getInterval();
     this.details = output.getDetails();
   }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import io.swagger.annotations.ApiModelProperty;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
 import lombok.Data;
 
 @Data
@@ -31,6 +32,7 @@ public class DetailedMonitorOutput {
     Map<String,String> labelSelector;
     LabelSelectorMethod labelSelectorMethod;
     String resourceId;
+    Set<String> excludedResourceIds;
     Duration interval;
     @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\", \"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false, \"reportActive\": false, \"totalcpu\": true} }")
     MonitorDetails details;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.io.Serializable;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.Data;
 
 // This annotation doesn't work with podam
@@ -55,6 +56,8 @@ public class MonitorCU implements Serializable {
     ConfigSelectorScope selectorScope = ConfigSelectorScope.LOCAL;
 
     List<String> zones;
+
+    Set<String> excludedResourceIds;
 
     String resourceId;
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -51,6 +52,8 @@ public class MonitorDTO {
 
   String resourceId;
 
+  Set<String> excludedResourceIds;
+
   String createdTimestamp;
 
   String updatedTimestamp;
@@ -70,6 +73,7 @@ public class MonitorDTO {
 
     this.labelSelectorMethod = monitor.getLabelSelectorMethod();
     this.resourceId = monitor.getResourceId();
+    this.excludedResourceIds = monitor.getExcludedResourceIds();
     this.tenantId = monitor.getTenantId();
     this.content = monitor.getContent();
     this.agentType = monitor.getAgentType();

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidCreateMonitorValidator.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidCreateMonitorValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,9 @@ public class ValidCreateMonitorValidator implements ConstraintValidator<ValidCre
       Map<String, String> labelSelector = monitorInput.getLabelSelector();
       String resourceId = monitorInput.getResourceId();
       if (ValidUpdateMonitorValidator.bothResourceAndLabelsSet(monitorInput)) {
+         return false;
+      }
+      if (ValidUpdateMonitorValidator.bothResourceAndExcludedSet(monitorInput)) {
          return false;
       }
       // Valid if either resourceId or labelSelector exists

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidUpdateMonitorValidator.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/validator/ValidUpdateMonitorValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.util.CollectionUtils;
 
 @Slf4j
 public class ValidUpdateMonitorValidator implements ConstraintValidator<ValidUpdateMonitor, DetailedMonitorInput> {
@@ -35,8 +34,15 @@ public class ValidUpdateMonitorValidator implements ConstraintValidator<ValidUpd
       return StringUtils.isNotBlank(resourceId) && labelSelector != null;
    }
 
+   static boolean bothResourceAndExcludedSet(DetailedMonitorInput monitorInput) {
+      return StringUtils.isNotBlank(monitorInput.getResourceId()) &&
+          monitorInput.getExcludedResourceIds() != null &&
+          !monitorInput.getExcludedResourceIds().isEmpty();
+   }
+
    public boolean isValid(DetailedMonitorInput monitorInput, ConstraintValidatorContext context) {
-      return !bothResourceAndLabelsSet(monitorInput);
+      return !bothResourceAndLabelsSet(monitorInput) &&
+          !bothResourceAndExcludedSet(monitorInput);
    }
 
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -442,6 +442,29 @@ public class MonitorConversionServiceTest {
         .setUpdatedTimestamp(Instant.EPOCH);
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
     assertThat(result.getResourceId()).isEqualTo(monitor.getResourceId());
+  }
+
+  @Test
+  public void testConvertFrom_ExcludedResourceIds() {
+    DetailedMonitorInput input = new DetailedMonitorInput()
+        .setExcludedResourceIds(Set.of("r-1","r-2"))
+        .setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
+    final MonitorCU result = conversionService.convertFromInput(
+        RandomStringUtils.randomAlphabetic(10), null, input);
+    assertThat(result.getExcludedResourceIds()).containsExactlyInAnyOrder("r-1", "r-2");
+  }
+
+  @Test
+  public void testConvertTo_ExcludedResourceIds() {
+    final UUID monitorId = UUID.randomUUID();
+
+    Monitor monitor = new Monitor()
+        .setExcludedResourceIds(Set.of("r-1","r-2"))
+        .setId(monitorId)
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
+    final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
+    assertThat(result.getExcludedResourceIds()).containsExactlyInAnyOrder("r-1", "r-2");
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
@@ -313,7 +313,7 @@ public class MonitorManagementExcludeResourceIdsTest {
 
     verify(envoyResourceManagement).getOne("t-1", "r-exclude-include");
     verify(envoyResourceManagement).getOne("t-1", "r-include-exclude");
-    verify(envoyResourceManagement, times(2)).getOne("t-1", "r-include-include");
+    verify(envoyResourceManagement).getOne("t-1", "r-include-include");
     verify(envoyResourceManagement, never()).getOne("t-1", "r-exclude-exclude");
 
     verifyNoMoreInteractions(resourceApi, envoyResourceManagement, monitorEventProducer);

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementWithDbTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementWithDbTest.java
@@ -1,0 +1,443 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.services;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.rackspace.salus.monitor_management.config.DatabaseConfig;
+import com.rackspace.salus.monitor_management.config.ZonesProperties;
+import com.rackspace.salus.monitor_management.errors.InvalidTemplateException;
+import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.model.ResourceDTO;
+import com.rackspace.salus.telemetry.entities.BoundMonitor;
+import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
+import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
+import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.ResourceInfo;
+import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Contains unit tests that use an embedded JPA database rather than mocking the repository
+ * interactions in {@link MonitorManagementTest}.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {
+    DatabaseConfig.class,
+    MonitorManagement.class,
+    ZonesProperties.class
+})
+@AutoConfigureDataJpa
+@AutoConfigureTestDatabase
+@AutoConfigureTestEntityManager
+@Transactional
+public class MonitorManagementWithDbTest {
+
+  @Autowired
+  MonitorManagement monitorManagement;
+
+  @Autowired
+  BoundMonitorRepository boundMonitorRepository;
+
+  @Autowired
+  TestEntityManager entityManager;
+
+  @MockBean
+  EnvoyResourceManagement envoyResourceManagement;
+
+  @MockBean
+  ZoneStorage zoneStorage;
+
+  @MockBean
+  ZoneManagement zoneManagement;
+
+  @MockBean
+  MonitorEventProducer monitorEventProducer;
+
+  @MockBean
+  MonitorContentRenderer monitorContentRenderer;
+
+  @MockBean
+  MonitorConversionService monitorConversionService;
+
+  @MockBean
+  MetadataUtils metadataUtils;
+
+  @MockBean
+  MeterRegistry meterRegistry;
+
+  @MockBean
+  PolicyApi policyApi;
+
+  @MockBean
+  ResourceApi resourceApi;
+
+  @Test
+  public void testCreate_excludedResourceIds_noResources() {
+    final Monitor monitor = monitorManagement.createMonitor(
+        "t-1",
+        new MonitorCU()
+            .setExcludedResourceIds(Set.of("r-3", "r-5"))
+            .setMonitorType(MonitorType.cpu)
+            .setAgentType(AgentType.TELEGRAF)
+            .setContent("{}")
+            .setInterval(Duration.ofSeconds(60))
+    );
+
+    assertThat(monitor).isNotNull();
+
+    final Monitor retrieved = entityManager.find(Monitor.class, monitor.getId());
+    assertThat(retrieved.getExcludedResourceIds()).containsExactlyInAnyOrder("r-3", "r-5");
+  }
+
+  @Test
+  public void testCreate_excludedResourceIds_withResources() {
+    when(resourceApi.getResourcesWithLabels(any(), any(), any()))
+        .thenReturn(List.of(
+            new ResourceDTO()
+                .setResourceId("r-1")
+                .setTenantId("t-1")
+                .setAssociatedWithEnvoy(true),
+            new ResourceDTO()
+                .setResourceId("r-3")
+                .setTenantId("t-1")
+                .setAssociatedWithEnvoy(true)
+        ));
+
+    setupEnvoyResourceManagement();
+
+    // EXECUTE
+
+    final Monitor monitor = monitorManagement.createMonitor(
+        "t-1",
+        new MonitorCU()
+            .setExcludedResourceIds(Set.of("r-3", "r-5"))
+            .setLabelSelector(emptyMap())
+            .setMonitorType(MonitorType.cpu)
+            .setSelectorScope(ConfigSelectorScope.LOCAL)
+            .setAgentType(AgentType.TELEGRAF)
+            .setContent("{}")
+            .setInterval(Duration.ofSeconds(60))
+    );
+
+    // VERIFY
+
+    assertThat(monitor).isNotNull();
+
+    final Monitor retrieved = entityManager.find(Monitor.class, monitor.getId());
+    assertThat(retrieved.getExcludedResourceIds()).containsExactlyInAnyOrder("r-3", "r-5");
+
+    final List<BoundMonitor> bound = boundMonitorRepository
+        .findAllByMonitor_IdAndMonitor_TenantId(monitor.getId(), "t-1");
+
+    assertThat(bound).hasSize(1);
+    assertThat(bound.get(0).getResourceId()).isEqualTo("r-1");
+
+    verify(resourceApi).getResourcesWithLabels("t-1", emptyMap(), LabelSelectorMethod.AND);
+
+    verify(envoyResourceManagement).getOne("t-1", "r-1");
+    // but won't query r-3 since it's excluded
+    verify(envoyResourceManagement, never()).getOne("t-1", "r-3");
+
+    verifyNoMoreInteractions(resourceApi, envoyResourceManagement);
+  }
+
+  @Test
+  public void testUpdate_excludedResourceIds_noResources() {
+    // JPA needs a mutable collection
+    final Set<String> originalExcludes = new HashSet<>(Set.of("r-3", "r-5"));
+    final UUID existingId = entityManager.persistAndGetId(
+        new Monitor()
+            .setExcludedResourceIds(originalExcludes)
+            .setTenantId("t-1")
+            .setMonitorType(MonitorType.cpu)
+            .setAgentType(AgentType.TELEGRAF)
+            .setInterval(Duration.ofSeconds(60))
+            .setContent("{}"),
+        UUID.class
+    );
+
+    // EXECUTE
+
+    final Monitor monitor = monitorManagement.updateMonitor(
+        "t-1",
+        existingId,
+        new MonitorCU()
+            .setExcludedResourceIds(Set.of("r-7", "r-9"))
+            .setMonitorType(MonitorType.cpu)
+            .setAgentType(AgentType.TELEGRAF)
+    );
+
+    // VERIFY
+
+    assertThat(monitor).isNotNull();
+
+    final Monitor retrieved = entityManager.find(Monitor.class, existingId);
+    assertThat(retrieved.getExcludedResourceIds()).containsExactlyInAnyOrder("r-7", "r-9");
+  }
+
+  @Test
+  public void testUpdate_excludedResourceIds_withResources() throws InvalidTemplateException {
+    /*
+    Test cases with the four resources
+    r-exclude-include : excluded at first, but not after update
+    r-include-include : included before and after
+    r-include-exclude : included at first, but excluded after
+    r-exclude-exclude : excluded at first and after
+     */
+
+    when(resourceApi.getResourcesWithLabels(any(), any(), any()))
+        .thenReturn(List.of(
+            new ResourceDTO()
+                .setResourceId("r-exclude-include")
+                .setTenantId("t-1")
+                .setAssociatedWithEnvoy(true),
+            new ResourceDTO()
+                .setResourceId("r-include-include")
+                .setTenantId("t-1")
+                .setAssociatedWithEnvoy(true),
+            new ResourceDTO()
+                .setResourceId("r-include-exclude")
+                .setTenantId("t-1")
+                .setAssociatedWithEnvoy(true),
+            new ResourceDTO()
+                .setResourceId("r-exclude-exclude")
+                .setTenantId("t-1")
+                .setAssociatedWithEnvoy(true)
+        ));
+
+    setupEnvoyResourceManagement();
+
+    setupMonitorContentRenderer();
+
+    // use a regular create to save the original monitor and perform bindings
+    final Monitor original = monitorManagement.createMonitor(
+        "t-1",
+        new MonitorCU()
+            .setExcludedResourceIds(Set.of("r-exclude-include", "r-exclude-exclude"))
+            .setLabelSelector(emptyMap())
+            .setLabelSelectorMethod(LabelSelectorMethod.AND)
+            .setMonitorType(MonitorType.cpu)
+            .setAgentType(AgentType.TELEGRAF)
+            .setInterval(Duration.ofSeconds(60))
+            .setContent("{}")
+    );
+
+    // sanity check bindings
+    final List<BoundMonitor> origBound = boundMonitorRepository
+        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1");
+    assertThat(origBound).extracting(BoundMonitor::getResourceId)
+        .containsExactlyInAnyOrder("r-include-include", "r-include-exclude");
+
+    // and verify up to this point
+    verify(monitorEventProducer).sendMonitorEvent(
+        new MonitorBoundEvent().setEnvoyId("envoy-r-include-include")
+    );
+
+    // EXECUTE
+
+    monitorManagement.updateMonitor(
+        "t-1",
+        original.getId(),
+        new MonitorCU()
+            .setExcludedResourceIds(Set.of("r-include-exclude", "r-exclude-exclude"))
+            .setMonitorType(MonitorType.cpu)
+            .setAgentType(AgentType.TELEGRAF)
+    );
+
+    // VERIFY
+
+    final List<BoundMonitor> updatedBound = boundMonitorRepository
+        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1");
+    assertThat(updatedBound).extracting(BoundMonitor::getResourceId)
+        .containsExactlyInAnyOrder("r-include-include", "r-exclude-include");
+
+    // 1x from create and 1x from update (unbinding)
+    verify(monitorEventProducer, times(2)).sendMonitorEvent(
+        new MonitorBoundEvent().setEnvoyId("envoy-r-include-exclude")
+    );
+    verify(monitorEventProducer).sendMonitorEvent(
+        new MonitorBoundEvent().setEnvoyId("envoy-r-exclude-include")
+    );
+
+    // 1x from create and 1x from update
+    verify(resourceApi, times(2))
+        .getResourcesWithLabels("t-1", emptyMap(), LabelSelectorMethod.AND);
+
+    verify(envoyResourceManagement).getOne("t-1", "r-exclude-include");
+    verify(envoyResourceManagement).getOne("t-1", "r-include-exclude");
+    verify(envoyResourceManagement, times(2)).getOne("t-1", "r-include-include");
+    verify(envoyResourceManagement, never()).getOne("t-1", "r-exclude-exclude");
+
+    verifyNoMoreInteractions(resourceApi, envoyResourceManagement, monitorEventProducer);
+  }
+
+  @Test
+  public void testUpdate_excludedResourceIds_labelChangeSelectsExcluded() throws InvalidTemplateException {
+
+    when(resourceApi.getResourcesWithLabels("t-1", Map.of("stage","before"), LabelSelectorMethod.AND))
+        .thenReturn(List.of(
+            new ResourceDTO()
+                // a "control" resource that'll be bound in both cases
+                .setResourceId("r-include-include")
+                .setTenantId("t-1")
+                .setAssociatedWithEnvoy(true)
+        ));
+    when(resourceApi.getResourcesWithLabels("t-1", Map.of("stage","after"), LabelSelectorMethod.AND))
+        .thenReturn(List.of(
+            new ResourceDTO()
+                .setResourceId("r-include-include")
+                .setTenantId("t-1")
+                .setAssociatedWithEnvoy(true),
+            new ResourceDTO()
+                // a resource that is newly selected and newly binds since it is not excluded
+                .setResourceId("r-absent-include")
+                .setTenantId("t-1")
+                .setAssociatedWithEnvoy(true),
+            new ResourceDTO()
+                // a resource that is newly selected, but should be excluded by the monitor still
+                .setResourceId("r-absent-exclude")
+                .setTenantId("t-1")
+                .setAssociatedWithEnvoy(true)
+        ));
+
+    setupEnvoyResourceManagement();
+
+    setupMonitorContentRenderer();
+
+    // use a regular create to save the original monitor and perform bindings
+    final Monitor original = monitorManagement.createMonitor(
+        "t-1",
+        new MonitorCU()
+            // setup the exclusion that comes into play after labels get changed
+            .setExcludedResourceIds(Set.of("r-absent-exclude"))
+            .setLabelSelector(Map.of("stage","before"))
+            .setLabelSelectorMethod(LabelSelectorMethod.AND)
+            .setMonitorType(MonitorType.cpu)
+            .setAgentType(AgentType.TELEGRAF)
+            .setInterval(Duration.ofSeconds(60))
+            .setContent("{}")
+    );
+
+    // sanity check bindings
+    final List<BoundMonitor> origBound = boundMonitorRepository
+        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1");
+    assertThat(origBound).extracting(BoundMonitor::getResourceId)
+        .containsExactlyInAnyOrder("r-include-include");
+
+    // and verify up to this point
+    verify(monitorEventProducer).sendMonitorEvent(
+        new MonitorBoundEvent().setEnvoyId("envoy-r-include-include")
+    );
+
+    // EXECUTE
+
+    monitorManagement.updateMonitor(
+        "t-1",
+        original.getId(),
+        new MonitorCU()
+            .setLabelSelector(Map.of("stage","after"))
+            .setMonitorType(MonitorType.cpu)
+            .setAgentType(AgentType.TELEGRAF)
+    );
+
+    // VERIFY
+
+    final List<BoundMonitor> updatedBound = boundMonitorRepository
+        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1");
+    assertThat(updatedBound).extracting(BoundMonitor::getResourceId)
+        .containsExactlyInAnyOrder("r-include-include", "r-absent-include");
+
+    verify(monitorEventProducer).sendMonitorEvent(
+        new MonitorBoundEvent().setEnvoyId("envoy-r-include-include")
+    );
+    verify(monitorEventProducer).sendMonitorEvent(
+        new MonitorBoundEvent().setEnvoyId("envoy-r-absent-include")
+    );
+    // and never for the absent-exclude one
+    verify(monitorEventProducer, never()).sendMonitorEvent(
+        new MonitorBoundEvent().setEnvoyId("envoy-r-absent-exclude")
+    );
+
+    verify(resourceApi)
+        .getResourcesWithLabels("t-1", Map.of("stage","before"), LabelSelectorMethod.AND);
+    verify(resourceApi)
+        .getResourcesWithLabels("t-1", Map.of("stage","after"), LabelSelectorMethod.AND);
+
+    verify(envoyResourceManagement).getOne("t-1", "r-include-include");
+    verify(envoyResourceManagement).getOne("t-1", "r-absent-include");
+    verify(envoyResourceManagement, never()).getOne("t-1", "r-absent-exclude");
+
+    verifyNoMoreInteractions(resourceApi, envoyResourceManagement, monitorEventProducer);
+  }
+
+  private void setupMonitorContentRenderer() throws InvalidTemplateException {
+    when(monitorContentRenderer.render(any(), any()))
+        // just return the given content
+        .then(invocationOnMock -> invocationOnMock.getArgument(0));
+  }
+
+  private void setupEnvoyResourceManagement() {
+    when(envoyResourceManagement.getOne(any(), any()))
+        .then(invocationOnMock -> CompletableFuture.completedFuture(
+            new ResourceInfo()
+                .setTenantId(invocationOnMock.getArgument(0))
+                .setResourceId(invocationOnMock.getArgument(1))
+                .setEnvoyId("envoy-" + invocationOnMock.getArgument(1))
+        ));
+  }
+
+  /*
+  TODO test excluded resource bindings
+  - on resource event
+  - invalid update, was using resource ID selector, now adding exclusions
+  - invalid update, was using exclusions, now adding resource ID selector
+   */
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,9 +34,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -336,6 +336,7 @@ public class MonitorApiControllerTest {
     DetailedMonitorInput create = podamFactory.manufacturePojo(DetailedMonitorInput.class);
     create.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
     create.setLabelSelector(null);
+    create.setExcludedResourceIds(null);
 
     mockMvc.perform(post(url)
         .content(objectMapper.writeValueAsString(create))
@@ -408,6 +409,7 @@ public class MonitorApiControllerTest {
 
     DetailedMonitorInput update = podamFactory.manufacturePojo(DetailedMonitorInput.class);
     update.setLabelSelector(null);
+    update.setExcludedResourceIds(null);
     update.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
 
     mockMvc.perform(put(url)
@@ -458,6 +460,7 @@ public class MonitorApiControllerTest {
     // ensure only one of these is set
     monitor.setResourceId(RandomStringUtils.randomAlphabetic(10));
     monitor.setLabelSelector(null);
+    monitor.setExcludedResourceIds(null);
 
     when(monitorManagement.getMonitor(anyString(), any()))
         .thenReturn(Optional.of(monitor));
@@ -680,6 +683,7 @@ public class MonitorApiControllerTest {
 
     DetailedMonitorInput create = podamFactory.manufacturePojo(DetailedMonitorInput.class);
     create.setDetails(new LocalMonitorDetails().setPlugin(new Mem()));
+    create.setExcludedResourceIds(null);
     return create;
   }
 

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -46,6 +47,7 @@ public class DetailedMonitorOutputTest {
     final DetailedMonitorOutput detailedMonitorOutput = new DetailedMonitorOutput()
         .setId("m-1")
         .setResourceId("r-1")
+        .setExcludedResourceIds(Set.of("r-excluded"))
         .setName("name-1")
         .setLabelSelector(
             Map.of("key1", "val1", "key2", "val2")
@@ -72,6 +74,7 @@ public class DetailedMonitorOutputTest {
     final DetailedMonitorOutput detailedMonitorOutput = new DetailedMonitorOutput()
         .setId("m-1")
         .setResourceId("r-1")
+        .setExcludedResourceIds(Set.of("r-excluded"))
         .setName("name-1")
         .setLabelSelector(
             Map.of("key1", "val1", "key2", "val2")

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidCreateMonitorValidatorTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidCreateMonitorValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,5 +117,23 @@ public class ValidCreateMonitorValidatorTest {
     assertThat(new ArrayList<>(errors).get(0).getMessage(), containsString(ValidCreateMonitor.DEFAULT_MESSAGE));
   }
 
+  @Test
+  public void testInvalid_BothResourceAndExcluded() {
+    final Mem plugin = new Mem();
 
+    final LocalMonitorDetails details = new LocalMonitorDetails();
+    details.setPlugin(plugin);
+
+    DetailedMonitorInput input = new DetailedMonitorInput()
+        .setDetails(details)
+        .setResourceId("r-1")
+        .setExcludedResourceIds(Set.of("r-2"));
+
+    final Set<ConstraintViolation<DetailedMonitorInput>> errors = validatorFactoryBean.validate(input,
+        ValidationGroups.Create.class);
+
+    assertThat(errors, hasSize(1));
+    assertThat(new ArrayList<>(errors).get(0).getMessage(), containsString(ValidCreateMonitor.DEFAULT_MESSAGE));
+
+  }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidUpdateMonitorValidatorTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidUpdateMonitorValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,6 +109,25 @@ public class ValidUpdateMonitorValidatorTest {
 
     assertThat(errors, hasSize(0));
   }
-  
+
+  @Test
+  public void testInvalid_BothResourceAndExcluded() {
+
+    final Mem plugin = new Mem();
+    final LocalMonitorDetails details = new LocalMonitorDetails();
+    details.setPlugin(plugin);
+
+    DetailedMonitorInput input = new DetailedMonitorInput()
+        .setDetails(details)
+        .setResourceId("r-1")
+        .setExcludedResourceIds(Set.of("r-2"));
+
+    final Set<ConstraintViolation<DetailedMonitorInput>> errors = validatorFactoryBean.validate(input,
+        ValidationGroups.Update.class);
+
+    assertThat(errors, hasSize(1));
+    assertThat(new ArrayList<>(errors).get(0).getMessage(), containsString(ValidUpdateMonitor.DEFAULT_MESSAGE));
+
+  }
 
 }

--- a/src/test/resources/DetailedMonitorOutputTest/local.json
+++ b/src/test/resources/DetailedMonitorOutputTest/local.json
@@ -1,6 +1,7 @@
 {
   "id": "m-1",
   "resourceId": "r-1",
+  "excludedResourceIds": ["r-excluded"],
   "name": "name-1",
   "labelSelector": {
     "key1": "val1",

--- a/src/test/resources/DetailedMonitorOutputTest/remote.json
+++ b/src/test/resources/DetailedMonitorOutputTest/remote.json
@@ -1,6 +1,7 @@
 {
   "id": "m-1",
   "resourceId": "r-1",
+  "excludedResourceIds": ["r-excluded"],
   "name": "name-1",
   "labelSelector": {
     "key1": "val1",


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-695

# What

Adds an `excludedResourceIds` field to monitors which allows for a monitor to be selectively excluded from binding to the given resource that would be normally be selected by labels.

# How

Tweaks the binding processing that happens during monitor creation and updates and resource events. There was also adjust model/DTO and validation changes needed to ensure that users can't improperly combine excludedResourceIds with a resourceId selector.

## How to test

The following primary scenarios are covered by the new tests
  - on monitor update, new exclusions
  - on monitor update, removed exclusions
  - on monitor update, new labels select resource that should be excluded
  - on monitor update, new labels select resource that should be excluded
  - on resource event
  - invalid update, was using resource ID selector, now adding exclusions
  - invalid update, was using exclusions, now adding resource ID selector

Speaking of which, all of the new tests were added to a new test file to avoid further bloating the infamous `MonitorManagementTest` file. I also wanted to make use of the embedded database rather than mock all the repository interactions.

# Depends on

https://github.com/racker/salus-telemetry-model/pull/96