### PR TITLE
Tweak order of translation operations

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
@@ -33,7 +33,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableMonitorType(MonitorType.http_response)
 public class HttpResponse extends RemotePlugin {
   @NotEmpty
-  String address;
+  String url;
   String httpProxy;
   @ValidGoDuration
   String responseTimeout;

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
@@ -283,7 +283,7 @@ public class MonitorContentTranslationServiceTest {
             // TEST type is renamed
             .setMonitorType(MonitorType.cpu),
         new MonitorTranslationOperator()
-            .setName("dontMatch")
+            .setName("renameField")
             .setAgentType(AgentType.TELEGRAF)
             .setAgentVersions(null)
             .setTranslatorSpec(buildRenameFieldSpec("beforeTranslate", "afterTranslate"))

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
@@ -34,6 +34,7 @@ import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.repositories.MonitorTranslationOperatorRepository;
 import com.rackspace.salus.telemetry.translators.MonitorTranslator;
 import com.rackspace.salus.telemetry.translators.RenameFieldKeyTranslator;
+import com.rackspace.salus.telemetry.translators.RenameTypeTranslator;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
@@ -228,14 +229,14 @@ public class MonitorContentTranslationServiceTest {
             .setName("match")
             .setAgentType(AgentType.TELEGRAF)
             .setAgentVersions(null)
-            .setTranslatorSpec(buildRenameSpec("matches", "afterMatch"))
+            .setTranslatorSpec(buildRenameFieldSpec("matches", "afterMatch"))
             // TEST matching monitor type
             .setMonitorType(MonitorType.cpu),
         new MonitorTranslationOperator()
             .setName("dontMatch")
             .setAgentType(AgentType.TELEGRAF)
             .setAgentVersions(null)
-            .setTranslatorSpec(buildRenameSpec("dontMatch", "neverUsed"))
+            .setTranslatorSpec(buildRenameFieldSpec("dontMatch", "neverUsed"))
             // TEST mismatching monitor type
             .setMonitorType(MonitorType.mem)
     );
@@ -272,20 +273,69 @@ public class MonitorContentTranslationServiceTest {
   }
 
   @Test
+  public void testTranslate_match_byMonitorType_afterRename() throws JsonProcessingException {
+    final List<MonitorTranslationOperator> operators = List.of(
+        new MonitorTranslationOperator()
+            .setName("renameType")
+            .setAgentType(AgentType.TELEGRAF)
+            .setAgentVersions(null)
+            .setTranslatorSpec(buildRenameTypeSpec("newType"))
+            // TEST type is renamed
+            .setMonitorType(MonitorType.cpu),
+        new MonitorTranslationOperator()
+            .setName("dontMatch")
+            .setAgentType(AgentType.TELEGRAF)
+            .setAgentVersions(null)
+            .setTranslatorSpec(buildRenameFieldSpec("beforeTranslate", "afterTranslate"))
+            // TEST translation still matches when original type has been altered
+            .setMonitorType(MonitorType.cpu)
+    );
+
+    when(repository.findAllByAgentType(any()))
+        .thenReturn(operators);
+
+    final List<BoundMonitor> boundMonitors = List.of(new BoundMonitor()
+        .setMonitor(
+            new Monitor()
+                .setContent("not used")
+                .setAgentType(AgentType.TELEGRAF)
+                .setSelectorScope(ConfigSelectorScope.LOCAL)
+                .setMonitorType(MonitorType.cpu)
+        )
+        .setRenderedContent(buildRenderedContent("cpu",
+            "beforeTranslate", "value-matches"))
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH));
+
+    // EXECUTE
+
+    final List<BoundMonitorDTO> dtos =
+        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "1.11.3"));
+
+    assertThat(dtos).hasSize(1);
+
+    final JsonContent<Object> jsonContent = json.from(dtos.get(0).getRenderedContent());
+    assertThat(jsonContent).hasJsonPathValue("$.type", "newType");
+    assertThat(jsonContent).hasJsonPathValue("$.afterTranslate", "value-matches");
+    assertThat(jsonContent).hasEmptyJsonPathValue("$.beforeTranslate");
+    assertThat(jsonContent).hasEmptyJsonPathValue("$.neverUsed");
+  }
+
+  @Test
   public void testTranslate_match_bySelectorScope() throws JsonProcessingException {
     final List<MonitorTranslationOperator> operators = List.of(
         new MonitorTranslationOperator()
             .setName("match")
             .setAgentType(AgentType.TELEGRAF)
             .setAgentVersions(null)
-            .setTranslatorSpec(buildRenameSpec("matches", "afterMatch"))
+            .setTranslatorSpec(buildRenameFieldSpec("matches", "afterMatch"))
             // TEST matching selector scope
             .setSelectorScope(ConfigSelectorScope.LOCAL),
         new MonitorTranslationOperator()
             .setName("dontMatch")
             .setAgentType(AgentType.TELEGRAF)
             .setAgentVersions(null)
-            .setTranslatorSpec(buildRenameSpec("dontMatch", "neverUsed"))
+            .setTranslatorSpec(buildRenameFieldSpec("dontMatch", "neverUsed"))
             // TEST mismatching scope
             .setSelectorScope(ConfigSelectorScope.REMOTE)
     );
@@ -438,12 +488,16 @@ public class MonitorContentTranslationServiceTest {
             .setName("rename-"+renameFromField)
             .setAgentType(agentType)
             .setAgentVersions(agentVersions)
-            .setTranslatorSpec(buildRenameSpec(renameFromField, "new_field"))
+            .setTranslatorSpec(buildRenameFieldSpec(renameFromField, "new_field"))
     );
   }
 
