### PR TITLE
Added a summary field to DetailedMonitorOutput

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -140,9 +140,7 @@ public class MonitorConversionService {
       return buildSummaryFromPlugin(((LocalMonitorDetails) details).getPlugin());
     } else if (details instanceof RemoteMonitorDetails) {
       return buildSummaryFromPlugin(((RemoteMonitorDetails) details).getPlugin());
-    } else if (details == null) {
-      return Map.of();
-    } else {
+    } {
       throw new IllegalStateException(String.format("Unexpected MonitorDetails type: %s", details.getClass()));
     }
   }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
@@ -38,4 +38,6 @@ public class DetailedMonitorOutput {
     MonitorDetails details;
     String createdTimestamp;
     String updatedTimestamp;
+
+    Map<String,String> summary;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/SummaryField.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/SummaryField.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to mark one or more fields of a {@link LocalPlugin} or {@link RemotePlugin}
+ * subclass to be included in the summary field of a {@link DetailedMonitorOutput}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface SummaryField {
+
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/SummaryField.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/SummaryField.java
@@ -23,7 +23,10 @@ import java.lang.annotation.Target;
 
 /**
  * This annotation is used to mark one or more fields of a {@link LocalPlugin} or {@link RemotePlugin}
- * subclass to be included in the summary field of a {@link DetailedMonitorOutput}.
+ * subclass to be included in the summary field of a {@link DetailedMonitorOutput}. Good fields
+ * to annotate are ones that are meaningful to the end user and help differentiate between several
+ * monitors of the same type. Things like http url, DNS domain, and server address are examples
+ * of fields that should be annotated.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/oracle/Dataguard.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/oracle/Dataguard.java
@@ -1,9 +1,26 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.monitor_management.web.model.oracle;
 
 
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
@@ -15,6 +32,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.ORACLE)
 @ApplicableMonitorType(MonitorType.oracle_dataguard)
 public class Dataguard extends LocalPlugin {
+  @SummaryField
   List<String> databaseNames;
   String filePath;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/oracle/Rman.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/oracle/Rman.java
@@ -1,8 +1,25 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.monitor_management.web.model.oracle;
 
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
@@ -15,6 +32,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableMonitorType(MonitorType.oracle_rman)
 public class Rman extends LocalPlugin {
   List<String> exclusionCodes;
+  @SummaryField
   List<String> databaseNames;
   String filePath;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/oracle/Tablespace.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/oracle/Tablespace.java
@@ -1,8 +1,25 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.monitor_management.web.model.oracle;
 
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
@@ -14,6 +31,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.ORACLE)
 @ApplicableMonitorType(MonitorType.oracle_tablespace)
 public class Tablespace extends LocalPlugin {
+  @SummaryField
   List<String> databaseNames;
   String filePath;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/packages/Packages.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/packages/Packages.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.packages;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import lombok.Data;
@@ -29,7 +30,9 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.PACKAGES)
 @ApplicableMonitorType(MonitorType.packages)
 public class Packages extends LocalPlugin {
+  @SummaryField
   boolean includeRpm = true;
+  @SummaryField
   boolean includeDebian = true;
   boolean failWhenNotSupported;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Apache.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Apache.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.time.Duration;
@@ -31,6 +32,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.apache)
 public class Apache extends LocalPlugin {
+  @SummaryField
   @NotBlank
   String url;
   String username;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Disk.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Disk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import javax.validation.constraints.NotBlank;
@@ -29,6 +30,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.disk)
 public class Disk extends LocalPlugin {
+  @SummaryField
   @NotBlank
   String mount;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIo.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskIo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import lombok.Data;
@@ -28,6 +29,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.diskio)
 public class DiskIo extends LocalPlugin {
+  @SummaryField
   String device;
   Boolean skipSerialNumber;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Dns.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Dns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.Protocol;
 import com.rackspace.salus.monitor_management.web.model.RecordType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.time.Duration;
@@ -35,6 +36,7 @@ import lombok.EqualsAndHashCode;
 public class Dns extends RemotePlugin {
   @NotBlank
   String dnsServer;
+  @SummaryField
   @NotBlank
   String domain;
   @NotNull

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.time.Duration;
@@ -32,10 +33,12 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.http)
 public class HttpResponse extends RemotePlugin {
+  @SummaryField
   @NotEmpty
   String url;
   String httpProxy;
   Duration timeout;
+  @SummaryField
   @Pattern(regexp = "GET|PUT|POST|DELETE|HEAD|OPTIONS|PATCH|TRACE", message = "invalid http method")
   String method;
   boolean followRedirects;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Mysql.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Mysql.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidLocalHost;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
@@ -35,6 +36,7 @@ import lombok.EqualsAndHashCode;
 public class Mysql extends LocalPlugin {
   public static final String REGEXP = "^((?<user>.+(:.+)?@)?(tcp(?<address>\\(.+\\))))?/(?<dbname>[^?]*)?(?<params>(\\?.+=[^&]+)?(&.+=.+)*)?$";
   public static final String ERR_MESSAGE = "invalid mysql db connection string";
+  @SummaryField
   @NotEmpty
   List<@ValidLocalHost @Pattern(regexp = Mysql.REGEXP, message = Mysql.ERR_MESSAGE) String> servers;
   Integer perfEventsStatementsDigestTextLimit;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlRemote.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.time.Duration;
@@ -32,6 +33,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.mysql)
 public class MysqlRemote extends RemotePlugin {
+  @SummaryField
   @NotEmpty
   List<@Pattern(regexp = Mysql.REGEXP, message = Mysql.ERR_MESSAGE) String> servers;
   Integer perfEventsStatementsDigestTextLimit;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import lombok.Data;
@@ -29,6 +30,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.net)
 public class Net extends LocalPlugin {
+  @SummaryField
   @JsonProperty("interface")
   String monitoredInterface;
   @JsonProperty(defaultValue = "true")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/NetResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.Protocol;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.time.Duration;
@@ -35,12 +36,15 @@ import lombok.EqualsAndHashCode;
 @ApplicableMonitorType(MonitorType.net_response)
 public class NetResponse extends RemotePlugin {
 
+  @SummaryField
   @NotNull
   Protocol protocol = Protocol.tcp;
 
+  @SummaryField
   @NotBlank
   String host;
 
+  @SummaryField
   @NotNull
   @Min(1)
   @Max(65535)

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Ping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.time.Duration;
@@ -30,6 +31,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.ping)
 public class Ping extends RemotePlugin {
+  @SummaryField
   @NotEmpty
   String target;
   Integer count;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Postgresql.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Postgresql.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidLocalHost;
 import com.rackspace.salus.monitor_management.web.validator.PostgresqlValidator.AtMostOneOf;
 import com.rackspace.salus.telemetry.model.AgentType;
@@ -37,6 +38,7 @@ import lombok.EqualsAndHashCode;
 public class Postgresql extends LocalPlugin {
   public static final String REGEXP = "^(postgres://.+)|(([^ ]+=[^ ]+ )*([^ ]+=[^ ]+))$";
   public static final String ERR_MESSAGE = "invalid postgresql db connection string";
+  @SummaryField
   @NotEmpty
   @ValidLocalHost
   @Pattern(regexp = Postgresql.REGEXP, message = Postgresql.ERR_MESSAGE)

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlRemote.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.monitor_management.web.validator.PostgresqlRemoteValidator.AtMostOneOf;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
@@ -34,6 +35,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableMonitorType(MonitorType.postgresql)
 @AtMostOneOf
 public class PostgresqlRemote extends RemotePlugin {
+  @SummaryField
   @NotEmpty
   @Pattern(regexp = Postgresql.REGEXP, message = Postgresql.ERR_MESSAGE)
   String address;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Procstat.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Procstat.java
@@ -1,16 +1,30 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.monitor_management.web.validator.ProcstatValidator;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-
-import javax.validation.Constraint;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
@@ -18,14 +32,22 @@ import javax.validation.Constraint;
 @ApplicableMonitorType(MonitorType.procstat)
 @ProcstatValidator.OneOf()
 public class Procstat extends LocalPlugin {
+    @SummaryField
     String pidFile;
+    @SummaryField
     String user;
+    @SummaryField
     String exe;
+    @SummaryField
     String pattern;
+    @SummaryField
     String systemdUnit;
+    @SummaryField
     String cgroup;
+    @SummaryField
     String winService;
 
     // This is optional; default is sourced from /proc/<pid>/status
+    @SummaryField
     String processName;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Redis.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Redis.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidLocalHost;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
@@ -30,6 +31,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.redis)
 public class Redis extends LocalPlugin {
+  @SummaryField
   @NotNull
   @ValidLocalHost
   String url;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.monitor_management.web.model.validator.ValidLocalHost;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
@@ -34,6 +35,7 @@ import lombok.EqualsAndHashCode;
 public class SqlServer extends LocalPlugin {
   public static final String REGEXP = "^(sqlserver://.+)|(([^?;]+=[^;]+;)*([^?;]+=[^;]+);?)$";
   public static final String ERR_MESSAGE = "invalid sqlserver db connection string";
+  @SummaryField
   @NotEmpty
   List<@ValidLocalHost @Pattern(regexp = SqlServer.REGEXP, message = SqlServer.ERR_MESSAGE)String> servers;
   boolean azuredb;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerRemote.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerRemote.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,10 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 import lombok.Data;
@@ -33,6 +32,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.sqlserver)
 public class SqlServerRemote extends RemotePlugin {
+  @SummaryField
   @NotEmpty
   List<@Pattern(regexp = SqlServer.REGEXP, message = SqlServer.ERR_MESSAGE) String> servers;
   boolean azuredb;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/X509Cert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
+import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.time.Duration;
@@ -30,6 +31,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableAgentType(AgentType.TELEGRAF)
 @ApplicableMonitorType(MonitorType.ssl)
 public class X509Cert extends RemotePlugin {
+  @SummaryField
   @NotBlank
   String target;
   Duration timeout;

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -438,6 +438,9 @@ public class MonitorConversionServiceTest {
     Monitor monitor = new Monitor()
         .setResourceId("r-1")
         .setId(monitorId)
+        .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setAgentType(AgentType.TELEGRAF)
+        .setContent("{\"type\":\"cpu\"}")
         .setCreatedTimestamp(Instant.EPOCH)
         .setUpdatedTimestamp(Instant.EPOCH);
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
@@ -461,6 +464,9 @@ public class MonitorConversionServiceTest {
     Monitor monitor = new Monitor()
         .setExcludedResourceIds(Set.of("r-1","r-2"))
         .setId(monitorId)
+        .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setAgentType(AgentType.TELEGRAF)
+        .setContent("{\"type\":\"cpu\"}")
         .setCreatedTimestamp(Instant.EPOCH)
         .setUpdatedTimestamp(Instant.EPOCH);
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
@@ -474,6 +480,9 @@ public class MonitorConversionServiceTest {
     Monitor monitor = new Monitor()
         .setLabelSelectorMethod(LabelSelectorMethod.AND)
         .setId(monitorId)
+        .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setAgentType(AgentType.TELEGRAF)
+        .setContent("{\"type\":\"cpu\"}")
         .setCreatedTimestamp(Instant.EPOCH)
         .setUpdatedTimestamp(Instant.EPOCH);
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
@@ -498,6 +507,9 @@ public class MonitorConversionServiceTest {
         .setLabelSelectorMethod(LabelSelectorMethod.AND)
         .setId(monitorId)
         .setInterval(Duration.ofSeconds(60))
+        .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setAgentType(AgentType.TELEGRAF)
+        .setContent("{\"type\":\"cpu\"}")
         .setCreatedTimestamp(Instant.EPOCH)
         .setUpdatedTimestamp(Instant.EPOCH);
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -850,6 +850,9 @@ public class MonitorApiControllerTest {
 
     final Monitor stubMonitorResp = new Monitor()
         .setId(UUID.randomUUID())
+        .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setAgentType(AgentType.TELEGRAF)
+        .setContent("{\"type\":\"cpu\"}")
         .setCreatedTimestamp(Instant.EPOCH)
         .setUpdatedTimestamp(Instant.EPOCH);
     when(monitorManagement.createMonitor(any(), any()))

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/ConversionHelpers.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/ConversionHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,6 @@ package com.rackspace.salus.monitor_management.web.model;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
-import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
-import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
-import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
-import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import java.time.Instant;
@@ -37,12 +32,14 @@ public class ConversionHelpers {
   private static final Instant DEFAULT_TIMESTAMP = Instant.ofEpochSecond(100000);
 
   public static <T> T assertCommon(DetailedMonitorOutput result,
-                            Monitor monitor, Class<T> pluginClass, String scenario) {
+                                   Monitor monitor, Class<T> pluginClass, String scenario,
+                                   Map<String, Object> summary) {
     assertThat(result).isNotNull();
     assertThat(result.getId()).isEqualTo(monitor.getId().toString());
     assertThat(result.getName()).isEqualTo(scenario);
     assertThat(result.getLabelSelector()).isEqualTo(monitor.getLabelSelector());
     assertThat(result.getDetails()).isInstanceOf(LocalMonitorDetails.class);
+    assertThat(result.getSummary()).isEqualTo(summary);
 
     final LocalPlugin plugin = ((LocalMonitorDetails) result.getDetails()).getPlugin();
     assertThat(plugin).isInstanceOf(pluginClass);
@@ -51,12 +48,14 @@ public class ConversionHelpers {
   }
 
   public static <T> T assertCommonRemote(DetailedMonitorOutput result,
-                            Monitor monitor, Class<T> pluginClass, String scenario) {
+                                         Monitor monitor, Class<T> pluginClass, String scenario,
+                                         Map<String, Object> summary) {
     assertThat(result).isNotNull();
     assertThat(result.getId()).isEqualTo(monitor.getId().toString());
     assertThat(result.getName()).isEqualTo(scenario);
     assertThat(result.getLabelSelector()).isEqualTo(monitor.getLabelSelector());
     assertThat(result.getDetails()).isInstanceOf(RemoteMonitorDetails.class);
+    assertThat(result.getSummary()).isEqualTo(summary);
 
     final RemotePlugin plugin = ((RemoteMonitorDetails) result.getDetails()).getPlugin();
     assertThat(plugin).isInstanceOf(pluginClass);
@@ -81,5 +80,15 @@ public class ConversionHelpers {
         .setContent(content)
         .setCreatedTimestamp(DEFAULT_TIMESTAMP)
         .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+  }
+
+  /**
+   * Since {@link Map#of(Object, Object)} doesn't allow for null values we need a helper method
+   * to create expected summary objects for default plugin cases.
+   */
+  public static Map<String,Object> nullableSummaryValue(String key) {
+    final Map<String,Object> summary = new HashMap<>(1);
+    summary.put(key, null);
+    return summary;
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
@@ -62,6 +62,7 @@ public class DetailedMonitorOutputTest {
                 .setTotalcpu(true)
             )
         )
+        .setSummary(Map.of("key", "value"))
         .setCreatedTimestamp(Instant.EPOCH.toString())
         .setUpdatedTimestamp(Instant.EPOCH.plusSeconds(1).toString());
 
@@ -91,6 +92,7 @@ public class DetailedMonitorOutputTest {
                 .setTimeout(Duration.ofSeconds(20))
             )
         )
+        .setSummary(Map.of("key", "value"))
         .setCreatedTimestamp(Instant.EPOCH.toString())
         .setUpdatedTimestamp(Instant.EPOCH.plusSeconds(1).toString());
 

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/DataguardConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/DataguardConversionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.monitor_management.web.model.oracle;
 
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.assertCommon;
@@ -19,7 +35,6 @@ import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -63,7 +78,8 @@ public class DataguardConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final Dataguard dataguardPlugin = assertCommon(result, monitor, Dataguard.class, "convertToOutput");
+    final Dataguard dataguardPlugin = assertCommon(result, monitor, Dataguard.class, "convertToOutput",
+        Map.of("databaseNames", "[backupDB, prodDB]"));
     assertThat(dataguardPlugin.getFilePath()).isEqualTo("./oracleDatabaseOutput");
 
     assertThat(dataguardPlugin.getDatabaseNames()).containsExactlyInAnyOrder("backupDB", "prodDB");

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/RmanConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/RmanConversionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.monitor_management.web.model.oracle;
 
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.assertCommon;
@@ -62,7 +78,8 @@ public class RmanConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final Rman rmanPlugin = assertCommon(result, monitor, Rman.class, "convertToOutput");
+    final Rman rmanPlugin = assertCommon(result, monitor, Rman.class, "convertToOutput",
+        Map.of("databaseNames", "[backupDB, prodDB]"));
     assertThat(rmanPlugin.getFilePath()).isEqualTo("./oracleDatabaseOutput");
     final List<String> databaseNames = new LinkedList<>();
     databaseNames.add("backupDB");

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/TablespaceConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/TablespaceConversionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.monitor_management.web.model.oracle;
 
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.assertCommon;
@@ -19,7 +35,6 @@ import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -62,7 +77,8 @@ public class TablespaceConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final Tablespace tablespacePlugin = assertCommon(result, monitor, Tablespace.class, "convertToOutput");
+    final Tablespace tablespacePlugin = assertCommon(result, monitor, Tablespace.class, "convertToOutput",
+        Map.of("databaseNames", "[backupDB, prodDB]"));
     assertThat(tablespacePlugin.getFilePath()).isEqualTo("./oracleDatabaseOutput");
 
     assertThat(tablespacePlugin.getDatabaseNames()).containsExactlyInAnyOrder("backupDB", "prodDB");

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/packages/PackagesConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/packages/PackagesConversionTest.java
@@ -80,7 +80,8 @@ public class PackagesConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final Packages plugin = assertCommon(result, monitor, Packages.class, "convertToOutput");
+    final Packages plugin = assertCommon(result, monitor, Packages.class, "convertToOutput",
+        Map.of("includeRpm", "false", "includeDebian", "true"));
 
     assertThat(plugin.isIncludeDebian()).isTrue();
     assertThat(plugin.isIncludeRpm()).isFalse();
@@ -97,7 +98,8 @@ public class PackagesConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final Packages plugin = assertCommon(result, monitor, Packages.class, "convertToOutput_defaults");
+    final Packages plugin = assertCommon(result, monitor, Packages.class, "convertToOutput_defaults",
+        Map.of("includeRpm", "true", "includeDebian", "true"));
 
     assertThat(plugin.isIncludeRpm()).isTrue();
     assertThat(plugin.isIncludeDebian()).isTrue();

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/CpuConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/CpuConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,15 +21,15 @@ import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
 import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
-import com.rackspace.salus.policy.manage.web.client.PolicyApi;
-import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
@@ -80,7 +80,7 @@ public class CpuConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final Cpu cpuPlugin = assertCommon(result, monitor, Cpu.class, "convertToOutput");
+    final Cpu cpuPlugin = assertCommon(result, monitor, Cpu.class, "convertToOutput", Map.of());
 
     assertThat(cpuPlugin.isCollectCpuTime()).isTrue();
     assertThat(cpuPlugin.isPercpu()).isFalse();
@@ -98,7 +98,8 @@ public class CpuConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final Cpu cpuPlugin = assertCommon(result, monitor, Cpu.class, "convertToOutput_defaults");
+    final Cpu cpuPlugin = assertCommon(result, monitor, Cpu.class, "convertToOutput_defaults",
+        Map.of());
 
     assertThat(cpuPlugin.isCollectCpuTime()).isFalse();
     assertThat(cpuPlugin.isPercpu()).isFalse();

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/DiskConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,23 +18,25 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.assertCommon;
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.createMonitor;
+import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.nullableSummaryValue;
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
 import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
-import com.rackspace.salus.policy.manage.web.client.PolicyApi;
-import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.json.JSONException;
 import org.junit.Test;
@@ -79,7 +81,7 @@ public class DiskConversionTest {
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
     final Disk specificPlugin =
-        assertCommon(result, monitor, Disk.class, "convertToOutput");
+        assertCommon(result, monitor, Disk.class, "convertToOutput", Map.of("mount", "/var/lib"));
 
     assertThat(specificPlugin.getMount()).isEqualTo("/var/lib");
   }
@@ -94,7 +96,7 @@ public class DiskConversionTest {
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
     final Disk specificPlugin =
-        assertCommon(result, monitor, Disk.class, "convertToOutput_defaults");
+        assertCommon(result, monitor, Disk.class, "convertToOutput_defaults", nullableSummaryValue("mount"));
 
     assertThat(specificPlugin.getMount()).isNull();
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,19 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.assertCommon;
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.createMonitor;
+import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.nullableSummaryValue;
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
 import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
-import com.rackspace.salus.policy.manage.web.client.PolicyApi;
-import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
@@ -82,7 +83,8 @@ public class MysqlConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final Mysql mysqlPlugin = assertCommon(result, monitor, Mysql.class, "convertToOutput");
+    final Mysql mysqlPlugin = assertCommon(result, monitor, Mysql.class, "convertToOutput",
+        Map.of("servers", "[1, 2]"));
 
     List<String> l = List.of("1","2");
     assertThat(mysqlPlugin.getServers()).isEqualTo(l);
@@ -119,7 +121,8 @@ public class MysqlConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final Mysql mysqlPlugin = assertCommon(result, monitor, Mysql.class, "convertToOutput_defaults");
+    final Mysql mysqlPlugin = assertCommon(result, monitor, Mysql.class, "convertToOutput_defaults",
+        nullableSummaryValue("servers"));
     assertThat(mysqlPlugin.getServers()).isEqualTo(null);
     assertThat(mysqlPlugin.getPerfEventsStatementsDigestTextLimit()).isEqualTo(null);
     assertThat(mysqlPlugin.getPerfEventsStatementsLimit()).isEqualTo(null);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlRemoteConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/MysqlRemoteConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,19 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.assertCommonRemote;
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.createMonitor;
+import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.nullableSummaryValue;
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
 import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
-import com.rackspace.salus.policy.manage.web.client.PolicyApi;
-import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
-import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
@@ -82,7 +83,8 @@ public class MysqlRemoteConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final MysqlRemote mysqlPlugin = assertCommonRemote(result, monitor, MysqlRemote.class, "convertToOutput");
+    final MysqlRemote mysqlPlugin = assertCommonRemote(result, monitor, MysqlRemote.class, "convertToOutput",
+        Map.of("servers", "[1, 2]"));
 
     List<String> l = List.of("1","2");
     assertThat(mysqlPlugin.getServers()).isEqualTo(l);
@@ -119,7 +121,8 @@ public class MysqlRemoteConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final MysqlRemote mysqlPlugin = assertCommonRemote(result, monitor, MysqlRemote.class, "convertToOutput_defaults");
+    final MysqlRemote mysqlPlugin = assertCommonRemote(result, monitor, MysqlRemote.class, "convertToOutput_defaults",
+        nullableSummaryValue("servers"));
     assertThat(mysqlPlugin.getServers()).isEqualTo(null);
     assertThat(mysqlPlugin.getPerfEventsStatementsDigestTextLimit()).isEqualTo(null);
     assertThat(mysqlPlugin.getPerfEventsStatementsLimit()).isEqualTo(null);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,19 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.assertCommon;
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.createMonitor;
+import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.nullableSummaryValue;
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
 import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
-import com.rackspace.salus.policy.manage.web.client.PolicyApi;
-import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
@@ -82,7 +83,8 @@ public class PostgresqlConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final Postgresql postgresqlPlugin = assertCommon(result, monitor, Postgresql.class, "convertToOutput");
+    final Postgresql postgresqlPlugin = assertCommon(result, monitor, Postgresql.class, "convertToOutput",
+        Map.of("address","host=localhost user=postgres sslmode=disable"));
 
     List<String> l = List.of("1","2");
     List<String> l2 = List.of("3","4");
@@ -103,7 +105,8 @@ public class PostgresqlConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final Postgresql postgresqlPlugin = assertCommon(result, monitor, Postgresql.class, "convertToOutput_defaults");
+    final Postgresql postgresqlPlugin = assertCommon(result, monitor, Postgresql.class, "convertToOutput_defaults",
+        nullableSummaryValue("address"));
     assertThat(postgresqlPlugin.getAddress()).isEqualTo(null);
     assertThat(postgresqlPlugin.getOutputaddress()).isEqualTo(null);
     assertThat(postgresqlPlugin.getMaxLifetime()).isEqualTo(null);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlRemoteConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/PostgresqlRemoteConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,19 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.assertCommonRemote;
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.createMonitor;
+import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.nullableSummaryValue;
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
 import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
-import com.rackspace.salus.policy.manage.web.client.PolicyApi;
-import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
-import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
@@ -82,7 +83,8 @@ public class PostgresqlRemoteConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final PostgresqlRemote postgresqlPlugin = assertCommonRemote(result, monitor, PostgresqlRemote.class, "convertToOutput");
+    final PostgresqlRemote postgresqlPlugin = assertCommonRemote(result, monitor, PostgresqlRemote.class, "convertToOutput",
+        Map.of("address", "host=localhost user=postgres sslmode=disable"));
 
     List<String> l = List.of("1","2");
     List<String> l2 = List.of("3","4");
@@ -103,7 +105,8 @@ public class PostgresqlRemoteConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final PostgresqlRemote postgresqlPlugin = assertCommonRemote(result, monitor, PostgresqlRemote.class, "convertToOutput_defaults");
+    final PostgresqlRemote postgresqlPlugin = assertCommonRemote(result, monitor, PostgresqlRemote.class, "convertToOutput_defaults",
+        nullableSummaryValue("address"));
     assertThat(postgresqlPlugin.getAddress()).isEqualTo(null);
     assertThat(postgresqlPlugin.getOutputaddress()).isEqualTo(null);
     assertThat(postgresqlPlugin.getMaxLifetime()).isEqualTo(null);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,19 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.assertCommon;
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.createMonitor;
+import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.nullableSummaryValue;
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
 import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
-import com.rackspace.salus.policy.manage.web.client.PolicyApi;
-import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
@@ -81,7 +82,8 @@ public class SqlServerConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final SqlServer sqlServerPlugin = assertCommon(result, monitor, SqlServer.class, "convertToOutput");
+    final SqlServer sqlServerPlugin = assertCommon(result, monitor, SqlServer.class, "convertToOutput",
+        Map.of("servers", "[1, 2]"));
 
     List<String> l = List.of("1","2");
     List<String> l2 = List.of("3","4");
@@ -100,7 +102,8 @@ public class SqlServerConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final SqlServer sqlServerPlugin = assertCommon(result, monitor, SqlServer.class, "convertToOutput_defaults");
+    final SqlServer sqlServerPlugin = assertCommon(result, monitor, SqlServer.class, "convertToOutput_defaults",
+        nullableSummaryValue("servers"));
     assertThat(sqlServerPlugin.getServers()).isEqualTo(null);
     assertThat(sqlServerPlugin.isAzuredb()).isFalse();
     assertThat(sqlServerPlugin.getQueryExclusions()).isEqualTo(null);

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerRemoteConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/SqlServerRemoteConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,19 @@ package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.assertCommonRemote;
 import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.createMonitor;
+import static com.rackspace.salus.monitor_management.web.model.ConversionHelpers.nullableSummaryValue;
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
 import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
-import com.rackspace.salus.policy.manage.web.client.PolicyApi;
-import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
-import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
+import com.rackspace.salus.monitor_management.web.model.RemoteMonitorDetails;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
@@ -81,7 +82,8 @@ public class SqlServerRemoteConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final SqlServerRemote sqlServerPlugin = assertCommonRemote(result, monitor, SqlServerRemote.class, "convertToOutput");
+    final SqlServerRemote sqlServerPlugin = assertCommonRemote(result, monitor, SqlServerRemote.class, "convertToOutput",
+        Map.of("servers", "[1, 2]"));
 
     List<String> l = List.of("1","2");
     List<String> l2 = List.of("3","4");
@@ -100,7 +102,8 @@ public class SqlServerRemoteConversionTest {
 
     final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
 
-    final SqlServerRemote sqlServerPlugin = assertCommonRemote(result, monitor, SqlServerRemote.class, "convertToOutput_defaults");
+    final SqlServerRemote sqlServerPlugin = assertCommonRemote(result, monitor, SqlServerRemote.class, "convertToOutput_defaults",
+        nullableSummaryValue("servers"));
     assertThat(sqlServerPlugin.getServers()).isEqualTo(null);
     assertThat(sqlServerPlugin.isAzuredb()).isFalse();
     assertThat(sqlServerPlugin.getQueryExclusions()).isEqualTo(null);

--- a/src/test/resources/DetailedMonitorOutputTest/local.json
+++ b/src/test/resources/DetailedMonitorOutputTest/local.json
@@ -19,6 +19,7 @@
       "totalcpu": true
     }
   },
+  "summary": {"key": "value"},
   "createdTimestamp": "1970-01-01T00:00:00Z",
   "updatedTimestamp": "1970-01-01T00:00:01Z"
 }

--- a/src/test/resources/DetailedMonitorOutputTest/remote.json
+++ b/src/test/resources/DetailedMonitorOutputTest/remote.json
@@ -21,6 +21,7 @@
       "timeout": "PT20S"
     }
   },
+  "summary": {"key": "value"},
   "createdTimestamp": "1970-01-01T00:00:00Z",
   "updatedTimestamp": "1970-01-01T00:00:01Z"
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-746

# What

Web frontends for Salus will need a way to convey the difference between several monitors all with the same type.

# How

Introduces a marker-annotation that is picked up by `MonitorConversionService` (not to be confused with "monitor translation") when building `DetailedMonitorOutput` objects returned from the monitor REST API.

## How to test

Updated existing tests to verify the annotated fields specific to each plugin type.