### PR TITLE
Use ISO format for Duration policy metadata

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -160,7 +160,7 @@ public class MetadataUtils {
           f.set(object, Integer.parseInt(policy.getValue()));
           break;
         case DURATION:
-          f.set(object, Duration.ofSeconds(Long.parseLong(policy.getValue())));
+          f.set(object, Duration.parse(policy.getValue()));
           break;
       }
     } catch (IllegalAccessException|NoSuchFieldException e) {

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -132,7 +132,7 @@ public class MonitorConversionServiceTest {
         "pingInterval", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
             .setKey("pingInterval")
             .setValueType(MetadataValueType.DURATION)
-            .setValue("2"));
+            .setValue("PT2S"));
 
     when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
         .thenReturn(expectedPolicy);
@@ -180,11 +180,11 @@ public class MonitorConversionServiceTest {
         "pingInterval", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
             .setKey("pingInterval")
             .setValueType(MetadataValueType.DURATION)
-            .setValue("2"),
+            .setValue("PT2S"),
         "interval", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
             .setKey("interval")
             .setValueType(MetadataValueType.DURATION)
-            .setValue("44"),
+            .setValue("PT44S"),
         "zones", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
             .setKey("zones")
             .setValueType(MetadataValueType.STRING_LIST)

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
@@ -230,7 +230,7 @@ public class MonitorManagement_MetadataPolicyTest {
         .thenReturn(Map.of("interval",
             (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setKey("interval")
-                .setValue("60")
+                .setValue("PT60S")
                 .setValueType(MetadataValueType.DURATION)));
 
     String tenantId = RandomStringUtils.randomAlphabetic(10);
@@ -265,7 +265,7 @@ public class MonitorManagement_MetadataPolicyTest {
             "interval",
             (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setKey("interval")
-                .setValue("42")
+                .setValue("PT42S")
                 .setValueType(MetadataValueType.DURATION)));
 
     final Monitor monitor = saveAssortmentOfPingMonitors(tenantId).get(0);
@@ -575,7 +575,7 @@ public class MonitorManagement_MetadataPolicyTest {
             (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setMonitorType(MonitorType.ping)
                 .setKey("interval")
-                .setValue(Long.toString(UPDATED_DURATION_VALUE.getSeconds()))
+                .setValue(UPDATED_DURATION_VALUE.toString())
                 .setValueType(MetadataValueType.DURATION)
                 .setTargetClassName(TargetClassName.Monitor)
                 .setId(policyId)));

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -103,7 +103,7 @@ public class MetadataUtilsTest {
         (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
             .setKey("interval")
             .setValueType(MetadataValueType.DURATION)
-            .setValue("12"));
+            .setValue("PT12S"));
 
     MetadataUtils.setNewMetadataValues(monitor, metadataFields, policyMetadata);
     assertThat(monitor.getInterval()).isEqualTo(Duration.ofSeconds(12));
@@ -149,7 +149,7 @@ public class MetadataUtilsTest {
         (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
             .setKey("pingInterval")
             .setValueType(MetadataValueType.DURATION)
-            .setValue("67"));
+            .setValue("PT67S"));
 
     MetadataUtils.setNewMetadataValues(plugin, metadataFields, policyMetadata);
     assertThat(plugin.getPingInterval()).isEqualTo(Duration.ofSeconds(67));
@@ -186,7 +186,7 @@ public class MetadataUtilsTest {
     MonitorMetadataPolicyDTO policy = (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
         .setKey("interval")
         .setValueType(MetadataValueType.DURATION)
-        .setValue("44");
+        .setValue("PT44S");
 
     MetadataUtils.updateMetadataValue(monitor, policy);
     assertThat(monitor.getInterval()).isEqualTo(Duration.ofSeconds(44));
@@ -210,7 +210,7 @@ public class MetadataUtilsTest {
         .thenReturn(Map.of(
             "interval", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setValueType(MetadataValueType.DURATION)
-                .setValue("1")
+                .setValue("PT1S")
                 .setKey("interval"),
             "zones", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setValueType(MetadataValueType.STRING_LIST)


### PR DESCRIPTION
# What / Why

Branched from https://github.com/racker/salus-telemetry-monitor-management/pull/133

Since we might need to provide duration policy metadata in either seconds or milliseconds we should provide the string value like `PT5S` and use `Duration.parse` rather than having to provide milliseconds for everything and using `Duration.ofMillis`
