### PR TITLE
Fix unassigned bound monitor bug

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -653,6 +653,10 @@ public class MonitorManagement {
     else {
       log.debug("No bound monitors were previously assigned to envoy={}", fromEnvoyId);
     }
+
+    // Also check to make sure there are no unassigned bound monitors
+    // This can happen if new monitors are created while all monitors in a zone are down
+    handleNewEnvoyInZone(tenantId, zoneName);
   }
 
   private ResolvedZone resolveZone(String tenantId, String zone) {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -655,7 +655,7 @@ public class MonitorManagement {
     }
 
     // Also check to make sure there are no unassigned bound monitors
-    // This can happen if new monitors are created while all monitors in a zone are down
+    // This can happen if new monitors are created while all poller-envoys in a zone are down
     handleNewEnvoyInZone(tenantId, zoneName);
   }
 


### PR DESCRIPTION
# What

Fix a bug related to bound monitors not being assigned to pollers.

When a previously connected envoy reconnects look to see if there are any bound monitors that are not assigned to an envoy and then try to assign them.

# How

When a `ReattachedResourceZoneEvent` is seen also trigger the same logic that happens when  a `NewResourceZoneEvent` is seen.

## How to test

New tests + manually

# Why

If all pollers in a zone went down and new monitors were created during that time, the bound monitors would be created but not assigned to any envoy.  When the envoys reconnected their previously assigned bound monitors would be updated to attach to the same envoy as before, but any of the new monitors created during the time when they were down would be left with a `null` envoy id.

i.e. Bound Monitors with a `null` envoyId were only being assigned when a new envoy attached and not when a previously seen one attached.
