### PR TITLE
Enable role based json views

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka-test</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-sleuth</artifactId>
     </dependency>
@@ -100,6 +104,11 @@
     <dependency>
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-model</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-common</artifactId>
       <version>0.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/src/main/java/com/rackspace/salus/monitor_management/TelemetryMonitorManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/TelemetryMonitorManagementApplication.java
@@ -18,16 +18,17 @@ package com.rackspace.salus.monitor_management;
 
 import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
 import com.rackspace.salus.common.util.DumpConfigProperties;
-import com.rackspace.salus.common.web.ExtendedErrorAttributesConfig;
+import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
+import com.rackspace.salus.common.web.EnableRoleBasedJsonViews;
 import com.rackspace.salus.telemetry.etcd.EnableEtcd;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
 @EnableSalusKafkaMessaging
 @EnableEtcd
-@Import(ExtendedErrorAttributesConfig.class)
+@EnableRoleBasedJsonViews
+@EnableExtendedErrorAttributes
 public class TelemetryMonitorManagementApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorEventProducer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorEventProducer.java
@@ -1,6 +1,6 @@
 package com.rackspace.salus.monitor_management.services;
 
-import static com.rackspace.salus.common.messaging.KafkaMessageKeyBuilder.buildMessageKey;
+import static com.rackspace.salus.telemetry.messaging.KafkaMessageKeyBuilder.buildMessageKey;
 
 import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -18,7 +18,6 @@ package com.rackspace.salus.monitor_management.web.controller;
 
 import static com.rackspace.salus.monitor_management.web.converter.PatchHelper.JSON_PATCH_TYPE;
 
-import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.monitor_management.services.MonitorContentTranslationService;
 import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.services.MonitorManagement;
