### PR TITLE
 Use integer instead of int 

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Dns.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Dns.java
@@ -42,7 +42,7 @@ public class Dns extends RemotePlugin {
   @NotNull
   RecordType recordType = RecordType.A;
   @NotNull
-  int port = 53;
+  Integer port = 53;
   @ValidGoDuration
   String timeout;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
@@ -40,7 +40,7 @@ public class NetResponse extends RemotePlugin {
   String host;
 
   @NotNull
-  int port;
+  Integer port;
 
   @ValidGoDuration
   String timeout;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -53,8 +53,10 @@ import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.monitor_management.web.model.Protocol;
 import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Mem;
+import com.rackspace.salus.monitor_management.web.model.telegraf.NetResponse;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidCreateMonitor;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidUpdateMonitor;
@@ -392,6 +394,27 @@ public class MonitorApiControllerTest {
         .characterEncoding(StandardCharsets.UTF_8.name()))
         .andExpect(status().isBadRequest())
         .andExpect(validationError("details.plugin.target", "must not be empty"));
+  }
+
+  @Test
+  public void testCreateRemoteNetResponseMonitor_NoPort() throws Exception {
+    String tenantId = RandomStringUtils.randomAlphabetic(8);
+    String url = String.format("/api/tenant/%s/monitors", tenantId);
+    DetailedMonitorInput create = podamFactory.manufacturePojo(DetailedMonitorInput.class);
+    create.setDetails(new RemoteMonitorDetails()
+        .setMonitoringZones(Collections.singletonList("myzone"))
+        .setPlugin(new NetResponse()
+            // If no port is set validation should fail
+            .setProtocol(Protocol.tcp)
+            .setHost(RandomStringUtils.randomAlphabetic(10))))
+        .setResourceId("");
+
+    mockMvc.perform(post(url)
+        .content(objectMapper.writeValueAsString(create))
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andExpect(status().isBadRequest())
+        .andExpect(validationError("details.plugin.port", "must not be null"));
   }
 
   @Test


### PR DESCRIPTION
# What

Use Integers instead of int in plugin classes.

## How to test

Manually and added a test.

# Why

Previously you could provide this payload and it would default the port to 0 rather than throwing an error.
```
{
  "labelSelector": {},
	"interval": 60,
  "details": {
    "type": "remote",
		"monitoringZones": ["dev"],
    "plugin": {
      "type": "ssl",
      "target": "rackspace.com"
    }
  }
}
```

# TODO
I considered changing some `boolean` fields to `Boolean` but for those it probably makes sense to default to false.