### PR TITLE
Added JsonSchemaDefault to fields that use explicit default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
       <groupId>com.kjetland</groupId>
       <!-- The "_2.12" suffix conveys Scala compatibility, so any is fine for us -->
       <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
-      <version>1.0.36</version>
+      <version>1.0.38</version>
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Cpu.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Cpu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDefault;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
@@ -30,6 +31,7 @@ import lombok.EqualsAndHashCode;
 @ApplicableMonitorType(MonitorType.cpu)
 public class Cpu extends LocalPlugin {
   boolean percpu;
+  @JsonSchemaDefault("true")
   @JsonProperty(defaultValue = "true")
   boolean totalcpu = true;
   boolean collectCpuTime;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Cpu.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Cpu.java
@@ -17,7 +17,6 @@
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDefault;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
@@ -31,7 +30,6 @@ import lombok.EqualsAndHashCode;
 @ApplicableMonitorType(MonitorType.cpu)
 public class Cpu extends LocalPlugin {
   boolean percpu;
-  @JsonSchemaDefault("true")
   @JsonProperty(defaultValue = "true")
   boolean totalcpu = true;
   boolean collectCpuTime;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDefault;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
@@ -33,6 +34,7 @@ public class Net extends LocalPlugin {
   @SummaryField
   @JsonProperty("interface")
   String monitoredInterface;
+  @JsonSchemaDefault("true")
   @JsonProperty(defaultValue = "true")
   Boolean ignoreProtocolStats = true;
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/telegraf/Net.java
@@ -17,7 +17,6 @@
 package com.rackspace.salus.monitor_management.web.model.telegraf;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDefault;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
@@ -34,7 +33,6 @@ public class Net extends LocalPlugin {
   @SummaryField
   @JsonProperty("interface")
   String monitoredInterface;
-  @JsonSchemaDefault("true")
   @JsonProperty(defaultValue = "true")
   Boolean ignoreProtocolStats = true;
 }

--- a/src/test/resources/MonitorSchemaControllerTest/monitor_plugins_schema_partial.json
+++ b/src/test/resources/MonitorSchemaControllerTest/monitor_plugins_schema_partial.json
@@ -36,7 +36,8 @@
           "type": "boolean"
         },
         "totalcpu": {
-          "type": "boolean"
+          "type": "boolean",
+          "default": true
         },
         "collectCpuTime": {
           "type": "boolean"


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-830

# What

The JSON schema generator used at runtime doesn't seem to leverage `@JsonProperty(defaultValue = "true")`, so those cases also need a `@JsonSchemaDefault("true")`.

## How to test

Existing unit tests and manually accessing `/schema/monitor-plugins` endpoint.