### PR TITLE
Add apache monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalPlugin.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalPlugin.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.rackspace.salus.monitor_management.web.model.oracle.Dataguard;
 import com.rackspace.salus.monitor_management.web.model.oracle.Rman;
 import com.rackspace.salus.monitor_management.web.model.oracle.Tablespace;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Apache;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Cpu;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Disk;
 import com.rackspace.salus.monitor_management.web.model.telegraf.DiskIo;
@@ -36,6 +37,7 @@ import com.rackspace.salus.monitor_management.web.model.telegraf.System;
 
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonSubTypes({
+    @Type(name = "apache", value = Apache.class),
     @Type(name = "cpu", value = Cpu.class),
     @Type(name = "disk", value = Disk.class),
     @Type(name = "diskio", value = DiskIo.class),

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Apache.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Apache.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.telegraf;
+
+import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
+import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.validator.ValidGoDuration;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import javax.validation.constraints.NotBlank;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.apache)
+public class Apache extends LocalPlugin {
+  @NotBlank
+  String url;
+  String username;
+  String password;
+  @ValidGoDuration
+  String timeout;
+  String tlsCa;
+  String tlsCert;
+  String tlsKey;
+  Boolean insecureSkipVerify;
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/ApacheConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/ApacheConversionTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.telegraf;
+
+import static com.rackspace.salus.test.JsonTestUtils.readContent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
+import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
+import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
+import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@JsonTest
+@Import({MonitorConversionService.class, MetadataUtils.class})
+public class ApacheConversionTest {
+  @Configuration
+  public static class TestConfig { }
+
+  @MockBean
+  PatchHelper patchHelper;
+
+  @MockBean
+  PolicyApi policyApi;
+
+  @MockBean
+  MonitorRepository monitorRepository;
+
+  @Autowired
+  MonitorConversionService conversionService;
+
+  @Autowired
+  MetadataUtils metadataUtils;
+
+  @Test
+  public void convertFromInput() throws JSONException, IOException {
+    final Map<String, String> labels = new HashMap<>();
+    labels.put("os", "linux");
+
+    final Apache plugin = new Apache()
+        .setUrl("rackspace.com")
+        .setUsername("user")
+        .setPassword("pass");
+
+    final LocalMonitorDetails details = new LocalMonitorDetails()
+        .setPlugin(plugin);
+
+    final DetailedMonitorInput input = new DetailedMonitorInput()
+        .setLabelSelector(labels)
+        .setDetails(details);
+    final MonitorCU result = conversionService.convertFromInput(
+        RandomStringUtils.randomAlphabetic(10), null, input);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
+    assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.LOCAL);
+    final String content = readContent("/ConversionTests/MonitorConversionServiceTest_apache.json");
+    JSONAssert.assertEquals(content, result.getContent(), true);
+  }
+
+  @Test
+  public void convertToOutput() throws IOException {
+    Map<String, String> labels = new HashMap<>();
+    labels.put("os", "linux");
+
+    final String content = readContent("/ConversionTests/MonitorConversionServiceTest_apache.json");
+
+    final UUID monitorId = UUID.randomUUID();
+
+    Monitor monitor = new Monitor()
+        .setId(monitorId)
+        .setAgentType(AgentType.TELEGRAF)
+        .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setLabelSelector(labels)
+        .setContent(content)
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
+
+    final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(monitorId.toString());
+    assertThat(result.getDetails()).isInstanceOf(LocalMonitorDetails.class);
+
+    final LocalMonitorDetails monitorDetails = (LocalMonitorDetails) result.getDetails();
+    final LocalPlugin plugin = monitorDetails.getPlugin();
+    assertThat(plugin).isInstanceOf(Apache.class);
+
+    final Apache expected = new Apache()
+        .setUrl("rackspace.com")
+        .setUsername("user")
+        .setPassword("pass");
+    assertThat(plugin).isEqualTo(expected);
+  }
+}

--- a/src/test/resources/ConversionTests/MonitorConversionServiceTest_apache.json
+++ b/src/test/resources/ConversionTests/MonitorConversionServiceTest_apache.json
@@ -1,0 +1,11 @@
+{
+  "type": "apache",
+  "url": "rackspace.com",
+  "username": "user",
+  "password": "pass",
+  "timeout": null,
+  "tlsCa": null,
+  "tlsCert": null,
+  "tlsKey": null,
+  "insecureSkipVerify": null
+}


### PR DESCRIPTION
# What

Adds the apache monitor that will be tied to https://github.com/influxdata/telegraf/tree/master/plugins/inputs/apache

# How

Copied a previous PR for adding a monitor.

Some fields of note:

I set `insecureSkipVerify` to `Boolean` and not `boolean` so it defaults to null.  It only needs to be set if the other tls options are included so a default of null is what we want.

Instead of `responseTimeout` I used `timeout`.  Having a consistent timeout field across our monitors seems sane.

Here is my previous discovery info about the telegraf plugin that shows the ele metrics do map to these new ones - https://github.com/Rackspace-Segment-Support/salus-docs-internal/blob/master/migration/ele/check-to-monitor-mapping.md#agentapache

# Why

We need it for the migration.

# TODO

Add translations.
Another PR that tweaks some other monitors' fields.

