### PR TITLE
Added package agent as supported for test-monitors feature

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ import org.springframework.util.CollectionUtils;
 @Slf4j
 public class TestMonitorService {
 
-  private static final Set<AgentType> SUPPORTED_AGENT_TYPES = Set.of(AgentType.TELEGRAF);
+  private static final Set<AgentType> SUPPORTED_AGENT_TYPES = Set.of(AgentType.TELEGRAF, AgentType.PACKAGES);
 
   private final MonitorConversionService monitorConversionService;
   private final ResourceRepository resourceRepository;


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-594

# What

Whe integration testing packages agent with the test-monitor feature I got this error response:

```
{
  "timestamp": "2020-01-21T22:34:06.809+0000",
  "status": 400,
  "error": "Bad Request",
  "message": "The given monitor type does not support test-monitors",
  "app": "salus-telemetry-monitor-management",
  "host": "MS90HCG8WL"
}
```

# How

Added package agent to the supported set.

## How to test

POST a test monitor such as
```
{
  "resourceId": "development:0",
  "details": {
    "type": "local",
    "plugin": {
      "type": "packages",
      "include-debian": true
    }
  }
}
```
