### PR TITLE
Updated unit test to use mysql testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 Rackspace US, Inc.
+  ~ Copyright 2020 Rackspace US, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -156,8 +156,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,7 +23,7 @@ spring:
     platform: mysql
   kafka:
     listener:
-      # this will allow for to start consumer of a particular topic before the producer
+      # this will allow for us to start consumer of a particular topic before the producer
       missing-topics-fatal: false
 logging:
   level:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -21,6 +21,10 @@ spring:
     url: jdbc:mysql://localhost:3306/default?verifyServerCertificate=false&useSSL=false&requireSSL=false
     driver-class-name: com.mysql.cj.jdbc.Driver
     platform: mysql
+  kafka:
+    listener:
+      # this will allow for to start consumer of a particular topic before the producer
+      missing-topics-fatal: false
 logging:
   level:
     com.rackspace.salus: debug

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
@@ -27,11 +27,11 @@ import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.repositories.MonitorTranslationOperatorRepository;
 import com.rackspace.salus.telemetry.translators.RenameFieldKeyTranslator;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
@@ -45,8 +45,8 @@ import org.springframework.test.context.junit4.SpringRunner;
     DatabaseConfig.class,
     ObjectMapper.class
 })
+@EnableTestContainersDatabase
 @AutoConfigureDataJpa
-@AutoConfigureTestDatabase
 @AutoConfigureTestEntityManager
 public class MonitorContentTranslationServiceTest {
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
@@ -47,6 +47,7 @@ import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.HashMap;
@@ -59,7 +60,6 @@ import java.util.concurrent.CompletableFuture;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
@@ -74,8 +74,8 @@ import org.springframework.transaction.annotation.Transactional;
     MonitorManagement.class,
     ZonesProperties.class
 })
+@EnableTestContainersDatabase
 @AutoConfigureDataJpa
