### PR TITLE
resourceId case insensitive comparison

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1211,15 +1211,16 @@ public class MonitorManagement {
                                                   Map<String, String> labelSelector,
                                                   @NotNull LabelSelectorMethod labelSelectorMethod,
                                                   Set<String> excludedResourceIds) {
+    Set<String> finalExcludedResourceIds = excludedResourceIds.stream()
+        .map(String::toLowerCase)
+        .collect(Collectors.toSet());
+
     return resourceApi
         .getResourcesWithLabels(tenantId, labelSelector, labelSelectorMethod)
         .stream()
         // filter to keep resources that are not in the given exclusion set
-        .filter(resourceDTO -> excludedResourceIds == null ||
-            !excludedResourceIds.stream()
-                .map(String::toLowerCase)
-                .collect(Collectors.toSet())
-                .contains(resourceDTO.getResourceId().toLowerCase()))
+        .filter(resourceDTO -> finalExcludedResourceIds == null ||
+                finalExcludedResourceIds.contains(resourceDTO.getResourceId().toLowerCase()))
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1216,8 +1216,10 @@ public class MonitorManagement {
         .stream()
         // filter to keep resources that are not in the given exclusion set
         .filter(resourceDTO -> excludedResourceIds == null ||
-            !excludedResourceIds.stream().map(String::toLowerCase).collect(Collectors.toList()).contains(resourceDTO.getResourceId().toLowerCase()))
-            //!excludedResourceIds.contains(resourceDTO.getResourceId()))
+            !excludedResourceIds.stream()
+                .map(String::toLowerCase)
+                .collect(Collectors.toSet())
+                .contains(resourceDTO.getResourceId().toLowerCase()))
         .collect(Collectors.toList());
   }
 
@@ -1447,8 +1449,7 @@ public class MonitorManagement {
           // but filter to include only monitors that don't exclude this resource
           .filter(monitor -> monitor.getExcludedResourceIds() == null ||
               !monitor.getExcludedResourceIds().stream().map(String::toLowerCase).collect(
-                  Collectors.toList()).contains(resourceId.toLowerCase()))
-              //!monitor.getExcludedResourceIds().contains(resourceId))
+                  Collectors.toSet()).contains(resourceId.toLowerCase()))
           .collect(Collectors.toList());
       //grab monitors that are using resourceId instead of labels
       selectedMonitors.addAll(monitorsWithResourceId);

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1216,7 +1216,8 @@ public class MonitorManagement {
         .stream()
         // filter to keep resources that are not in the given exclusion set
         .filter(resourceDTO -> excludedResourceIds == null ||
-            !excludedResourceIds.contains(resourceDTO.getResourceId()))
+            !excludedResourceIds.stream().map(String::toLowerCase).collect(Collectors.toList()).contains(resourceDTO.getResourceId().toLowerCase()))
+            //!excludedResourceIds.contains(resourceDTO.getResourceId()))
         .collect(Collectors.toList());
   }
 
@@ -1445,7 +1446,9 @@ public class MonitorManagement {
           .stream()
           // but filter to include only monitors that don't exclude this resource
           .filter(monitor -> monitor.getExcludedResourceIds() == null ||
-              !monitor.getExcludedResourceIds().contains(resourceId))
+              !monitor.getExcludedResourceIds().stream().map(String::toLowerCase).collect(
+                  Collectors.toList()).contains(resourceId.toLowerCase()))
+              //!monitor.getExcludedResourceIds().contains(resourceId))
           .collect(Collectors.toList());
       //grab monitors that are using resourceId instead of labels
       selectedMonitors.addAll(monitorsWithResourceId);

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1211,16 +1211,20 @@ public class MonitorManagement {
                                                   Map<String, String> labelSelector,
                                                   @NotNull LabelSelectorMethod labelSelectorMethod,
                                                   Set<String> excludedResourceIds) {
-    Set<String> finalExcludedResourceIds = excludedResourceIds.stream()
-        .map(String::toLowerCase)
-        .collect(Collectors.toSet());
-
+    final Set<String> finalExcludedResourceIds;
+    if(excludedResourceIds != null) {
+      finalExcludedResourceIds = excludedResourceIds.stream()
+          .map(String::toLowerCase)
+          .collect(Collectors.toSet());
+    }else {
+      finalExcludedResourceIds = null;
+    }
     return resourceApi
         .getResourcesWithLabels(tenantId, labelSelector, labelSelectorMethod)
         .stream()
         // filter to keep resources that are not in the given exclusion set
         .filter(resourceDTO -> finalExcludedResourceIds == null ||
-                finalExcludedResourceIds.contains(resourceDTO.getResourceId().toLowerCase()))
+                !finalExcludedResourceIds.contains(resourceDTO.getResourceId().toLowerCase()))
         .collect(Collectors.toList());
   }
 
@@ -1442,7 +1446,7 @@ public class MonitorManagement {
         log.warn("Resource change event indicated deletion, but resource is present: {}", resource);
         // continue with normal processing, assuming it got revived concurrently
       }
-
+      String lowerResourceId = resourceId.toLowerCase();
       // Grab all monitors using labels first
       selectedMonitors = getMonitorsFromLabels(
           resource.get().getLabels(), tenantId, Pageable.unpaged()).getContent()
