### PR TITLE
Fix ping timeout type

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.validator.ValidGoDuration;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import javax.validation.constraints.NotEmpty;
@@ -33,7 +34,8 @@ public class Ping extends RemotePlugin {
   String target;
   Integer count;
   Integer pingInterval;
-  Integer timeout;
+  @ValidGoDuration
+  String timeout;
   Integer deadline;
 
   // DO NOT include 'binary' or 'arguments' from telegraf raw config since those would expose an

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -271,7 +271,7 @@ public class MonitorConversionServiceTest {
         .add(Json.createObjectBuilder()
             .add("op", "replace")
             .add("path", "/details/plugin/timeout")
-            .add("value", 33))
+            .add("value", "33s"))
         .build());
 
     final MonitorCU result = conversionService.convertFromPatchInput(
@@ -304,7 +304,7 @@ public class MonitorConversionServiceTest {
         .setTarget("localhost")
         .setCount(1)
         .setPingInterval(2)
-        .setTimeout(3);
+        .setTimeout("3s");
 
     final Map<String, String> labels = new HashMap<>();
     labels.put("os", "linux");
@@ -355,7 +355,7 @@ public class MonitorConversionServiceTest {
         .setTarget("localhost")
         .setCount(1)
         .setPingInterval(2)
-        .setTimeout(3);
+        .setTimeout("3s");
 
     final Map<String, String> labels = new HashMap<>();
     labels.put("os", "linux");

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -72,7 +72,7 @@ public class MetadataUtilsTest {
   public void getMetadataFieldsForUpdate_Ping() {
     Ping ping = new Ping()
         .setCount(3)
-        .setTimeout(10)
+        .setTimeout("10s")
         .setPingInterval(20);
 
     Map<String, MonitorMetadataPolicyDTO> policies = Map.of(
@@ -82,8 +82,8 @@ public class MetadataUtilsTest {
             .setValue("5"),
         "timeout", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
             .setKey("timeout")
-            .setValueType(MetadataValueType.INT)
-            .setValue("10")
+            .setValueType(MetadataValueType.STRING)
+            .setValue("10s")
     );
 
     // count has a different value than the policy.  even though it was previously using metadata, it is now excluded

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
@@ -88,7 +88,7 @@ public class DetailedMonitorOutputTest {
                 .setCount(5)
                 .setDeadline(10)
                 .setPingInterval(15)
-                .setTimeout(20)
+                .setTimeout("20s")
             )
         )
         .setCreatedTimestamp(Instant.EPOCH.toString())

--- a/src/test/resources/DetailedMonitorOutputTest/remote.json
+++ b/src/test/resources/DetailedMonitorOutputTest/remote.json
@@ -18,7 +18,7 @@
       "count": 5,
       "deadline": 10,
       "pingInterval": 15,
-      "timeout": 20
+      "timeout": "20s"
     }
   },
   "createdTimestamp": "1970-01-01T00:00:00Z",

--- a/src/test/resources/MonitorConversionServiceTest_patch_with_policy.json
+++ b/src/test/resources/MonitorConversionServiceTest_patch_with_policy.json
@@ -3,6 +3,6 @@
   "target": "localhost",
   "count": 63,
   "pingInterval": 2,
-  "timeout": 33,
+  "timeout": "33s",
   "deadline": null
 }


### PR DESCRIPTION
# What

Changes the `timeout` type from Integer to String of `@ValidGoDuration`.

All other `timeout` parameters use this.  I'm not certain that there aren't other fields that need to change though.

# Why

We need to pass the units down to telegraf otherwise it looks like it will use the default which @itzg says is nanoseconds.

# TODO

Whatever monitors are configured in dev/stage/prod right now might need to be recreated to get the correct format... but I don't think anything will completely break since those details are only stored in the string content - it can still (de)serialize that value to a string.