### PR TITLE
Sort applied translations by order

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
@@ -31,6 +31,7 @@ import com.rackspace.salus.telemetry.translators.MonitorTranslator;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -239,6 +240,7 @@ public class MonitorContentTranslationService {
     return operators.stream()
         .filter(o -> o.getMonitorType() == null || o.getMonitorType() == bound.getMonitor().getMonitorType())
         .filter(o -> o.getSelectorScope() == null || o.getSelectorScope() == bound.getMonitor().getSelectorScope())
+        .sorted(Comparator.comparingInt(MonitorTranslationOperator::getOrder))
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
@@ -91,7 +91,8 @@ public class MonitorContentTranslationService {
         .setAgentVersions(in.getAgentVersions())
         .setMonitorType(in.getMonitorType())
         .setSelectorScope(in.getSelectorScope())
-        .setTranslatorSpec(in.getTranslatorSpec());
+        .setTranslatorSpec(in.getTranslatorSpec())
+        .setOrder(in.getOrder());
 
     log.info("Creating new monitorTranslationOperator={}", operator);
     return monitorTranslationOperatorRepository.save(operator);

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorCreate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorCreate.java
@@ -60,4 +60,6 @@ public class MonitorTranslationOperatorCreate {
 
   @NotNull @Valid
   MonitorTranslator translatorSpec;
+
+  int order;
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationServiceTest.java
@@ -71,7 +71,8 @@ public class MonitorContentTranslationServiceTest {
         .setAgentVersions(">= 1.12.0")
         .setMonitorType(MonitorType.dns)
         .setSelectorScope(ConfigSelectorScope.REMOTE)
-        .setTranslatorSpec(new RenameFieldKeyTranslator().setFrom("from").setTo("to"));
+        .setTranslatorSpec(new RenameFieldKeyTranslator().setFrom("from").setTo("to"))
+        .setOrder(5);
 
     MonitorTranslationOperator op = service.create(create);
 


### PR DESCRIPTION
# What

Utilizes https://github.com/racker/salus-telemetry-model/pull/118 and adds tests.

# How

Uses that new field to sort the translations so they get applied in the correct order.