### PR TITLE
Add redis monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalPlugin.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/LocalPlugin.java
@@ -33,6 +33,7 @@ import com.rackspace.salus.monitor_management.web.model.telegraf.Mysql;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Net;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Postgresql;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Procstat;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Redis;
 import com.rackspace.salus.monitor_management.web.model.telegraf.SqlServer;
 import com.rackspace.salus.monitor_management.web.model.telegraf.System;
 
@@ -47,6 +48,7 @@ import com.rackspace.salus.monitor_management.web.model.telegraf.System;
     @Type(name = "procstat", value = Procstat.class),
     @Type(name = "mysql", value = Mysql.class),
     @Type(name = "postgresql", value = Postgresql.class),
+    @Type(name = "redis", value = Redis.class),
     @Type(name = "sqlserver", value = SqlServer.class),
     @Type(name = "system", value = System.class),
     @Type(name = "oracle_rman", value = Rman.class),

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
@@ -39,8 +39,7 @@ import com.rackspace.salus.monitor_management.web.model.telegraf.X509Cert;
     @Type(name = "mysql", value = MysqlRemote.class),
     @Type(name = "postgresql", value = PostgresqlRemote.class),
     @Type(name = "sqlserver", value = SqlServerRemote.class),
-    @Type(name = "dns", value = Dns.class),
-    @Type(name = "redis", value = Redis.class)
+    @Type(name = "dns", value = Dns.class)
 })
 public abstract class RemotePlugin {
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/RemotePlugin.java
@@ -26,6 +26,7 @@ import com.rackspace.salus.monitor_management.web.model.telegraf.MysqlRemote;
 import com.rackspace.salus.monitor_management.web.model.telegraf.NetResponse;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
 import com.rackspace.salus.monitor_management.web.model.telegraf.PostgresqlRemote;
+import com.rackspace.salus.monitor_management.web.model.telegraf.Redis;
 import com.rackspace.salus.monitor_management.web.model.telegraf.SqlServerRemote;
 import com.rackspace.salus.monitor_management.web.model.telegraf.X509Cert;
 
@@ -38,7 +39,8 @@ import com.rackspace.salus.monitor_management.web.model.telegraf.X509Cert;
     @Type(name = "mysql", value = MysqlRemote.class),
     @Type(name = "postgresql", value = PostgresqlRemote.class),
     @Type(name = "sqlserver", value = SqlServerRemote.class),
-    @Type(name = "dns", value = Dns.class)
+    @Type(name = "dns", value = Dns.class),
+    @Type(name = "redis", value = Redis.class)
 })
 public abstract class RemotePlugin {
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Redis.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Redis.java
@@ -18,7 +18,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
-import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import javax.validation.constraints.NotEmpty;
@@ -28,7 +28,7 @@ import lombok.EqualsAndHashCode;
 @Data @EqualsAndHashCode(callSuper = false)
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.redis)
-public class Redis extends RemotePlugin {
+public class Redis extends LocalPlugin {
   @NotEmpty
   String url;
   String password;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Redis.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Redis.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.telegraf;
+
+import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
+import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
+import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data @EqualsAndHashCode(callSuper = false)
+@ApplicableAgentType(AgentType.TELEGRAF)
+@ApplicableMonitorType(MonitorType.redis)
+public class Redis extends RemotePlugin {
+  @NotEmpty
+  String url;
+  String password;
+  String tlsCa;
+  String tlsCert;
+  String tlsKey;
+  Boolean insecureSkipVerify;
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Redis.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Redis.java
@@ -19,9 +19,10 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.validator.ValidLocalHost;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
-import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -29,7 +30,8 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.redis)
 public class Redis extends LocalPlugin {
-  @NotEmpty
+  @NotNull
+  @ValidLocalHost
   String url;
   String password;
   String tlsCa;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/RedisConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/RedisConversionTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model.telegraf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rackspace.salus.common.util.SpringResourceUtils;
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
+import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
+import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
+import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@JsonTest
+@Import({MonitorConversionService.class, MetadataUtils.class})
+public class RedisConversionTest {
+  @Configuration
+  public static class TestConfig { }
+
+  @MockBean
+  PatchHelper patchHelper;
+
+  @MockBean
+  PolicyApi policyApi;
+
+  @MockBean
+  MonitorRepository monitorRepository;
+
+  @Autowired
+  MonitorConversionService conversionService;
+
+  @Autowired
+  MetadataUtils metadataUtils;
+
+  @Test
+  public void convertToOutput() throws IOException {
+    Map<String, String> labels = new HashMap<>();
+    labels.put("os", "linux");
+    labels.put("test", "convertToOutput");
+
+    final String content = SpringResourceUtils.readContent(
+        "/ConversionTests/MonitorConversionServiceTest_redis.json");
+    final UUID monitorId = UUID.randomUUID();
+
+    Monitor monitor = new Monitor()
+        .setId(monitorId)
+        .setMonitorName("name-a")
+        .setAgentType(AgentType.TELEGRAF)
+        .setSelectorScope(ConfigSelectorScope.REMOTE)
+        .setZones(Collections.singletonList("z-1"))
+        .setLabelSelector(labels)
+        .setContent(content)
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
+
+    final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo(monitorId.toString());
+    assertThat(result.getName()).isEqualTo("name-a");
+    assertThat(result.getLabelSelector()).isEqualTo(labels);
+    assertThat(result.getDetails()).isInstanceOf(RemoteMonitorDetails.class);
+
+    final RemoteMonitorDetails remoteMonitorDetails = (RemoteMonitorDetails) result.getDetails();
+    assertThat(remoteMonitorDetails.getMonitoringZones()).contains("z-1");
+    final RemotePlugin plugin = remoteMonitorDetails.getPlugin();
+    assertThat(plugin).isInstanceOf(Redis.class);
+
+    final Redis redisPlugin = (Redis) plugin;
+    assertThat(redisPlugin.getUrl()).isEqualTo("tcp://localhost:123");
+    assertThat(redisPlugin.getPassword()).isEqualTo("myPass");
+    assertThat(redisPlugin.getTlsCa()).isEqualTo("/etc/telegraf/ca.pem");
+    assertThat(redisPlugin.getTlsCert()).isEqualTo("/etc/telegraf/cert.pem");
+    assertThat(redisPlugin.getTlsKey()).isEqualTo("/etc/telegraf/key.pem");
+    assertThat(redisPlugin.getInsecureSkipVerify()).isEqualTo(false);
+  }
+
+  @Test
+  public void convertFromInput() throws JSONException, IOException {
+    final Map<String, String> labels = new HashMap<>();
+    labels.put("os", "linux");
+    labels.put("test", "convertFromInput_http");
+
+    final RemoteMonitorDetails details = new RemoteMonitorDetails();
+    details.setMonitoringZones(Collections.singletonList("z-1"));
+    final Redis plugin = new Redis();
+    plugin.setUrl("tcp://localhost:123");
+    plugin.setPassword("myPass");
+    plugin.setTlsCa("/etc/telegraf/ca.pem");
+    plugin.setTlsCert("/etc/telegraf/cert.pem");
+    plugin.setTlsKey("/etc/telegraf/key.pem");
+    plugin.setInsecureSkipVerify(false);
+    details.setPlugin(plugin);
+
+    DetailedMonitorInput input = new DetailedMonitorInput()
+        .setName("name-a")
+        .setLabelSelector(labels)
+        .setDetails(details);
+    final MonitorCU result = conversionService.convertFromInput(
+        RandomStringUtils.randomAlphabetic(10), null, input);
+
+    assertThat(result).isNotNull();
+    assertThat(result.getLabelSelector()).isEqualTo(labels);
+    assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
+    assertThat(result.getMonitorName()).isEqualTo("name-a");
+    assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.REMOTE);
+    final String content = SpringResourceUtils.readContent(
+        "/ConversionTests/MonitorConversionServiceTest_redis.json");
+    JSONAssert.assertEquals(content, result.getContent(), true);
+  }
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/RedisConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/RedisConversionTest.java
@@ -25,8 +25,8 @@ import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
-import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
-import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
+import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
@@ -34,7 +34,6 @@ import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -86,8 +85,7 @@ public class RedisConversionTest {
         .setId(monitorId)
         .setMonitorName("name-a")
         .setAgentType(AgentType.TELEGRAF)
-        .setSelectorScope(ConfigSelectorScope.REMOTE)
-        .setZones(Collections.singletonList("z-1"))
+        .setSelectorScope(ConfigSelectorScope.LOCAL)
         .setLabelSelector(labels)
         .setContent(content)
         .setCreatedTimestamp(Instant.EPOCH)
@@ -99,11 +97,10 @@ public class RedisConversionTest {
     assertThat(result.getId()).isEqualTo(monitorId.toString());
     assertThat(result.getName()).isEqualTo("name-a");
     assertThat(result.getLabelSelector()).isEqualTo(labels);
-    assertThat(result.getDetails()).isInstanceOf(RemoteMonitorDetails.class);
+    assertThat(result.getDetails()).isInstanceOf(LocalMonitorDetails.class);
 
-    final RemoteMonitorDetails remoteMonitorDetails = (RemoteMonitorDetails) result.getDetails();
-    assertThat(remoteMonitorDetails.getMonitoringZones()).contains("z-1");
-    final RemotePlugin plugin = remoteMonitorDetails.getPlugin();
+    final LocalMonitorDetails localMonitorDetails = (LocalMonitorDetails) result.getDetails();
+    final LocalPlugin plugin = localMonitorDetails.getPlugin();
     assertThat(plugin).isInstanceOf(Redis.class);
 
     final Redis redisPlugin = (Redis) plugin;
@@ -121,8 +118,7 @@ public class RedisConversionTest {
     labels.put("os", "linux");
     labels.put("test", "convertFromInput_http");
 
-    final RemoteMonitorDetails details = new RemoteMonitorDetails();
-    details.setMonitoringZones(Collections.singletonList("z-1"));
+    final LocalMonitorDetails details = new LocalMonitorDetails();
     final Redis plugin = new Redis();
     plugin.setUrl("tcp://localhost:123");
     plugin.setPassword("myPass");
@@ -143,7 +139,7 @@ public class RedisConversionTest {
     assertThat(result.getLabelSelector()).isEqualTo(labels);
     assertThat(result.getAgentType()).isEqualTo(AgentType.TELEGRAF);
     assertThat(result.getMonitorName()).isEqualTo("name-a");
-    assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.REMOTE);
+    assertThat(result.getSelectorScope()).isEqualTo(ConfigSelectorScope.LOCAL);
     final String content = SpringResourceUtils.readContent(
         "/ConversionTests/MonitorConversionServiceTest_redis.json");
     JSONAssert.assertEquals(content, result.getContent(), true);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidLocalHostTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/validator/ValidLocalHostTest.java
@@ -72,4 +72,29 @@ public class ValidLocalHostTest {
         containsString(ValidLocalHost.DEFAULT_MESSAGE));
 
   }
+
+  @Test
+  public void testEmpty() {
+    List<String> l = new ArrayList<>();
+    l.add("");
+    final WithLocalHost obj = new WithLocalHost(l);
+
+    final Set<ConstraintViolation<WithLocalHost>> results = validatorFactoryBean.validate(obj);
+
+    assertThat(results, hasSize(1));
+    assertThat(new ArrayList<>(results).get(0).getMessage(),
+        containsString(ValidLocalHost.DEFAULT_MESSAGE));
+
+  }
+
+  @Test
+  public void testNull() {
+    List<String> l = new ArrayList<>();
+    l.add(null);
+    final WithLocalHost obj = new WithLocalHost(l);
+
+    final Set<ConstraintViolation<WithLocalHost>> results = validatorFactoryBean.validate(obj);
+
+    assertThat(results, hasSize(0));
+  }
 }

--- a/src/test/resources/ConversionTests/MonitorConversionServiceTest_redis.json
+++ b/src/test/resources/ConversionTests/MonitorConversionServiceTest_redis.json
@@ -1,0 +1,9 @@
+{
+  "type": "redis",
+  "url": "tcp://localhost:123",
+  "password": "myPass",
+  "tlsCa": "/etc/telegraf/ca.pem",
+  "tlsCert": "/etc/telegraf/cert.pem",
+  "tlsKey": "/etc/telegraf/key.pem",
+  "insecureSkipVerify": false
+}


### PR DESCRIPTION
# What

Adds the ability to use the redis telegraf plugin type.

# Why

We need to migrate ele remote.redis checks.

# TODO

Add monitor translations
