### PR TITLE
Added activation of PolicyApiCacheConfig

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,18 @@
       <artifactId>jmustache</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <optional>true</optional>

--- a/src/main/java/com/rackspace/salus/monitor_management/config/RestClientsConfig.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/RestClientsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.rackspace.salus.monitor_management.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.policy.manage.web.client.PolicyApiCacheConfig;
 import com.rackspace.salus.policy.manage.web.client.PolicyApiClient;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.resource_management.web.client.ResourceApiClient;
@@ -25,8 +26,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 @Configuration
+@Import(PolicyApiCacheConfig.class)
 public class RestClientsConfig {
 
   private final ServicesProperties servicesProperties;

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1276,7 +1276,7 @@ public class MonitorManagement {
     log.info("Handling metadata policy event={}", event);
 
     String tenantId = event.getTenantId();
-    List<MonitorMetadataPolicyDTO> effectivePolicies = policyApi.getEffectiveMonitorMetadataPolicies(tenantId);
+    List<MonitorMetadataPolicyDTO> effectivePolicies = policyApi.getEffectiveMonitorMetadataPolicies(tenantId, false);
 
     Optional<MonitorMetadataPolicyDTO> policyOptional = effectivePolicies.stream()
         .filter(p -> p.getId().equals(event.getPolicyId()))
@@ -1359,7 +1359,7 @@ public class MonitorManagement {
     final Set<String> affectedEnvoys = new HashSet<>();
 
     // Get effective monitors
-    List<UUID> policyMonitorIds = policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId);
+    List<UUID> policyMonitorIds = policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId, false);
     List<UUID> boundPolicyMonitorIds = getAllBoundPolicyMonitorsByTenantId(tenantId)
         .stream().map(b -> b.getMonitor().getId()).collect(Collectors.toList());
 
@@ -1956,7 +1956,7 @@ public class MonitorManagement {
         new NotFoundException(String.format("No policy monitor found for %s on tenant %s",
             monitorId, tenantId)));
 
-    List<UUID> policyMonitorIds = policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId);
+    List<UUID> policyMonitorIds = policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId, true);
 
     // If the policy monitor exists but is not in use by this account, do not return it.
     if (!policyMonitorIds.contains(monitorId)) {
@@ -1974,7 +1974,7 @@ public class MonitorManagement {
    * @return A list of monitors.
    */
   public Page<Monitor> getAllPolicyMonitorsForTenant(String tenantId, Pageable page) {
-    List<UUID> policyMonitorIds = policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId);
+    List<UUID> policyMonitorIds = policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId, true);
 
     return monitorRepository.findByIdIn(policyMonitorIds, page);
   }
@@ -1986,7 +1986,7 @@ public class MonitorManagement {
    */
   List<Monitor> getPolicyMonitorsForResource(Resource resource) {
     String tenantId = resource.getTenantId();
-    List<UUID> policyMonitorIds = policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId);
+    List<UUID> policyMonitorIds = policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId, true);
 
     List<Monitor> resourcePolicies = monitorRepository.findByIdIn(policyMonitorIds)
         .stream()

--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -198,7 +198,7 @@ public class MetadataUtils {
     if (!patchOperation &&
         monitor.getMonitorMetadataFields() != null &&
         !monitor.getMonitorMetadataFields().isEmpty()) {
-      policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType());
+      policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType(), true);
       metadataFields = MetadataUtils
           .getMetadataFieldsForUpdate(monitor, monitor.getMonitorMetadataFields(), policyMetadata);
     } else {
@@ -215,7 +215,7 @@ public class MetadataUtils {
 
     if (policyMetadata == null) {
       // this api request is avoided if there are no metadata fields to set
-      policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType());
+      policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType(), true);
     }
 
     log.debug("Setting policy metadata on {} fields for tenant {}", metadataFields.size(), tenantId);
@@ -244,7 +244,7 @@ public class MetadataUtils {
     if (!patchOperation &&
         monitor.getPluginMetadataFields() != null &&
         !monitor.getPluginMetadataFields().isEmpty()) {
-      policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType());
+      policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType(), true);
       metadataFields = MetadataUtils
           .getMetadataFieldsForUpdate(plugin, monitor.getPluginMetadataFields(), policyMetadata);
     } else {
@@ -261,7 +261,7 @@ public class MetadataUtils {
 
     if (policyMetadata == null) {
       // this api request is avoided if there are no metadata fields to set
-      policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType());
+      policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType(), true);
     }
 
     log.debug("Setting policy metadata on {} fields for tenant {}", metadataFields.size(), tenantId);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,3 +38,9 @@ logging:
   level:
     com.rackspace.salus: debug
     web: debug
