### PR TITLE
Added monitors schema endpoint

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/SchemaService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/SchemaService.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.services;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.LocalPlugin;
 import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import lombok.Data;
@@ -43,6 +44,12 @@ public class SchemaService {
 
   public JsonNode getMonitorPluginsSchema() {
     return schemaGen.generateJsonSchema(MonitorPluginScopes.class, "monitor-plugins-scopes",
-        "Conveys monitor scopes and plugin definitions for each");
+        "Salus Monitor Scopes and Plugin definitions");
+  }
+
+  public JsonNode getMonitorInputSchema() {
+    return schemaGen.generateJsonSchema(
+        DetailedMonitorInput.class, "monitor",
+        "Salus Monitor definition");
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorSchemaController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorSchemaController.java
@@ -38,4 +38,9 @@ public class MonitorSchemaController {
     return schemaService.getMonitorPluginsSchema();
   }
 
+  @GetMapping("/monitors")
+  public JsonNode getMonitorInputSchema() {
+    return schemaService.getMonitorInputSchema();
+  }
+
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/SchemaServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/SchemaServiceTest.java
@@ -53,4 +53,27 @@ public class SchemaServiceTest {
     // spot check a definition
     assertThat(schema.path("definitions").path("Cpu").isObject()).isTrue();
   }
+
+  @Test
+  public void testGetMonitorInputSchema() {
+    final JsonNode schema = schemaService.getMonitorInputSchema();
+
+    assertThat(schema).isNotNull();
+    assertThat(schema.path("title").asText()).isEqualTo("monitor");
+    assertThat(schema.path("properties").path("name").path("type").asText()).isEqualTo("string");
+    assertThat(schema.path("properties").path("details").path("oneOf").isArray()).isTrue();
+    assertThat(ImmutableList.copyOf(schema.path("properties").path("details").path("oneOf").elements()))
+        .extracting(node -> node.path("$ref").asText())
+        // spot check a known definition reference
+        .containsExactlyInAnyOrder(
+            "#/definitions/LocalMonitorDetails",
+            "#/definitions/RemoteMonitorDetails"
+        );
+    // spot check some definitions
+    assertThat(schema.path("definitions").path("LocalMonitorDetails").isObject()).isTrue();
+    assertThat(schema.path("definitions").path("RemoteMonitorDetails").isObject()).isTrue();
+    assertThat(schema.path("definitions").path("RemoteMonitorDetails").path("properties")
+        .path("plugin").path("oneOf").isArray()).isTrue();
+    assertThat(schema.path("definitions").path("Cpu").isObject()).isTrue();
+  }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorSchemaControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorSchemaControllerTest.java
@@ -53,4 +53,19 @@ public class MonitorSchemaControllerTest {
 
   }
 
+  @Test
+  public void testGetMonitorsSchema() throws Exception {
+    final String expectedSubset = readContent(
+        "MonitorSchemaControllerTest/monitors_schema_partial.json");
+
+    mockMvc.perform(get(
+        "/schema/monitors",
+        "t-1"
+    ).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(
+            content().json(expectedSubset, false));
+
+  }
+
 }

--- a/src/test/resources/MonitorSchemaControllerTest/monitor_plugins_schema_partial.json
+++ b/src/test/resources/MonitorSchemaControllerTest/monitor_plugins_schema_partial.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "monitor-plugins-scopes",
-  "description": "Conveys monitor scopes and plugin definitions for each",
+  "description": "Salus Monitor Scopes and Plugin definitions",
   "type": "object",
   "additionalProperties": false,
   "properties": {

--- a/src/test/resources/MonitorSchemaControllerTest/monitors_schema_partial.json
+++ b/src/test/resources/MonitorSchemaControllerTest/monitors_schema_partial.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "monitor",
+  "description": "Salus Monitor definition",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "labelSelector": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "labelSelectorMethod": {
+      "type": "string",
+      "enum": [
+        "AND",
+        "OR"
+      ]
+    },
+    "resourceId": {
+      "type": "string"
+    },
+    "excludedResourceIds": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "interval": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "details": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/LocalMonitorDetails"
+        },
+        {
+          "$ref": "#/definitions/RemoteMonitorDetails"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "LocalMonitorDetails": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "local"
+          ],
+          "default": "local"
+        },
+        "plugin": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Apache"
+            },
+            {
+              "$ref": "#/definitions/Cpu"
+            },
+            {
+              "$ref": "#/definitions/Disk"
+            },
+            {
+              "$ref": "#/definitions/DiskIo"
+            },
+            {
+              "$ref": "#/definitions/Mem"
+            },
+            {
+              "$ref": "#/definitions/Mysql"
+            },
+            {
+              "$ref": "#/definitions/Net"
+            },
+            {
+              "$ref": "#/definitions/Dataguard"
+            },
+            {
+              "$ref": "#/definitions/Rman"
+            },
+            {
+              "$ref": "#/definitions/Tablespace"
+            },
+            {
+              "$ref": "#/definitions/Packages"
+            },
+            {
+              "$ref": "#/definitions/Postgresql"
+            },
+            {
+              "$ref": "#/definitions/Procstat"
+            },
+            {
+              "$ref": "#/definitions/Redis"
+            },
+            {
+              "$ref": "#/definitions/SqlServer"
+            },
+            {
+              "$ref": "#/definitions/System"
+            }
+          ]
+        }
+      },
+      "title": "local",
+      "required": [
+        "type",
+        "plugin"
+      ]
+    },
+    "RemoteMonitorDetails": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "remote"
+          ],
+          "default": "remote"
+        },
+        "monitoringZones": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "plugin": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Dns"
+            },
+            {
+              "$ref": "#/definitions/HttpResponse"
+            },
+            {
+              "$ref": "#/definitions/MysqlRemote"
+            },
+            {
+              "$ref": "#/definitions/NetResponse"
+            },
+            {
+              "$ref": "#/definitions/Ping"
+            },
+            {
+              "$ref": "#/definitions/PostgresqlRemote"
+            },
+            {
+              "$ref": "#/definitions/Smtp"
+            },
+            {
+              "$ref": "#/definitions/SqlServerRemote"
+            },
+            {
+              "$ref": "#/definitions/X509Cert"
+            }
+          ]
+        }
+      },
+      "title": "remote",
+      "required": [
+        "type",
+        "plugin"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-843

# What

The `/schema/monitor-plugins` is useful for informational purposes, but the UI's model validation really needed a JSON schema that was rooted at the `DetailedMonitorInput`.

# How

Added an API endpoint that uses the same strategy as `/monitor-plugins`.

## How to test

Added unit tests