### PR TITLE
Add boolean metadata handler and some other small things

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -107,7 +107,13 @@ public class MetadataUtils {
                 break;
               case DURATION:
                 Duration durationValue = (Duration) f.get(object);
-                if (durationValue.getSeconds() == Long.parseLong(policy.getValue())) {
+                if (durationValue.equals(Duration.parse(policy.getValue()))) {
+                  metadataFields.add(f.getName());
+                }
+                break;
+              case BOOL:
+                Boolean boolValue = (Boolean) f.get(object);
+                if (boolValue == Boolean.parseBoolean(policy.getValue())) {
                   metadataFields.add(f.getName());
                 }
                 break;
@@ -161,6 +167,9 @@ public class MetadataUtils {
           break;
         case DURATION:
           f.set(object, Duration.parse(policy.getValue()));
+          break;
+        case BOOL:
+          f.set(object, Boolean.parseBoolean(policy.getValue()));
           break;
       }
     } catch (IllegalAccessException|NoSuchFieldException e) {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponse.java
@@ -37,8 +37,8 @@ public class HttpResponse extends RemotePlugin {
   String httpProxy;
   Duration timeout;
   @Pattern(regexp = "GET|PUT|POST|DELETE|HEAD|OPTIONS|PATCH|TRACE", message = "invalid http method")
-  String method;
-  boolean followRedirects;
+  String method = "GET";
+  Boolean followRedirects;
   String body;
   String responseStringMatch;
   String tlsCa;

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -117,7 +117,7 @@ public class MetadataUtilsTest {
             .setValue("true")
     );
 
-    // url has a different value than the policy.  even though it was previously using metadata, it is now excluded
+    // url is set and has no policy value.  even though it was previously using metadata, it is now excluded
     // body has a different value than the policy, but is now null so will continue to use metadata regardless
     // timeout has the same value as the metadata and was previously set using it, so it remains as metadata
     // any field that was not previously metadata and is now null will be set to metadata

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.rackspace.salus.monitor_management.web.model.telegraf.Disk;
+import com.rackspace.salus.monitor_management.web.model.telegraf.HttpResponse;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
@@ -83,7 +84,7 @@ public class MetadataUtilsTest {
         "timeout", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
             .setKey("timeout")
             .setValueType(MetadataValueType.DURATION)
-            .setValue("10")
+            .setValue("PT10S")
     );
 
     // count has a different value than the policy.  even though it was previously using metadata, it is now excluded
@@ -93,6 +94,48 @@ public class MetadataUtilsTest {
     // interfaceOrAddress is set to null so it will be set to metadata
     assertThat(MetadataUtils.getMetadataFieldsForUpdate(ping, List.of("count", "timeout"), policies))
         .containsAll(List.of("timeout", "deadline"));
+  }
+
+  @Test
+  public void getMetadataFieldsForUpdate_Http() {
+    HttpResponse ping = new HttpResponse()
+        .setUrl("localhost")
+        .setTimeout(Duration.ofSeconds(12));
+
+    Map<String, MonitorMetadataPolicyDTO> policies = Map.of(
+        "body", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+            .setKey("body")
+            .setValueType(MetadataValueType.STRING)
+            .setValue("httpbody"),
+        "timeout", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+            .setKey("timeout")
+            .setValueType(MetadataValueType.DURATION)
+            .setValue("PT12S"),
+        "followRedirects", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+            .setKey("followRedirects")
+            .setValueType(MetadataValueType.BOOL)
+            .setValue("true")
+    );
+
+    // url has a different value than the policy.  even though it was previously using metadata, it is now excluded
+    // body has a different value than the policy, but is now null so will continue to use metadata regardless
+    // timeout has the same value as the metadata and was previously set using it, so it remains as metadata
+    // any field that was not previously metadata and is now null will be set to metadata
+    List<String> fields = MetadataUtils.getMetadataFieldsForUpdate(
+        ping, List.of("url", "body", "timeout", "followRedirects"), policies);
+
+    assertThat(fields).hasSize(10);
+    assertThat(fields).containsAll(List.of(
+        "httpProxy",
+        "timeout",
+        "followRedirects",
+        "body",
+        "responseStringMatch",
+        "tlsCa",
+        "tlsCert",
+        "tlsKey",
+        "insecureSkipVerify",
+        "headers"));
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponseConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/telegraf/HttpResponseConversionTest.java
@@ -116,7 +116,7 @@ public class HttpResponseConversionTest {
     assertThat(httpPlugin.getHttpProxy()).isEqualTo("http://localhost:8888");
     assertThat(httpPlugin.getTimeout()).isEqualTo(Duration.ofSeconds(5));
     assertThat(httpPlugin.getMethod()).isEqualTo("GET");
-    assertThat(httpPlugin.isFollowRedirects()).isEqualTo(false);
+    assertThat(httpPlugin.getFollowRedirects()).isEqualTo(false);
     assertThat(httpPlugin.getBody()).isEqualTo("{'fake':'data'}");
     assertThat(httpPlugin.getResponseStringMatch()).isEqualTo("\"service_status\": \"up\"");
     assertThat(httpPlugin.getTlsCa()).isEqualTo("/etc/telegraf/ca.pem");


### PR DESCRIPTION
# What / How / Why

Adds a `BOOL` metadata value handler so we can use metadata for boolean values.

Set `followRedirects` to `Boolean` instead of `boolean` so it can come through as null (and use metadata) rather than defaulting to false.

Made a Duration change following on from https://github.com/racker/salus-telemetry-monitor-management/pull/134.  Tests still provided the old `int` payload instead of the duration format so I never caught that I only updated half of the methods previously.

Added a test that hits the BOOL logic.

# Related PRs

https://github.com/Rackspace-Segment-Support/salus-data-loader-content/pull/10
https://github.com/racker/salus-telemetry-model/pull/111