-@AutoConfigureTestDatabase
 @AutoConfigureTestEntityManager
 @Transactional
 public class MonitorManagementExcludeResourceIdsTest {

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
 import com.rackspace.salus.telemetry.repositories.MonitorPolicyRepository;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
@@ -104,6 +105,7 @@ import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 @RunWith(SpringRunner.class)
+@EnableTestContainersDatabase
 @DataJpaTest(showSql = false)
 @Import({ServicesProperties.class, ObjectMapper.class, MonitorManagement.class,
     MonitorContentRenderer.class,

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -76,6 +77,7 @@ import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import com.rackspace.salus.telemetry.repositories.ResourceRepository;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
@@ -99,6 +101,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.persistence.EntityManager;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -118,7 +121,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
@@ -126,6 +128,7 @@ import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 @SuppressWarnings("SameParameterValue")
 @RunWith(SpringRunner.class)
+@EnableTestContainersDatabase
 @DataJpaTest(showSql = false)
 @Import({ServicesProperties.class, ObjectMapper.class, MonitorManagement.class,
     MonitorContentRenderer.class,
@@ -249,6 +252,13 @@ public class MonitorManagementTest {
 
     when(resourceApi.getResourcesWithLabels(any(), any(), eq(LabelSelectorMethod.AND)))
         .thenReturn(resourceList);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    // transactional rollback should take care of purging test data, but do a deleteAll to be sure
+    monitorRepository.deleteAll();
+    entityManager.flush();
   }
 
   private void createMonitors(int count) {
@@ -3999,10 +4009,12 @@ public class MonitorManagementTest {
     final MultiValueMap<String, String> results = monitorManagement
         .getTenantMonitorLabelSelectors("t-1");
 
-    final MultiValueMap<String, String> expected = new LinkedMultiValueMap<>();
-    expected.put("key1", Arrays.asList("value-1-1", "value-1-2"));
-    expected.put("key2", Arrays.asList("value-2-1", "value-2-2"));
-    expected.put("key3", Arrays.asList("value-3-1", "value-3-2"));
-    assertThat(results, equalTo(expected));
+    assertThat(results.size(), equalTo(3));
+    assertThat(results, hasKey("key1"));
+    assertThat(results, hasKey("key2"));
+    assertThat(results, hasKey("key3"));
+    assertThat(results.get("key1"), containsInAnyOrder("value-1-1", "value-1-2"));
+    assertThat(results.get("key2"), containsInAnyOrder("value-2-1", "value-2-2"));
+    assertThat(results.get("key3"), containsInAnyOrder("value-3-1", "value-3-2"));
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneManagementTest.java
@@ -1,33 +1,55 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.monitor_management.services;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.monitor_management.config.DatabaseConfig;
-import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
-import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.monitor_management.errors.DeletionNotAllowedException;
-import com.rackspace.salus.telemetry.repositories.MonitorRepository;
-import com.rackspace.salus.telemetry.repositories.ZoneRepository;
-import com.rackspace.salus.telemetry.model.ZoneState;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.monitor_management.web.model.ZoneCreatePrivate;
 import com.rackspace.salus.monitor_management.web.model.ZoneCreatePublic;
 import com.rackspace.salus.monitor_management.web.model.ZoneUpdate;
+import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.ZoneState;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import com.rackspace.salus.telemetry.repositories.ZoneRepository;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,12 +60,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
-import java.time.Duration;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Random;
 
 @RunWith(SpringRunner.class)
+@EnableTestContainersDatabase
 @DataJpaTest(showSql = false)
 @Import({ZoneManagement.class, ObjectMapper.class, DatabaseConfig.class})
 public class ZoneManagementTest {
@@ -239,8 +258,6 @@ public class ZoneManagementTest {
     }
 
     @Test
-    @Ignore
-    // Cannot test this function due to the FIELD part of the sql query being incompatible with h2
     public void testGetAvailableZonesForTenant() {
         Random random = new Random();
         int privateCount = random.nextInt(20);
@@ -249,18 +266,22 @@ public class ZoneManagementTest {
         String unrelatedTenant = RandomStringUtils.randomAlphabetic(10);
 
         // there is one default zone in these tests
-        assertThat(zoneManagement.getAvailableZonesForTenant(tenant, Pageable.unpaged()).getTotalElements(), equalTo(1));
+        assertThat(zoneManagement.getAvailableZonesForTenant(tenant, Pageable.unpaged()).getTotalElements(),
+            equalTo(1L));
 
         // any new private zone for the tenant should be visible
         createPrivateZonesForTenant(privateCount, tenant);
-        assertThat(zoneManagement.getAvailableZonesForTenant(tenant, Pageable.unpaged()), equalTo(1 + privateCount));
+        assertThat(zoneManagement.getAvailableZonesForTenant(tenant, Pageable.unpaged()).getTotalElements(),
+            equalTo(1L + privateCount));
 
         // new public zones should be visible too
         createPublicZones(publicCount);
-        assertThat(zoneManagement.getAvailableZonesForTenant(tenant, Pageable.unpaged()), equalTo(1 + privateCount + publicCount));
+        assertThat(zoneManagement.getAvailableZonesForTenant(tenant, Pageable.unpaged()).getTotalElements(),
+            equalTo(1L + privateCount + publicCount));
 
         // Another tenant can only see public zones
-        assertThat(zoneManagement.getAvailableZonesForTenant(unrelatedTenant, Pageable.unpaged()), equalTo(1 + publicCount));
+        assertThat(zoneManagement.getAvailableZonesForTenant(unrelatedTenant, Pageable.unpaged()).getTotalElements(),
+            equalTo(1L + publicCount));
     }
 
     @Test


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-738

# What

The Spring Boot upgrade from 2.1.8 to 2.2.4 included an upgrade of h2 from 1.4.199 to 1.4.200. Even though that version of h2 brings some nice features like json data type support, it also became more picky (correctly so) about the SQL used in the flyway migration files.

With the Spring Boot 2.2.4 upgrade the default must have changed for `spring.kafka.listener.missing-topics-fatal` from false to true or it's a new condition spring kafka checks. In any case, when starting one of our kafka-consuming apps locally it was failing to start since I had a fresh kafka container without the topic it wanted. It's a good property and default to have in production, but annoying locally.

# How

Use the new `@EnableTestContainersDatabase` annotation provided by https://github.com/racker/salus-test/pull/7 to activate mysql testcontainers support in place of h2 during unit tests.

# How to test

Existing unit tests

# Depends on

https://github.com/racker/salus-test/pull/7