### PR TITLE
Remove exclusion of null values in procstat serialization

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Procstat.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Procstat.java
@@ -16,7 +16,6 @@ import javax.validation.Constraint;
 @EqualsAndHashCode(callSuper = true)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.procstat)
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @ProcstatValidator.OneOf()
 public class Procstat extends LocalPlugin {
     String pidFile;

--- a/src/test/resources/ConversionTests/MonitorConversionServiceTest_procstat.json
+++ b/src/test/resources/ConversionTests/MonitorConversionServiceTest_procstat.json
@@ -1,5 +1,11 @@
 {
   "type" : "procstat",
   "pidFile" : "/path/to/file",
+  "user": null,
+  "exe": null,
+  "pattern": null,
+  "systemdUnit": null,
+  "cgroup": null,
+  "winService": null,
   "processName" : "thisIsAProcess"
 }


### PR DESCRIPTION
# What

Remove the exclusion of null values in procstat serialization

# Why

We talked about this at a high level a while ago and decided whatever fields can be set on a monitor should be returned via the api.  It should not only return the fields that currently have a value.

This is the only remaining place the exclusion exists.