### PR TITLE
Route zone API requests properly for public zones

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/TelemetryMonitorManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/TelemetryMonitorManagementApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.monitor_management;
 
+import com.rackspace.salus.common.config.AutoConfigureSalusAppMetrics;
 import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
 import com.rackspace.salus.common.util.DumpConfigProperties;
 import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
@@ -29,6 +30,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @EnableEtcd
 @EnableRoleBasedJsonViews
 @EnableExtendedErrorAttributes
+@AutoConfigureSalusAppMetrics
 public class TelemetryMonitorManagementApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,11 +71,21 @@ public class ZoneApiClient implements ZoneApi {
   @Override
   public ZoneDTO getByZoneName(String tenantId, String name) {
     try {
-      return restTemplate.getForObject(
-          "/api/tenant/{tenantId}/zones/{name}",
-          ZoneDTO.class,
-          tenantId, name
-      );
+      if (tenantId == null) {
+        // Public zones do not have an owning tenant, so use the admin, public zone API
+
+        return restTemplate.getForObject(
+            // can't use regular URL placeholders since it would URL-encode the slash in the zone name
+            String.format("/api/admin/zones/%s", name),
+            ZoneDTO.class
+        );
+      } else {
+        return restTemplate.getForObject(
+            "/api/tenant/{tenantId}/zones/{name}",
+            ZoneDTO.class,
+            tenantId, name
+        );
+      }
     } catch (HttpClientErrorException e) {
       if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
         return null;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClientTest.java
@@ -1,4 +1,25 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.monitor_management.web.client;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,11 +36,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.MockRestServiceServer;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
-
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 @RunWith(SpringRunner.class)
 @RestClientTest
@@ -42,7 +58,7 @@ public class ZoneApiClientTest {
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void testGetByZoneName() throws JsonProcessingException {
+    public void testGetByZoneName_private() throws JsonProcessingException {
         ZoneDTO expectedZone = podamFactory.manufacturePojo(ZoneDTO.class);
         mockServer.expect(requestTo("/api/tenant/t-1/zones/z-1"))
                 .andRespond(withSuccess(
@@ -50,6 +66,19 @@ public class ZoneApiClientTest {
                 ));
 
         final ZoneDTO zone = zoneApiClient.getByZoneName("t-1", "z-1");
+
+        assertThat(zone, equalTo(expectedZone));
+    }
+
+    @Test
+    public void testGetByZoneName_public() throws JsonProcessingException {
+        ZoneDTO expectedZone = podamFactory.manufacturePojo(ZoneDTO.class);
+        mockServer.expect(requestTo("/api/admin/zones/public/west"))
+                .andRespond(withSuccess(
+                        objectMapper.writeValueAsString(expectedZone), MediaType.APPLICATION_JSON
+                ));
+
+        final ZoneDTO zone = zoneApiClient.getByZoneName(null, "public/west");
 
         assertThat(zone, equalTo(expectedZone));
     }


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-806

# What

The Jira has a lot more details, but in short, when a public poller-envoy re-attaches it uses the ZoneApi to retrieve the zone. The ZoneApiClient was always routing the requests to the private zone endpoint, which fails with a 400 (rightly so) when the tenant was missing.

# How

Route to the proper endpoint based upon the presence of the tenant ID in the retrieval.

## How to test

Updated unit tests