+management:
+  endpoints:
+    web:
+      exposure:
+        # enable further access to endpoints like /actuator/caches and /actuator/metrics
+        include: "*"

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -134,7 +135,7 @@ public class MonitorConversionServiceTest {
             .setValueType(MetadataValueType.DURATION)
             .setValue("PT2S"));
 
-    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
+    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any(), anyBoolean()))
         .thenReturn(expectedPolicy);
 
     final Map<String, String> labels = new HashMap<>();
@@ -190,7 +191,7 @@ public class MonitorConversionServiceTest {
             .setValueType(MetadataValueType.STRING_LIST)
             .setValue("defaultZone1,defaultZone2"));
 
-    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
+    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any(), anyBoolean()))
         .thenReturn(expectedPolicy);
 
     // Create the plugin that will be converted to the monitor's contents
@@ -567,7 +568,7 @@ public class MonitorConversionServiceTest {
             .setValueType(MetadataValueType.DURATION)
             .setValue("300"));
 
-    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
+    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any(), anyBoolean()))
         .thenReturn(expectedPolicy);
 
     final MonitorCU result = conversionService.convertFromInput(
@@ -592,7 +593,7 @@ public class MonitorConversionServiceTest {
             .setValueType(MetadataValueType.DURATION)
             .setValue("300"));
 
-    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
+    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any(), anyBoolean()))
         .thenReturn(expectedPolicy);
 
     final MonitorCU result = conversionService.convertFromInput(
@@ -602,6 +603,6 @@ public class MonitorConversionServiceTest {
     assertThat(result.getInterval()).isNull();
 
     // ping has metadata fields so the api would have been called
-    verify(policyApi).getEffectiveMonitorMetadataMap(tenantId, TargetClassName.RemotePlugin, MonitorType.ping);
+    verify(policyApi).getEffectiveMonitorMetadataMap(tenantId, TargetClassName.RemotePlugin, MonitorType.ping, true);
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -283,7 +284,7 @@ public class MonitorManagementPolicyTest {
             .setInterval(Duration.ofSeconds(60)));
 
     // Use the two saved monitors
-    when(policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId))
+    when(policyApi.getEffectivePolicyMonitorIdsForTenant(anyString(), anyBoolean()))
         .thenReturn(List.of(monitor.getId()));
 
     Monitor returned = monitorManagement.getPolicyMonitorForTenant(tenantId, monitor.getId());
@@ -291,7 +292,7 @@ public class MonitorManagementPolicyTest {
     assertThat(returned, notNullValue());
     assertThat(returned, equalTo(monitor));
 
-    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId);
+    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId, true);
     verifyNoMoreInteractions(policyApi);
   }
 
@@ -325,7 +326,7 @@ public class MonitorManagementPolicyTest {
     UUID monitorId = UUID.randomUUID();
 
     // Use the two saved monitors
-    when(policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId))
+    when(policyApi.getEffectivePolicyMonitorIdsForTenant(anyString(), anyBoolean()))
         .thenReturn(Collections.emptyList());
 
     exceptionRule.expect(NotFoundException.class);
@@ -383,7 +384,7 @@ public class MonitorManagementPolicyTest {
         .map(Monitor::getId).collect(Collectors.toList());
 
     // Use two of the three saved monitors
-    when(policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId))
+    when(policyApi.getEffectivePolicyMonitorIdsForTenant(anyString(), anyBoolean()))
         .thenReturn(monitorIds);
 
     Page<Monitor> results = monitorManagement.getAllPolicyMonitorsForTenant(tenantId,
@@ -393,7 +394,7 @@ public class MonitorManagementPolicyTest {
     assertThat(results.getTotalElements(), equalTo(2L));
     assertThat(results.getContent(), containsInAnyOrder(monitors.toArray()));
 
-    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId);
+    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId, true);
     verifyNoMoreInteractions(policyApi);
   }
 
@@ -681,7 +682,7 @@ public class MonitorManagementPolicyTest {
         .map(Monitor::getId).collect(Collectors.toList());
 
     // Use the two saved monitors
-    when(policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId))
+    when(policyApi.getEffectivePolicyMonitorIdsForTenant(anyString(), anyBoolean()))
         .thenReturn(monitorIds);
 
     // No prior monitors exist so return an empty list