@@ -1450,7 +1454,7 @@ public class MonitorManagement {
           // but filter to include only monitors that don't exclude this resource
           .filter(monitor -> monitor.getExcludedResourceIds() == null ||
               !monitor.getExcludedResourceIds().stream().map(String::toLowerCase).collect(
-                  Collectors.toSet()).contains(resourceId.toLowerCase()))
+                  Collectors.toSet()).contains(lowerResourceId))
           .collect(Collectors.toList());
       //grab monitors that are using resourceId instead of labels
       selectedMonitors.addAll(monitorsWithResourceId);

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePrivate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePrivate.java
@@ -30,7 +30,7 @@ import org.hibernate.validator.constraints.NotBlank;
 public class ZoneCreatePrivate implements Serializable {
 
     @NotBlank
-    @Pattern(regexp = "^[A-Za-z0-9_]+$", message = "Only alphanumeric and underscore characters can be used")
+    @Pattern(regexp = "^[a-z0-9_]+$", message = "Only lowercase alphanumeric and underscore characters can be used")
     @PrivateZoneName
     String name;
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePublic.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneCreatePublic.java
@@ -31,7 +31,7 @@ import org.hibernate.validator.constraints.NotBlank;
 public class ZoneCreatePublic implements Serializable {
 
   @NotBlank
-  @Pattern(regexp = "^[A-Za-z0-9_/]+$", message = "Only alphanumeric, underscores, and slashes can be used")
+  @Pattern(regexp = "^[a-z0-9_/]+$", message = "Only lowercase alphanumeric, underscores, and slashes can be used")
   @PublicZoneName
   String name;
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
@@ -426,7 +426,7 @@ public class MonitorManagementExcludeResourceIdsTest {
     final UUID excludingMonitorId = entityManager.persistAndGetId(
         new Monitor()
             // JPA needs a mutable collection
-            .setExcludedResourceIds(new HashSet<>(Set.of("r-new")))
+            .setExcludedResourceIds(new HashSet<>(Set.of("r-NEW")))
             .setTenantId("t-1")
             .setMonitorType(MonitorType.cpu)
             .setSelectorScope(ConfigSelectorScope.LOCAL)
@@ -485,7 +485,7 @@ public class MonitorManagementExcludeResourceIdsTest {
     final UUID monitorId = entityManager.persistAndGetId(
         new Monitor()
             .setTenantId("t-1")
-            .setResourceId("r-specific")
+            .setResourceId("r-SPECIFIC")
             .setMonitorType(MonitorType.cpu)
             .setSelectorScope(ConfigSelectorScope.LOCAL)
             .setAgentType(AgentType.TELEGRAF)
@@ -507,7 +507,7 @@ public class MonitorManagementExcludeResourceIdsTest {
     final UUID monitorId = entityManager.persistAndGetId(
         new Monitor()
             .setTenantId("t-1")
-            .setExcludedResourceIds(new HashSet<>(Set.of("r-excluded")))
+            .setExcludedResourceIds(new HashSet<>(Set.of("r-EXCLUDED")))
             .setMonitorType(MonitorType.cpu)
             .setSelectorScope(ConfigSelectorScope.LOCAL)
             .setAgentType(AgentType.TELEGRAF)

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
@@ -360,7 +360,7 @@ public class MonitorManagementExcludeResourceIdsTest {
         "t-1",
         new MonitorCU()
             // setup the exclusion that comes into play after labels get changed
-            .setExcludedResourceIds(Set.of("r-absent-exclude"))
+            .setExcludedResourceIds(Set.of("r-absent-Exclude"))
             .setLabelSelector(Map.of("stage", "before"))
             .setLabelSelectorMethod(LabelSelectorMethod.AND)
             .setMonitorType(MonitorType.cpu)

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -98,14 +98,14 @@ public class ZoneApiControllerTest {
     private ZoneCreatePrivate newZoneCreatePrivate() {
         Random random = new Random();
         return new ZoneCreatePrivate()
-                .setName(RandomStringUtils.randomAlphanumeric(10))
+                .setName(RandomStringUtils.randomAlphanumeric(10).toLowerCase())
                 .setPollerTimeout(random.nextInt(1000) + 30L);
     }
 
     private ZoneCreatePublic newZoneCreatePublic() {
         Random random = new Random();
         return new ZoneCreatePublic()
-            .setName(ResolvedZone.PUBLIC_PREFIX + RandomStringUtils.randomAlphanumeric(6))
+            .setName(ResolvedZone.PUBLIC_PREFIX + RandomStringUtils.randomAlphanumeric(6).toLowerCase())
             .setProvider(RandomStringUtils.randomAlphanumeric(6))
             .setProviderRegion(RandomStringUtils.randomAlphanumeric(6))
             .setPollerTimeout(random.nextInt(1000) + 30L)
@@ -393,7 +393,7 @@ public class ZoneApiControllerTest {
             .characterEncoding(StandardCharsets.UTF_8.name()))
             .andExpect(status().isBadRequest())
             .andExpect(validationError("name",
-                "Only alphanumeric and underscore characters can be used"));
+                "Only lowercase alphanumeric and underscore characters can be used"));
     }
 
     @Test


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-694

# What

Make sure that the resource id for exclusions is doing a case insensitive check in the code since that is what the database is doing. 

# How

When we get the resourceId's back we toLowerCase them for comparison but don't alter the values being stored at all. 

## How to test

Run unit tests

# Why

The collation in the database meant that we were already doing case insensitive comparisons. Behind the scenes its just a bit shift one way or the other between upper and lower case conversion, and I am not aware of a better/easier way to do case insensitive comparison in java.

# TODO

Should be done
