### PR TITLE
Remove json view from controller

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorSchemaController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorSchemaController.java
@@ -16,10 +16,8 @@
 
 package com.rackspace.salus.monitor_management.web.controller;
 
-import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.rackspace.salus.monitor_management.services.SchemaService;
-import com.rackspace.salus.telemetry.model.View;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,7 +34,6 @@ public class MonitorSchemaController {
   }
 
   @GetMapping("/monitor-plugins")
-  @JsonView(View.Public.class)
   public JsonNode getMonitorPluginsSchema() {
     return schemaService.getMonitorPluginsSchema();
   }


### PR DESCRIPTION
With the recent changes to add role based json views, this is no longer needed and is currently making the build fail since `View` moved from model to common.