@@ -737,7 +738,7 @@ public class MonitorManagementPolicyTest {
     org.assertj.core.api.Assertions.assertThat(found)
         .containsExactlyInAnyOrderElementsOf(expectedBound);
 
-    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId);
+    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId, false);
 
     // Verify events were sent out (to be consumed by ambassador)
     verify(monitorEventProducer).sendMonitorEvent(
@@ -780,7 +781,7 @@ public class MonitorManagementPolicyTest {
         .map(Monitor::getId).collect(Collectors.toList());
 
     // Use the two saved monitors
-    when(policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId))
+    when(policyApi.getEffectivePolicyMonitorIdsForTenant(anyString(), anyBoolean()))
         .thenReturn(monitorIds);
 
     // Define the resources the policy will be applied to
@@ -829,7 +830,7 @@ public class MonitorManagementPolicyTest {
     // VERIFY
 
     verify(boundMonitorRepository).findAllByTenantIdAndMonitor_TenantId(tenantId, POLICY_TENANT);
-    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId);
+    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId, false);
 
     // no bound monitor saves or event producer sends should happen.
     verifyNoMoreInteractions(boundMonitorRepository, monitorPolicyRepository, monitorEventProducer);
@@ -868,7 +869,7 @@ public class MonitorManagementPolicyTest {
         .map(Monitor::getId).collect(Collectors.toList());
 
     // Use the two saved monitors
-    when(policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId))
+    when(policyApi.getEffectivePolicyMonitorIdsForTenant(anyString(), anyBoolean()))
         .thenReturn(monitorIds);
 
     // Define the resources the policy will be applied to
