### PR TITLE
Improved HTTP status returned for JDBC data integrity violations

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/RestExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.hibernate.JDBCException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -55,7 +56,11 @@ public class RestExceptionHandler extends
   @ExceptionHandler({JDBCException.class})
   public ResponseEntity<?> handleJDBCException(HttpServletRequest request, Exception e) {
     logRequestFailure(request, e);
-    return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.jdbcExceptionMessage);
+    if (e instanceof DataIntegrityViolationException) {
+      return respondWith(request, HttpStatus.BAD_REQUEST, e.getMessage());
+    } else {
+      return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.jdbcExceptionMessage);
+    }
   }
 
 }


### PR DESCRIPTION
# What

When creating a duplicate monitor translation operator, the REST API would respond with a 503 (service unavailable) and the message contained no indication of the constraint violation.

# How

Turns out all JDBC exceptions are getting lumped into the 503, so I added a conditional to check for the constraint violation and propagate the message from it along with a 400 response. It looks like a 409 might be a possible status code, so I'll open that choice up for a vote.

## How to test

Can't really test this one since even integration-unit tests don't seem to make use of the error handler.