### PR TITLE
updated boolean parser

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.monitor_management.utils;
 
+import com.rackspace.salus.common.util.BooleanParser;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
@@ -113,7 +114,7 @@ public class MetadataUtils {
                 break;
               case BOOL:
                 Boolean boolValue = (Boolean) f.get(object);
-                if (boolValue == Boolean.parseBoolean(policy.getValue())) {
+                if (boolValue == BooleanParser.parseBoolean(policy.getValue())) {
                   metadataFields.add(f.getName());
                 }
                 break;
@@ -169,7 +170,7 @@ public class MetadataUtils {
           f.set(object, Duration.parse(policy.getValue()));
           break;
         case BOOL:
-          f.set(object, Boolean.parseBoolean(policy.getValue()));
+          f.set(object, BooleanParser.parseBoolean(policy.getValue()));
           break;
       }
     } catch (IllegalAccessException|NoSuchFieldException e) {

--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -114,7 +114,7 @@ public class MetadataUtils {
                 break;
               case BOOL:
                 Boolean boolValue = (Boolean) f.get(object);
-                if (boolValue == BooleanParser.parseBoolean(policy.getValue())) {
+                if (boolValue == BooleanUtils.toBoolean(policy.getValue().toLowerCase(), "true", "false")) {
                   metadataFields.add(f.getName());
                 }
                 break;

--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -16,7 +16,6 @@
 
 package com.rackspace.salus.monitor_management.utils;
 
-import com.rackspace.salus.common.util.BooleanParser;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
@@ -30,6 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -170,7 +170,7 @@ public class MetadataUtils {
           f.set(object, Duration.parse(policy.getValue()));
           break;
         case BOOL:
-          f.set(object, BooleanParser.parseBoolean(policy.getValue()));
+          f.set(object, BooleanUtils.toBoolean(policy.getValue().toLowerCase(), "true", "false"));
           break;
       }
     } catch (IllegalAccessException|NoSuchFieldException e) {

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -264,7 +265,7 @@ public class MetadataUtilsTest {
     assertThat(monitor.getFollowRedirects()).isEqualTo(true);
   }
 
-  @Test(expected = BooleanFormatException.class)
+  @Test
   public void setUpdateMetadataValue_BOOLfails() {
     HttpResponse monitor = new HttpResponse();
     MonitorMetadataPolicyDTO policy = (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
@@ -272,8 +273,9 @@ public class MetadataUtilsTest {
         .setValueType(MetadataValueType.BOOL)
         .setValue("not a boolean value");
 
-    MetadataUtils.updateMetadataValue(monitor, policy);
-    Assert.fail("The String value should have caused a BooleanFormatException and never hit this line.");
+    assertThatThrownBy(() -> MetadataUtils.updateMetadataValue(monitor, policy))
+      .isInstanceOf(BooleanFormatException.class)
+      .hasMessageContaining("'not a boolean value' is not a valid boolean value");
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -274,8 +274,8 @@ public class MetadataUtilsTest {
         .setValue("not a boolean value");
 
     assertThatThrownBy(() -> MetadataUtils.updateMetadataValue(monitor, policy))
-      .isInstanceOf(BooleanFormatException.class)
-      .hasMessageContaining("'not a boolean value' is not a valid boolean value");
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("The String did not match either specified value");
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.rackspace.salus.common.errors.BooleanFormatException;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Disk;
 import com.rackspace.salus.monitor_management.web.model.telegraf.HttpResponse;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
@@ -31,11 +32,13 @@ import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.MetadataValueType;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.TargetClassName;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -246,6 +249,31 @@ public class MetadataUtilsTest {
 
     MetadataUtils.updateMetadataValue(monitor, policy);
     assertThat(monitor.getZones()).isEqualTo(List.of("zone1", "zone2"));
+  }
+
+  @Test
+  public void setUpdateMetadataValue_BOOL() {
+    HttpResponse monitor = new HttpResponse();
+    MonitorMetadataPolicyDTO policy = (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+        .setMonitorType(MonitorType.http)
+        .setKey("followRedirects")
+        .setValueType(MetadataValueType.BOOL)
+        .setValue("true");
+
+    MetadataUtils.updateMetadataValue(monitor, policy);
+    assertThat(monitor.getFollowRedirects()).isEqualTo(true);
+  }
+
+  @Test(expected = BooleanFormatException.class)
+  public void setUpdateMetadataValue_BOOLfails() {
+    HttpResponse monitor = new HttpResponse();
+    MonitorMetadataPolicyDTO policy = (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+        .setKey("followRedirects")
+        .setValueType(MetadataValueType.BOOL)
+        .setValue("not a boolean value");
+
+    MetadataUtils.updateMetadataValue(monitor, policy);
+    Assert.fail("The String value should have caused a BooleanFormatException and never hit this line.");
   }
 
   @Test


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-783

# What

Since we are updating how the validation works we should update how we are parsing the values as well.

# How

It switches the parse function to our new `BooleanParser.parseBoolean` function to match how the validation is happening

## How to test

Run the unit tests

# Why

We didn't like the standard `parseBoolean` function and how it assumed anything that wasn't 'true' was just false. 

# TODO

Should be done