### PR TITLE
Added constraint that monitorType be non-null when creating a translation operator

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorCreate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorCreate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ public class MonitorTranslationOperatorCreate {
   /**
    * Optional field, when set, indicates that the translation should only apply to monitors of this type.
    */
+  @NotNull
   MonitorType monitorType;
 
   /**


### PR DESCRIPTION
# What

Enforces the non-null requirement of `monitorType` on monitor translations. This corresponds with the uniqueness constraint change in https://github.com/racker/salus-telemetry-model/pull/102

## How to test

Existing unit tests