@@ -929,7 +930,7 @@ public class MonitorManagementPolicyTest {
     org.assertj.core.api.Assertions.assertThat(captorOfBoundMonitorList.getValue())
         .containsExactlyInAnyOrderElementsOf(newBound);
 
-    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId);
+    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId, false);
 
     // Verify events were sent out (to be consumed by ambassador)
     verify(monitorEventProducer).sendMonitorEvent(
@@ -970,7 +971,7 @@ public class MonitorManagementPolicyTest {
     List<Monitor> savedMonitors = Lists.newArrayList(monitorRepository.saveAll(monitors));
 
     // Use the first monitor, which means the policy for the second was removed.
-    when(policyApi.getEffectivePolicyMonitorIdsForTenant(tenantId))
+    when(policyApi.getEffectivePolicyMonitorIdsForTenant(anyString(), anyBoolean()))
         .thenReturn(Collections.singletonList(savedMonitors.get(0).getId()));
 
     // Define the resources the policy will be applied to
@@ -1030,7 +1031,7 @@ public class MonitorManagementPolicyTest {
     verify(boundMonitorRepository).findAllByTenantIdAndMonitor_IdIn(
         tenantId, Set.of(savedMonitors.get(1).getId()));
 
-    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId);
+    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(tenantId, false);
 
     verify(boundMonitorRepository).deleteAll(captorOfBoundMonitorList.capture());
     org.assertj.core.api.Assertions.assertThat(captorOfBoundMonitorList.getValue())
@@ -1226,7 +1227,7 @@ public class MonitorManagementPolicyTest {
         .setTenantId(RandomStringUtils.randomAlphabetic(10))
         .setLabels(Map.of("os", "linux", "env", "dev"));
 
-    when(policyApi.getEffectivePolicyMonitorIdsForTenant(anyString()))
+    when(policyApi.getEffectivePolicyMonitorIdsForTenant(anyString(), anyBoolean()))
         .thenReturn(monitors
             .stream()
             .map(Monitor::getId)
@@ -1239,7 +1240,7 @@ public class MonitorManagementPolicyTest {
     assertThat(effectiveMonitors, hasSize(2));
     assertThat(effectiveMonitors, containsInAnyOrder(monitors.subList(0,2).toArray()));
 
-    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(resource.getTenantId());
+    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(resource.getTenantId(), true);
     verifyNoMoreInteractions(policyApi);
   }
 
@@ -1291,7 +1292,7 @@ public class MonitorManagementPolicyTest {
         .setTenantId(RandomStringUtils.randomAlphabetic(10))
         .setLabels(Map.of("os", "linux", "env", "dev"));
 
-    when(policyApi.getEffectivePolicyMonitorIdsForTenant(anyString()))
+    when(policyApi.getEffectivePolicyMonitorIdsForTenant(anyString(), anyBoolean()))
         .thenReturn(monitors
             .stream()
             .map(Monitor::getId)
@@ -1304,7 +1305,7 @@ public class MonitorManagementPolicyTest {
     assertThat(effectiveMonitors, hasSize(3));
     assertThat(effectiveMonitors, containsInAnyOrder(monitors.subList(0,3).toArray()));
 
-    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(resource.getTenantId());
+    verify(policyApi).getEffectivePolicyMonitorIdsForTenant(resource.getTenantId(), true);
     verifyNoMoreInteractions(policyApi);
   }
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -235,7 +236,7 @@ public class MonitorManagement_MetadataPolicyTest {
 
   @Test
   public void createMonitor_withIntervalPolicy() {
-    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
+    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any(), anyBoolean()))
         .thenReturn(Map.of("interval",
             (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setKey("interval")
@@ -265,7 +266,7 @@ public class MonitorManagement_MetadataPolicyTest {
   public void testPatchExistingMonitor_allNullValues() {
     String tenantId = RandomStringUtils.randomAlphabetic(10);
 
-    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
+    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any(), anyBoolean()))
         .thenReturn(Map.of("zones",
             (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setKey("zones")
@@ -335,7 +336,7 @@ public class MonitorManagement_MetadataPolicyTest {
   public void testPatchExistingMonitor_someValueSetSomeValueNull() {
     String tenantId = RandomStringUtils.randomAlphabetic(10);
 
-    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
+    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any(), anyBoolean()))
         .thenReturn(Map.of("zones",
             (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setKey("zones")
@@ -409,7 +410,7 @@ public class MonitorManagement_MetadataPolicyTest {
     when(zoneManagement.getAvailableZonesForTenant(any(), any()))
         .thenReturn(new PageImpl<>(List.of(new Zone().setName("public/newZone1")), Pageable.unpaged(), 1));
 
-    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
+    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any(), anyBoolean()))
         .thenReturn(Map.of("zones",
             (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setKey("zones")
@@ -483,7 +484,7 @@ public class MonitorManagement_MetadataPolicyTest {
     UUID policyId = UUID.randomUUID();
 
     // Returns the list of monitor metadata policies effective on this account
-    when(policyApi.getEffectiveMonitorMetadataPolicies(tenantId))
+    when(policyApi.getEffectiveMonitorMetadataPolicies(anyString(), anyBoolean()))
         .thenReturn(List.of(
             // The actual RemotePlugin policy that will be used
             (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
@@ -575,7 +576,7 @@ public class MonitorManagement_MetadataPolicyTest {
     UUID policyId = UUID.randomUUID();
 
     // Returns the list of monitor metadata policies effective on this account
-    when(policyApi.getEffectiveMonitorMetadataPolicies(tenantId))
+    when(policyApi.getEffectiveMonitorMetadataPolicies(anyString(), anyBoolean()))
         .thenReturn(List.of(
             // An irrelevant RemotePlugin policy
             (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.monitor_management.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -249,7 +250,7 @@ public class MetadataUtilsTest {
 
   @Test
   public void testSetMetadataFieldsForMonitor() {
-    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any()))
+    when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any(), anyBoolean()))
         .thenReturn(Map.of(
             "interval", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setValueType(MetadataValueType.DURATION)
@@ -285,6 +286,6 @@ public class MetadataUtilsTest {
     metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
     assertThat(monitor.getMonitorMetadataFields()).hasSize(1);
 
-    verify(policyApi, times(4)).getEffectiveMonitorMetadataMap(tenantId, TargetClassName.Monitor, null);
+    verify(policyApi, times(4)).getEffectiveMonitorMetadataMap(tenantId, TargetClassName.Monitor, null, true);
   }
 }


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-731

# What

From issue description:

Things like monitor management have to request data from policy management, but that data will change infrequently.

These responses should be cached so if policy mgmt it does not cause many problems and so that general api requests can be faster.

# How

`@Import` the new `PolicyApiCacheConfig` added in https://github.com/racker/salus-policy-management/pull/25 and add the appropriate dependencies for ehcache usage. (Transitive dependencies don't work since our convention is to exclude all transitives from the client dependencies.)

# How to test

Existing unit tests