### PR TITLE
Fix small things in monitor models

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Cpu.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Cpu.java
@@ -25,7 +25,7 @@ import com.rackspace.salus.telemetry.model.MonitorType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.cpu)
 public class Cpu extends LocalPlugin {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Disk.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Disk.java
@@ -25,7 +25,7 @@ import javax.validation.constraints.NotBlank;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.disk)
 public class Disk extends LocalPlugin {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIo.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIo.java
@@ -24,7 +24,7 @@ import com.rackspace.salus.telemetry.model.MonitorType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.diskio)
 public class DiskIo extends LocalPlugin {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
@@ -28,7 +28,7 @@ import javax.validation.constraints.Pattern;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.http)
 public class HttpResponse extends RemotePlugin {
@@ -36,7 +36,7 @@ public class HttpResponse extends RemotePlugin {
   String url;
   String httpProxy;
   @ValidGoDuration
-  String responseTimeout;
+  String timeout;
   @Pattern(regexp = "GET|PUT|POST|DELETE|HEAD|OPTIONS|PATCH|TRACE", message = "invalid http method")
   String method;
   boolean followRedirects;
@@ -45,6 +45,6 @@ public class HttpResponse extends RemotePlugin {
   String tlsCa;
   String tlsCert;
   String tlsKey;
-  boolean insecureSkipVerify;
+  Boolean insecureSkipVerify;
   Map<String, String> headers;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Mem.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Mem.java
@@ -21,7 +21,9 @@ import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.mem)
 public class Mem extends LocalPlugin {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Mysql.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Mysql.java
@@ -29,7 +29,7 @@ import javax.validation.constraints.Pattern;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.mysql)
 public class Mysql extends LocalPlugin {
@@ -59,4 +59,5 @@ public class Mysql extends LocalPlugin {
   String tlsCa;
   String tlsCert;
   String tlsKey;
+  Boolean insecureSkipVerify;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlRemote.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlRemote.java
@@ -28,7 +28,7 @@ import javax.validation.constraints.Pattern;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.mysql)
 public class MysqlRemote extends RemotePlugin {
@@ -56,4 +56,5 @@ public class MysqlRemote extends RemotePlugin {
   String tlsCa;
   String tlsCert;
   String tlsKey;
+  Boolean insecureSkipVerify;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
@@ -25,7 +25,7 @@ import javax.validation.constraints.NotEmpty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.ping)
 public class Ping extends RemotePlugin {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Postgresql.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Postgresql.java
@@ -30,7 +30,7 @@ import javax.validation.constraints.Pattern;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.postgresql)
 @AtMostOneOf

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlRemote.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlRemote.java
@@ -29,7 +29,7 @@ import javax.validation.constraints.Pattern;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.postgresql)
 @AtMostOneOf

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Procstat.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Procstat.java
@@ -13,7 +13,7 @@ import lombok.EqualsAndHashCode;
 import javax.validation.Constraint;
 
 @Data
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.procstat)
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServer.java
@@ -28,7 +28,7 @@ import javax.validation.constraints.Pattern;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.sqlserver)
 public class SqlServer extends LocalPlugin {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerRemote.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerRemote.java
@@ -29,7 +29,7 @@ import javax.validation.constraints.Pattern;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.sqlserver)
 public class SqlServerRemote extends RemotePlugin {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/System.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/System.java
@@ -25,7 +25,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.system)
 public class System extends LocalPlugin {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
@@ -26,7 +26,7 @@ import javax.validation.constraints.NotBlank;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-@Data @EqualsAndHashCode(callSuper = true)
+@Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.ssl)
 public class X509Cert extends RemotePlugin {
@@ -37,5 +37,5 @@ public class X509Cert extends RemotePlugin {
   String tlsCa;
   String tlsCert;
   String tlsKey;
-  boolean insecureSkipVerify;
+  Boolean insecureSkipVerify;
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponseConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponseConversionTest.java
@@ -113,7 +113,7 @@ public class HttpResponseConversionTest {
     final HttpResponse httpPlugin = (HttpResponse) plugin;
     assertThat(httpPlugin.getUrl()).isEqualTo("http://localhost");
     assertThat(httpPlugin.getHttpProxy()).isEqualTo("http://localhost:8888");
-    assertThat(httpPlugin.getResponseTimeout()).isEqualTo("5s");
+    assertThat(httpPlugin.getTimeout()).isEqualTo("5s");
     assertThat(httpPlugin.getMethod()).isEqualTo("GET");
     assertThat(httpPlugin.isFollowRedirects()).isEqualTo(false);
     assertThat(httpPlugin.getBody()).isEqualTo("{'fake':'data'}");
@@ -121,7 +121,7 @@ public class HttpResponseConversionTest {
     assertThat(httpPlugin.getTlsCa()).isEqualTo("/etc/telegraf/ca.pem");
     assertThat(httpPlugin.getTlsCert()).isEqualTo("/etc/telegraf/cert.pem");
     assertThat(httpPlugin.getTlsKey()).isEqualTo("/etc/telegraf/key.pem");
-    assertThat(httpPlugin.isInsecureSkipVerify()).isEqualTo(false);
+    assertThat(httpPlugin.getInsecureSkipVerify()).isEqualTo(false);
     assertThat(httpPlugin.getHeaders().get("host")).isEqualTo("github.com");
 
     final LocalValidatorFactoryBean validatorFactoryBean = new LocalValidatorFactoryBean();
@@ -147,7 +147,7 @@ public class HttpResponseConversionTest {
     final HttpResponse plugin = new HttpResponse();
     plugin.setUrl("http://localhost");
     plugin.setHttpProxy("http://localhost:8888");
-    plugin.setResponseTimeout("5s");
+    plugin.setTimeout("5s");
     plugin.setMethod("GET");
     plugin.setFollowRedirects(false);
     plugin.setBody("{'fake':'data'}");

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509ConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509ConversionTest.java
@@ -120,7 +120,7 @@ public class X509ConversionTest {
     assertThat(x509Plugin.getTlsCa()).isEqualTo("/etc/telegraf/ca.pem");
     assertThat(x509Plugin.getTlsCert()).isEqualTo("/etc/telegraf/cert.pem");
     assertThat(x509Plugin.getTlsKey()).isEqualTo("/etc/telegraf/key.pem");
-    assertThat(x509Plugin.isInsecureSkipVerify()).isEqualTo(false);
+    assertThat(x509Plugin.getInsecureSkipVerify()).isEqualTo(false);
 
     final LocalValidatorFactoryBean validatorFactoryBean = new LocalValidatorFactoryBean();
     validatorFactoryBean.afterPropertiesSet();

--- a/src/test/resources/ConversionTests/MonitorConversionServiceTest_http.json
+++ b/src/test/resources/ConversionTests/MonitorConversionServiceTest_http.json
@@ -2,7 +2,7 @@
   "type": "http",
   "url": "http://localhost",
   "httpProxy": "http://localhost:8888",
-  "responseTimeout": "5s",
+  "timeout": "5s",
   "method": "GET",
   "followRedirects": false,
   "body": "{'fake':'data'}",

--- a/src/test/resources/ConversionTests/MonitorConversionServiceTest_mysql.json
+++ b/src/test/resources/ConversionTests/MonitorConversionServiceTest_mysql.json
@@ -21,5 +21,6 @@
   "intervalSlow": "3s",
   "tlsCa": "tlsCa",
   "tlsCert": "tlsCert",
-  "tlsKey": "tlsKey"
+  "tlsKey": "tlsKey",
+  "insecureSkipVerify": null
 }


### PR DESCRIPTION
# What

* Sets `@EqualsAndHashCode(callSuper = false)` instead of `callSuper = true`
   * There's no reason to call super and it can cause problems in tests
* Change http timeout field
* Use `Boolean` for skipping insecure things
   * That field is only used if the other tls settings are provided so a null default is best.
* Add `insecureSkipVerify` to a few places it was missing.