@@ -31,7 +30,6 @@ import com.rackspace.salus.telemetry.entities.BoundMonitor;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
-import com.rackspace.salus.telemetry.model.View;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -88,7 +86,6 @@ public class MonitorApiController {
 
   @GetMapping("/admin/monitors")
   @ApiOperation(value = "Gets all Monitors irrespective of Tenant")
-  @JsonView(View.Admin.class)
   public PagedContent<DetailedMonitorOutput> getAll(Pageable pageable) {
 
     return PagedContent.fromPage(monitorManagement.getAllMonitors(pageable)
@@ -98,7 +95,6 @@ public class MonitorApiController {
   @PostMapping("/admin/bound-monitors")
   @ApiOperation(value = "Queries BoundMonitors attached to a particular Envoy"
       + " and translates the content for the given agent types and versions")
-  @JsonView(View.Admin.class)
   public List<BoundMonitorDTO> queryBoundMonitors(@RequestBody @Validated BoundMonitorsRequest query) {
     final List<BoundMonitor> boundMonitors = monitorManagement
         .getAllBoundMonitorsByEnvoyId(query.getEnvoyId());
@@ -111,7 +107,6 @@ public class MonitorApiController {
 
   @GetMapping("/tenant/{tenantId}/monitors/{uuid}")
   @ApiOperation(value = "Gets specific Monitor for Tenant")
-  @JsonView(View.Public.class)
   public DetailedMonitorOutput getById(@PathVariable String tenantId,
                                        @PathVariable UUID uuid) throws NotFoundException {
     Monitor monitor = monitorManagement.getMonitor(tenantId, uuid).orElseThrow(
@@ -123,7 +118,6 @@ public class MonitorApiController {
 
   @GetMapping("/tenant/{tenantId}/policy-monitors")
   @ApiOperation(value = "Gets all Policy Monitors for Tenant")
-  @JsonView(View.Public.class)
   public PagedContent<DetailedMonitorOutput> getAllPolicyMonitorsForTenant(
       @PathVariable String tenantId, Pageable pageable)
       throws NotFoundException {
@@ -134,7 +128,6 @@ public class MonitorApiController {
 
   @GetMapping("/tenant/{tenantId}/policy-monitors/{uuid}")
   @ApiOperation(value = "Gets specific Policy Monitor for Tenant")
-  @JsonView(View.Public.class)
   public DetailedMonitorOutput getPolicyMonitorForTenant(
       @PathVariable String tenantId, @PathVariable UUID uuid)
       throws NotFoundException {
@@ -144,7 +137,6 @@ public class MonitorApiController {
 
   @GetMapping("/admin/policy-monitors")
   @ApiOperation(value = "Gets all Policy Monitors")
-  @JsonView(View.Admin.class)
   public PagedContent<DetailedMonitorOutput> getAllPolicyMonitors(Pageable pageable) {
     return PagedContent.fromPage(monitorManagement.getAllPolicyMonitors(pageable)
         .map(monitorConversionService::convertToOutput));
@@ -152,7 +144,6 @@ public class MonitorApiController {
 
   @GetMapping("/admin/policy-monitors/{uuid}")
   @ApiOperation(value = "Get specific Policy Monitor by Id")
-  @JsonView(View.Admin.class)
   public DetailedMonitorOutput getPolicyMonitorById(@PathVariable UUID uuid)
       throws NotFoundException {
     Monitor monitor = monitorManagement.getPolicyMonitor(uuid).orElseThrow(() ->
@@ -163,7 +154,6 @@ public class MonitorApiController {
 
   @PutMapping("/admin/policy-monitors/{uuid}")
   @ApiOperation(value = "Updates specific Policy Monitor")
-  @JsonView(View.Admin.class)
   public DetailedMonitorOutput updatePolicyMonitor(@PathVariable UUID uuid,
                                                    @Validated(ValidationGroups.Update.class)
                                                    @RequestBody final DetailedMonitorInput input)
@@ -179,7 +169,6 @@ public class MonitorApiController {
   @PatchMapping(path = "/admin/policy-monitors/{uuid}",
                 consumes = {MediaType.APPLICATION_JSON_VALUE, JSON_PATCH_TYPE})
   @ApiOperation(value = "Patch specific Policy Monitor")
-  @JsonView(View.Admin.class)
   public DetailedMonitorOutput patchPolicyMonitor(@PathVariable UUID uuid,
                                                   @RequestBody final JsonPatch input)
       throws IllegalArgumentException {
@@ -199,7 +188,6 @@ public class MonitorApiController {
   @ResponseStatus(HttpStatus.CREATED)
   @ApiOperation(value = "Creates new Policy Monitor")
   @ApiResponses(value = {@ApiResponse(code = 201, message = "Successfully Created Policy Monitor")})
-  @JsonView(View.Admin.class)
   public DetailedMonitorOutput createPolicyMonitor(
       @Validated(ValidationGroups.Create.class)
       @RequestBody final DetailedMonitorInput input)
@@ -213,13 +201,11 @@ public class MonitorApiController {
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation(value = "Deletes specific Policy Monitor")
   @ApiResponses(value = {@ApiResponse(code = 204, message = "Policy Monitor Deleted")})
-  @JsonView(View.Admin.class)
   public void deletePolicyMonitor(@PathVariable UUID uuid) {
     monitorManagement.removePolicyMonitor(uuid);
   }
 
   @GetMapping("/tenant/{tenantId}/bound-monitors")
-  @JsonView(View.Public.class)
   public PagedContent<BoundMonitorDTO> getBoundMonitorsForTenant(@PathVariable String tenantId,
                                                                  Pageable pageable) {
     return PagedContent.fromPage(
@@ -230,7 +216,6 @@ public class MonitorApiController {
 
   @GetMapping("/tenant/{tenantId}/monitors")
   @ApiOperation(value = "Gets all Monitors for Tenant")
-  @JsonView(View.Public.class)
   public PagedContent<DetailedMonitorOutput> getAllForTenant(@PathVariable String tenantId,
                                                              Pageable pageable) {
 
@@ -242,7 +227,6 @@ public class MonitorApiController {
   @ResponseStatus(HttpStatus.CREATED)
   @ApiOperation(value = "Creates new Monitor for Tenant")
   @ApiResponses(value = {@ApiResponse(code = 201, message = "Successfully Created Monitor")})
-  @JsonView(View.Public.class)
   public DetailedMonitorOutput create(@PathVariable String tenantId,
                                       @Validated(ValidationGroups.Create.class)
                                       @RequestBody final DetailedMonitorInput input)
@@ -257,7 +241,6 @@ public class MonitorApiController {
 
   @PutMapping("/tenant/{tenantId}/monitors/{uuid}")
   @ApiOperation(value = "Updates specific Monitor for Tenant")
-  @JsonView(View.Public.class)
   public DetailedMonitorOutput update(@PathVariable String tenantId,
                                       @PathVariable UUID uuid,
                                       @Validated(ValidationGroups.Update.class)
@@ -275,7 +258,6 @@ public class MonitorApiController {
   @PatchMapping(path = "/tenant/{tenantId}/monitors/{uuid}",
                 consumes = {MediaType.APPLICATION_JSON_VALUE, JSON_PATCH_TYPE})
   @ApiOperation(value = "Updates specific Monitor for Tenant")
-  @JsonView(View.Public.class)
   public DetailedMonitorOutput patch(@PathVariable String tenantId,
       @PathVariable UUID uuid,
       @RequestBody final JsonPatch input)
@@ -299,7 +281,6 @@ public class MonitorApiController {
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation(value = "Deletes specific Monitor for Tenant")
   @ApiResponses(value = {@ApiResponse(code = 204, message = "Resource Deleted")})
-  @JsonView(View.Public.class)
   public void delete(@PathVariable String tenantId,
                      @PathVariable UUID uuid) {
     monitorManagement.removeMonitor(tenantId, uuid);
@@ -307,7 +288,6 @@ public class MonitorApiController {
 
   @GetMapping("/tenant/{tenantId}/monitor-labels")
   @ApiOperation(value = "Gets all Monitors that match labels. All labels must match to retrieve relevant Monitors.")
-  @JsonView(View.Public.class)
   public PagedContent<DetailedMonitorOutput> getMonitorsWithLabels(@PathVariable String tenantId,
                                                                    @RequestBody Map<String, String> labels,
                                                                    Pageable pageable) {
@@ -317,7 +297,6 @@ public class MonitorApiController {
 
   @GetMapping("/tenant/{tenantId}/monitor-label-selectors")
   @ApiOperation("Lists the label selector keys and the values for each that are currently in use on monitors")
-  @JsonView(View.Public.class)
   public MultiValueMap<String, String> getMonitorLabelSelectors(@PathVariable String tenantId) {
     return monitorManagement.getTenantMonitorLabelSelectors(tenantId);
   }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorTranslationApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorTranslationApiController.java
@@ -16,12 +16,10 @@
 
 package com.rackspace.salus.monitor_management.web.controller;
 
-import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.monitor_management.services.MonitorContentTranslationService;
 import com.rackspace.salus.monitor_management.web.model.MonitorTranslationOperatorCreate;
 import com.rackspace.salus.monitor_management.web.model.MonitorTranslationOperatorDTO;
 import com.rackspace.salus.telemetry.model.PagedContent;
-import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorTranslationApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorTranslationApiController.java
@@ -21,7 +21,7 @@ import com.rackspace.salus.monitor_management.services.MonitorContentTranslation
 import com.rackspace.salus.monitor_management.web.model.MonitorTranslationOperatorCreate;
 import com.rackspace.salus.monitor_management.web.model.MonitorTranslationOperatorDTO;
 import com.rackspace.salus.telemetry.model.PagedContent;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -64,7 +64,6 @@ public class MonitorTranslationApiController {
 
   @GetMapping("/admin/monitor-translations")
   @ApiOperation("Gets all monitor translation operators")
-  @JsonView(View.Admin.class)
   public PagedContent<MonitorTranslationOperatorDTO> getAll(Pageable pageable) {
     return PagedContent.fromPage(monitorContentTranslationService.getAll(pageable))
         .map(MonitorTranslationOperatorDTO::new);
@@ -72,7 +71,6 @@ public class MonitorTranslationApiController {
 
   @GetMapping("/admin/monitor-translations/{id}")
   @ApiOperation("Gets a specific monitor translation operator")
-  @JsonView(View.Admin.class)
   public MonitorTranslationOperatorDTO getById(@PathVariable UUID id) {
     return new MonitorTranslationOperatorDTO(
         monitorContentTranslationService.getById(id)
@@ -83,7 +81,6 @@ public class MonitorTranslationApiController {
   @ResponseStatus(HttpStatus.CREATED)
   @ApiOperation("Create a new monitor translation operator")
   @ApiResponses(value = {@ApiResponse(code = 201, message = "Successfully created")})
-  @JsonView(View.Admin.class)
   public MonitorTranslationOperatorDTO create(@RequestBody @Valid MonitorTranslationOperatorCreate in) {
     return new MonitorTranslationOperatorDTO(
         monitorContentTranslationService.create(in)
@@ -94,7 +91,6 @@ public class MonitorTranslationApiController {
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation("Delete a monitor translation operator")
   @ApiResponses(value = {@ApiResponse(code = 204, message = "Successfully deleted")})
-  @JsonView(View.Admin.class)
   public void delete(@PathVariable UUID id) {
     monitorContentTranslationService.delete(id);
   }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -15,8 +15,6 @@
  */
 package com.rackspace.salus.monitor_management.web.controller;
 
-import com.fasterxml.jackson.annotation.JsonView;
-import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.monitor_management.services.MonitorManagement;
 import com.rackspace.salus.monitor_management.services.ZoneManagement;
 import com.rackspace.salus.monitor_management.web.model.MonitorDTO;
@@ -26,12 +24,12 @@ import com.rackspace.salus.monitor_management.web.model.ZoneCreatePrivate;
 import com.rackspace.salus.monitor_management.web.model.ZoneCreatePublic;
 import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
 import com.rackspace.salus.monitor_management.web.model.ZoneUpdate;
+import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.etcd.types.PrivateZoneName;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
-import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.Authorization;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -31,7 +31,7 @@ import com.rackspace.salus.telemetry.etcd.types.PrivateZoneName;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.Authorization;
@@ -79,7 +79,6 @@ public class ZoneApiController {
 
   @GetMapping("/tenant/{tenantId}/zones/**")
   @ApiOperation(value = "Gets specific zone by tenant id and zone name")
-  @JsonView(View.Public.class)
   public ZoneDTO getAvailableZone(@PathVariable String tenantId, HttpServletRequest request) {
     String name = extractZoneNameFromUri(request);
     return getByZoneName(tenantId, name);
@@ -98,7 +97,6 @@ public class ZoneApiController {
 
   @GetMapping("/admin/zones/**")
   @ApiOperation(value = "Gets specific public zone by name")
-  @JsonView(View.Admin.class)
   public ZoneDTO getPublicZone(HttpServletRequest request) {
     String name = extractZoneNameFromUri(request);
     return getByZoneName(null, name);
@@ -138,7 +136,6 @@ public class ZoneApiController {
 
   @GetMapping("/tenant/{tenantId}/zone-assignment-counts/{name}")
   @ApiOperation(value = "Gets assignment counts of monitors to poller-envoys in the private zone")
-  @JsonView(View.Public.class)
   public CompletableFuture<List<ZoneAssignmentCount>> getPrivateZoneAssignmentCounts(
       @PathVariable String tenantId, @PathVariable @PrivateZoneName String name) {
 
@@ -151,7 +148,6 @@ public class ZoneApiController {
 
   @GetMapping("/admin/zone-assignment-counts/**")
   @ApiOperation(value = "Gets assignment counts of monitors to poller-envoys in the public zone")
-  @JsonView(View.Admin.class)
   public CompletableFuture<List<ZoneAssignmentCount>> getPublicZoneAssignmentCounts(
       HttpServletRequest request) {
 
@@ -167,7 +163,6 @@ public class ZoneApiController {
   @PostMapping("/tenant/{tenantId}/zones")
   @ResponseStatus(HttpStatus.CREATED)
   @ApiOperation(value = "Creates a new private zone for the tenant")
-  @JsonView(View.Public.class)
   public ZoneDTO create(@PathVariable String tenantId, @Valid @RequestBody ZoneCreatePrivate zone)
           throws AlreadyExistsException {
     return new ZoneDTO(zoneManagement.createPrivateZone(tenantId, zone));
@@ -176,7 +171,6 @@ public class ZoneApiController {
   @PostMapping("/admin/zones")
   @ResponseStatus(HttpStatus.CREATED)
   @ApiOperation(value = "Creates a new public zone")
-  @JsonView(View.Admin.class)
   public ZoneDTO create(@Valid @RequestBody ZoneCreatePublic zone)
       throws AlreadyExistsException {
     return new ZoneDTO(zoneManagement.createPublicZone(zone));
@@ -184,14 +178,12 @@ public class ZoneApiController {
 
   @PutMapping("/tenant/{tenantId}/zones/{name}")
   @ApiOperation(value = "Updates a specific private zone for the tenant")
-  @JsonView(View.Public.class)
   public ZoneDTO update(@PathVariable String tenantId, @PathVariable String name, @Valid @RequestBody ZoneUpdate zone) {
     return new ZoneDTO(zoneManagement.updatePrivateZone(tenantId, name, zone));
   }
 
   @PutMapping("/admin/zones/**")
   @ApiOperation(value = "Updates a specific public zone")
-  @JsonView(View.Admin.class)
   public ZoneDTO update(HttpServletRequest request, @Valid @RequestBody ZoneUpdate zone) {
     String name = extractPublicZoneNameFromUri(request);
     return new ZoneDTO(zoneManagement.updatePublicZone(name, zone));
@@ -199,7 +191,6 @@ public class ZoneApiController {
 
   @PostMapping("/tenant/{tenantId}/rebalance-zone/{name}")
   @ApiOperation(value = "Rebalances a private zone")
-  @JsonView(View.Public.class)
   public CompletableFuture<RebalanceResult> rebalancePrivateZone(@PathVariable String tenantId,
                                                                  @PathVariable @PrivateZoneName String name) {
     if (!zoneManagement.exists(tenantId, name)) {
@@ -212,7 +203,6 @@ public class ZoneApiController {
 
   @PostMapping("/admin/rebalance-zone/**")
   @ApiOperation(value = "Rebalances a public zone")
-  @JsonView(View.Admin.class)
   public CompletableFuture<RebalanceResult> rebalancePublicZone(HttpServletRequest request) {
     String name = extractPublicZoneNameFromUri(request);
 
@@ -227,7 +217,6 @@ public class ZoneApiController {
   @DeleteMapping("/tenant/{tenantId}/zones/{name}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation(value = "Deletes a specific private zone for the tenant")
-  @JsonView(View.Public.class)
   public void delete(@PathVariable String tenantId,
                      @PathVariable @PrivateZoneName String name) {
     zoneManagement.removePrivateZone(tenantId, name);
@@ -236,7 +225,6 @@ public class ZoneApiController {
   @DeleteMapping("/admin/zones/**")
   @ApiOperation(value = "Deletes a specific public zone")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  @JsonView(View.Admin.class)
   public void delete(HttpServletRequest request) {
     String name = extractPublicZoneNameFromUri(request);
     zoneManagement.removePublicZone(name);
@@ -244,7 +232,6 @@ public class ZoneApiController {
 
   @GetMapping("/tenant/{tenantId}/zones")
   @ApiOperation(value = "Gets all zones available to be used in the tenant's monitor configurations")
-  @JsonView(View.Public.class)
   public PagedContent<ZoneDTO> getAvailableZones(@PathVariable String tenantId, Pageable pageable) {
     return PagedContent.fromPage(
         zoneManagement.getAvailableZonesForTenant(tenantId, pageable)
@@ -253,7 +240,6 @@ public class ZoneApiController {
 
   @GetMapping("/admin/zones")
   @ApiOperation(value = "Gets all public zones")
-  @JsonView(View.Admin.class)
   public PagedContent<ZoneDTO> getAllPublicZones(Pageable pageable) {
     return PagedContent.fromPage(
         zoneManagement.getAllPublicZones(pageable)
@@ -262,7 +248,6 @@ public class ZoneApiController {
 
   @GetMapping("/tenant/{tenantId}/monitors-by-zone/{zone}")
   @ApiOperation(value = "Gets all monitors in a given zone for a specific tenant")
-  @JsonView(View.Public.class)
   public PagedContent<MonitorDTO> getMonitorsForZone(@PathVariable String tenantId, @PathVariable String zone, Pageable pageable) {
     return PagedContent.fromPage(
         zoneManagement.getMonitorsForZone(tenantId, zone, pageable)

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
@@ -23,7 +23,7 @@ import com.rackspace.salus.telemetry.entities.BoundMonitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import java.time.Duration;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneDTO.java
@@ -17,7 +17,7 @@ package com.rackspace.salus.monitor_management.web.model;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.telemetry.entities.Zone;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import com.rackspace.salus.telemetry.model.ZoneState;
 import java.time.format.DateTimeFormatter;
 import lombok.Data;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,15 +8,15 @@ salus:
       http://localhost:8085
     policyManagementUrl:
       http://localhost:8091
-    common:
-      roles:
-        role-to-view:
-          # An anonymous role is used for unauthenticated requests.
-          # i.e. internal service-to-service requests.
-          ROLE_ANONYMOUS: ADMIN
-          ROLE_CUSTOMER: PUBLIC
-          ROLE_EMPLOYEE: INTERNAL
-          ROLE_ENGINEER: ADMIN
+  common:
+    roles:
+      role-to-view:
+        # An anonymous role is used for unauthenticated requests.
+        # i.e. internal service-to-service requests.
+        ROLE_ANONYMOUS: ADMIN
+        ROLE_CUSTOMER: PUBLIC
+        ROLE_EMPLOYEE: INTERNAL
+        ROLE_ENGINEER: ADMIN
 spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,6 +8,15 @@ salus:
       http://localhost:8085
     policyManagementUrl:
       http://localhost:8091
+    common:
+      roles:
+        role-to-view:
+          # An anonymous role is used for unauthenticated requests.
+          # i.e. internal service-to-service requests.
+          ROLE_ANONYMOUS: ADMIN
+          ROLE_CUSTOMER: PUBLIC
+          ROLE_EMPLOYEE: INTERNAL
+          ROLE_ENGINEER: ADMIN
 spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,7 @@
+salus:
+  common:
+    roles:
+      role-to-view:
+        ROLE_CUSTOMER: PUBLIC
+        ROLE_EMPLOYEE: INTERNAL
+        ROLE_ENGINEER: ADMIN

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/ZoneDTOTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/ZoneDTOTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.telemetry.entities.Zone;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import org.junit.Test;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;

--- a/src/test/resources/ZoneApiControllerTest/privateZone_basic.json
+++ b/src/test/resources/ZoneApiControllerTest/privateZone_basic.json
@@ -5,6 +5,7 @@
   "providerRegion":"p-r-1",
   "sourceIpAddresses":[],
   "public":false,
+  "state":"ACTIVE",
   "createdTimestamp": "1970-01-02T03:46:40Z",
   "updatedTimestamp": "1970-01-02T03:46:40Z"
 }

--- a/src/test/resources/ZoneApiControllerTest/privateZone_underscores.json
+++ b/src/test/resources/ZoneApiControllerTest/privateZone_underscores.json
@@ -4,6 +4,7 @@
   "provider":"p-1",
   "providerRegion":"p-r-1",
   "sourceIpAddresses":[],
+  "state":"ACTIVE",
   "public":false,
   "createdTimestamp": "1970-01-02T03:46:40Z",
   "updatedTimestamp": "1970-01-02T03:46:40Z"

--- a/src/test/resources/ZoneApiControllerTest/publicZone_as_admin.json
+++ b/src/test/resources/ZoneApiControllerTest/publicZone_as_admin.json
@@ -5,6 +5,7 @@
   "providerRegion":"p-r-1",
   "sourceIpAddresses":["127.0.0.1/27"],
   "public":true,
+  "state":"ACTIVE",
   "createdTimestamp": "1970-01-02T03:46:40Z",
   "updatedTimestamp": "1970-01-02T03:46:40Z"
 }

--- a/src/test/resources/ZoneApiControllerTest/publicZone_as_customer.json
+++ b/src/test/resources/ZoneApiControllerTest/publicZone_as_customer.json
@@ -5,6 +5,7 @@
   "providerRegion":"p-r-1",
   "sourceIpAddresses":["127.0.0.1/27"],
   "public":true,
+  "state":"ACTIVE",
   "createdTimestamp": "1970-01-02T03:46:40Z",
   "updatedTimestamp": "1970-01-02T03:46:40Z"
 }


### PR DESCRIPTION
# What

Enable role based json views instead of endpoint driven views.

# How

1. Add `@EnableRoleBasedJsonViews` to app
   * https://github.com/racker/salus-common/pull/49
1. Remove `@JsonView` annotations on api controllers
1. Add default role mappings to `application-dev.yml`

# Why

See https://github.com/racker/salus-common/pull/49