-  private MonitorTranslator buildRenameSpec(String from, String to) {
+  private MonitorTranslator buildRenameFieldSpec(String from, String to) {
     return new RenameFieldKeyTranslator().setFrom(from).setTo(to);
+  }
+
+  private MonitorTranslator buildRenameTypeSpec(String to) {
+    return new RenameTypeTranslator().setValue(to);
   }
 
   private String buildRenderedContent(String type, String... fieldAndValue)

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponseConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponseConversionTest.java
@@ -111,7 +111,7 @@ public class HttpResponseConversionTest {
     assertThat(plugin).isInstanceOf(HttpResponse.class);
 
     final HttpResponse httpPlugin = (HttpResponse) plugin;
-    assertThat(httpPlugin.getAddress()).isEqualTo("http://localhost");
+    assertThat(httpPlugin.getUrl()).isEqualTo("http://localhost");
     assertThat(httpPlugin.getHttpProxy()).isEqualTo("http://localhost:8888");
     assertThat(httpPlugin.getResponseTimeout()).isEqualTo("5s");
     assertThat(httpPlugin.getMethod()).isEqualTo("GET");
@@ -145,7 +145,7 @@ public class HttpResponseConversionTest {
     final RemoteMonitorDetails details = new RemoteMonitorDetails();
     details.setMonitoringZones(Collections.singletonList("z-1"));
     final HttpResponse plugin = new HttpResponse();
-    plugin.setAddress("http://localhost");
+    plugin.setUrl("http://localhost");
     plugin.setHttpProxy("http://localhost:8888");
     plugin.setResponseTimeout("5s");
     plugin.setMethod("GET");

--- a/src/test/resources/ConversionTests/MonitorConversionServiceTest_http.json
+++ b/src/test/resources/ConversionTests/MonitorConversionServiceTest_http.json
@@ -1,6 +1,6 @@
 {
   "type": "http_response",
-  "address": "http://localhost",
+  "url": "http://localhost",
   "httpProxy": "http://localhost:8888",
   "responseTimeout": "5s",
   "method": "GET",


### PR DESCRIPTION
# What

1. Changes the field in http monitors from `address` to `url`
1. Renamed `translateOne` to `translateBoundMonitor`
1. Updates the order things are done in translations

# How

1. Renamed things
2. Renamed things
3. Get the list of all operations to be performed on a bound monitor and pass that to `translateBoundMonitor` instead of having it receive all and then decide what ones should be executed or not.

## How to test

All tests still pass?

# Why

1. For the http change, `address` was what the old telegraf version required.  Now we can use whatever we like and I just like `url` more.

2. When reading the code I wasn't sure if `One` referred to the number of operations being translated at a time or the number of bound monitors.  This might be clearer?

3. For the translation change, previously due to the `renameType` operations the order the operations were performed in could have caused problems.  i.e. if the type was changed prior to other operations being ran, their `type` test would have failed and they would have been skipped.