### PR TITLE
Support polymorphic metadata values

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
@@ -93,10 +93,9 @@ public class MonitorContentRenderer {
     //
     //   "${resource.metadata.url}"
     //
-    // It then has a matching group to group the is best explained with an example:
     // if the delimiters is configured with the following, note the required space between delimiters
     //   ${ }
-    // then the regex pattern becomes
+    // then the final regex pattern becomes
     //   "\$\{(.+?)\}"
     quotedPlaceholderPattern = Pattern.compile("\"" +
         escapeRegexChars(properties.getPlaceholderDelimiters())

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
@@ -16,16 +16,21 @@
 
 package com.rackspace.salus.monitor_management.services;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.monitor_management.config.MonitorContentProperties;
 import com.rackspace.salus.monitor_management.errors.InvalidTemplateException;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.samskivert.mustache.Escapers;
 import com.samskivert.mustache.Mustache;
 import com.samskivert.mustache.Mustache.Compiler;
+import com.samskivert.mustache.Mustache.Formatter;
 import com.samskivert.mustache.MustacheException;
 import com.samskivert.mustache.Template;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -35,16 +40,42 @@ public class MonitorContentRenderer {
   private static final String CTX_RESOURCE = "resource";
 
   private final Compiler mustacheCompiler;
+  private final Pattern quotedPlaceholderPattern;
+  private final ObjectMapper objectMapper;
 
   @Autowired
-  public MonitorContentRenderer(MonitorContentProperties properties) {
+  public MonitorContentRenderer(MonitorContentProperties properties, ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
     mustacheCompiler = Mustache.compiler()
         .withEscaper(Escapers.NONE)
-        .withDelims(properties.getPlaceholderDelimiters());
+        .withDelims(properties.getPlaceholderDelimiters())
+        .withFormatter(new JsonValueFormatter());
+
+    // The following is best explained with an example:
+    // if the delimiters is configured with the following, note the required space between delimiters
+    //   ${ }
+    // then the regex pattern becomes
+    //   "(\$\{.+?\})"
+    quotedPlaceholderPattern = Pattern.compile("\"(" +
+        escapeRegexChars(properties.getPlaceholderDelimiters())
+            .replace(" ", ".+?")
+        + ")\"");
+  }
+
+  private static String escapeRegexChars(String raw) {
+    // This replacement is MUCH simpler than it looks -- it's just putting a backslash
+    // in front of the characters
+    //   $ { } [ ]
+    // since they have special meaning in regex patterns and the placeholder delimiters are likely
+    // to use some or all of those characters.
+    return raw.replaceAll("[${}[\\\\]]", "\\\\$0");
   }
 
   String render(String rawContent, ResourceDTO resource) throws InvalidTemplateException {
-    final Template template = mustacheCompiler.compile(rawContent);
+
+    final Template template = mustacheCompiler.compile(
+        unquotePlaceholders(rawContent)
+    );
 
     final Map<String, Object> context = new HashMap<>();
     context.put(CTX_RESOURCE, resource);
@@ -56,6 +87,73 @@ public class MonitorContentRenderer {
           String.format("Unable to render monitor content template, content=%s, resource=%s",
               rawContent, resource),
           e);
+    }
+  }
+
+  /**
+   * This method works in conjunction with {@link JsonValueFormatter} by preparing the following
+   * type of content block:
+   * <pre>
+   *   {
+   *     "interval": "${resource.metadata.per_resource_interval}",
+   *     "host": "${resource.metadata.custom_host}"
+   *   }
+   * </pre>
+   * into
+   * <pre>
+   *   {
+   *     "interval": ${resource.metadata.per_resource_interval},
+   *     "host": ${resource.metadata.custom_host}
+   *   }
+   * </pre>
+   * so that non-string metadata values can be rendered correctly along with string values. Given
+   * this metadata:
+   * <pre>
+   *   {
+   *     "metadata": {
+   *       "per_resource_interval": 30,
+   *       "custom_host": "host-123"
+   *     }
+   *   }
+   * </pre>
+   * ...the content is rendered into:
+   * <pre>
+   *   {
+   *     "interval" 30,
+   *     "host": "host-123"
+   *   }
+   * </pre>
+   * @param rawContent
+   * @return
+   */
+  private String unquotePlaceholders(String rawContent) {
+    final Matcher m = quotedPlaceholderPattern.matcher(rawContent);
+
+    final StringBuilder result = new StringBuilder();
+
+    while (m.find()) {
+      m.appendReplacement(result, "$1");
+    }
+    m.appendTail(result);
+
+    return result.toString();
+  }
+
+  /**
+   * This formatter performs the second half of the processing described in
+   * {@link MonitorContentRenderer#unquotePlaceholders(String)}. Each value is formatting using
+   * a JSON {@link ObjectMapper} to ensure JSON compatible rendering of scalar and non-scalar types.
+   */
+  private class JsonValueFormatter implements Formatter {
+
+    @Override
+    public String format(Object value) {
+      try {
+        return objectMapper.writeValueAsString(value);
+      } catch (JsonProcessingException e) {
+        throw new IllegalArgumentException(
+            String.format("Unable to format the value '%s' while rendering monitor content", value), e);
+      }
     }
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentRenderer.java
@@ -72,6 +72,10 @@ public class MonitorContentRenderer {
   public MonitorContentRenderer(MonitorContentProperties properties, ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;
 
+    if (REDELIMS.equals(properties.getPlaceholderDelimiters())) {
+      throw new IllegalStateException("Configured placeholder delimiters clash with re-delimiters");
+    }
+
     mustacheWholeValueCompiler = Mustache.compiler()
         .withEscaper(Escapers.NONE)
         // Use a delimiter that differs from the configured one

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentRendererTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentRendererTest.java
@@ -138,7 +138,7 @@ public class MonitorContentRendererTest {
         resource
     );
 
-    assertThat(rendered, equalTo("os=\"linux\""));
+    assertThat(rendered, equalTo("os=linux"));
   }
 
   @Test
@@ -155,7 +155,7 @@ public class MonitorContentRendererTest {
         resource
     );
 
-    assertThat(rendered, equalTo("os=\"linux\""));
+    assertThat(rendered, equalTo("os=linux"));
   }
 
   @Test
@@ -172,6 +172,6 @@ public class MonitorContentRendererTest {
         resource
     );
 
-    assertThat(rendered, equalTo("os=\"linux\""));
+    assertThat(rendered, equalTo("os=linux"));
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -859,7 +859,7 @@ public class MonitorManagementTest {
     reset(envoyResourceManagement, resourceApi);
 
     // This resource will result in a change to rendered content
-    final Map<String, String> r1metadata = new HashMap<>();
+    final Map<String, Object> r1metadata = new HashMap<>();
     r1metadata.put("ping_ip", "something_else");
     r1metadata.put("address", "localhost");
     final ResourceDTO r1 = new ResourceDTO()
@@ -872,7 +872,7 @@ public class MonitorManagementTest {
         .thenReturn(r1);
 
     // ...and this resource will NOT since both metadata values are the same
-    final Map<String, String> r2metadata = new HashMap<>();
+    final Map<String, Object> r2metadata = new HashMap<>();
     r2metadata.put("ping_ip", "localhost");
     r2metadata.put("address", "localhost");
     final ResourceDTO r2 = new ResourceDTO()

--- a/src/test/resources/MonitorContentRendererTest_content.json
+++ b/src/test/resources/MonitorContentRendererTest_content.json
@@ -2,6 +2,7 @@
   "host": "${resource.metadata.public_ip}",
   "embedded_string": "value=${resource.metadata.public_ip}",
   "dirs": "${resource.metadata.dirs}",
+  "embedded_list": "List is ${resource.metadata.dirs}",
   "count": "${resource.metadata.count}",
   "embedded_int": "value=${resource.metadata.count}"
 }

--- a/src/test/resources/MonitorContentRendererTest_content.json
+++ b/src/test/resources/MonitorContentRendererTest_content.json
@@ -1,0 +1,7 @@
+{
+  "host": "${resource.metadata.public_ip}",
+  "embedded_string": "value=${resource.metadata.public_ip}",
+  "dirs": "${resource.metadata.dirs}",
+  "count": "${resource.metadata.count}",
+  "embedded_int": "value=${resource.metadata.count}"
+}

--- a/src/test/resources/MonitorContentRendererTest_rendered.json
+++ b/src/test/resources/MonitorContentRendererTest_rendered.json
@@ -1,0 +1,7 @@
+{
+  "host": "150.1.2.3",
+  "embedded_string": "value=\"150.1.2.3\"",
+  "dirs": ["/tmp","/usr"],
+  "count": 5,
+  "embedded_int": "value=5"
+}

--- a/src/test/resources/MonitorContentRendererTest_rendered.json
+++ b/src/test/resources/MonitorContentRendererTest_rendered.json
@@ -1,7 +1,8 @@
 {
   "host": "150.1.2.3",
-  "embedded_string": "value=\"150.1.2.3\"",
+  "embedded_string": "value=150.1.2.3",
   "dirs": ["/tmp","/usr"],
+  "embedded_list": "List is [/tmp,/usr]",
   "count": 5,
   "embedded_int": "value=5"
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-491

# What


# How

Given that `Resource`'s metadata field is changed to a `Map<String,Object>` this change alters the monitor content renderer to allow specific uses of placeholder variables, such as

```
   "some_config": "${resource.metadata.listOfSomething}"
```

to be replaced by a string (as it is currently), number, array, or object. For a list that would become:

```
    "some_config": ["item1","item2"]
```

## NOTE

As of https://github.com/racker/salus-telemetry-monitor-management/pull/118 this feature is not as useful since there are any remaining list-type fields since we realized they need to be scalars to handle downstream correlation of events, tickets, etc.

## How to test

Unit test updated

# Why

<Why was the final approach taken? Were alternatives considered?>

# TODO

<outstanding tasks before this PR is considered 'ready'>
