### PR TITLE
Add clone monitor functionality

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -177,6 +177,14 @@ public class MetadataUtils {
     }
   }
 
+  public void setMetadataFieldsForMonitor(String tenantId, Monitor monitor, boolean patchOperation) {
+    setMetadataFieldsForMonitor(tenantId, monitor, patchOperation, false);
+  }
+
+  public void setMetadataFieldsForClonedMonitor(String tenantId, Monitor monitor) {
+    setMetadataFieldsForMonitor(tenantId, monitor, false, true);
+  }
+
   /**
    * Updates a monitors metadata policy fields in place.
    *
@@ -190,12 +198,14 @@ public class MetadataUtils {
    * @param tenantId The tenant id the monitor is created under.
    * @param monitor The monitor object to update.
    */
-  public void setMetadataFieldsForMonitor(String tenantId, Monitor monitor, boolean patchOperation) {
+  public void setMetadataFieldsForMonitor(String tenantId, Monitor monitor, boolean patchOperation, boolean clone) {
     Map<String, MonitorMetadataPolicyDTO> policyMetadata = null;
     List<String> metadataFields;
     TargetClassName className = TargetClassName.getTargetClassName(monitor);
 
-    if (!patchOperation &&
+    if (clone) {
+      metadataFields = monitor.getMonitorMetadataFields();
+    } else if (!patchOperation &&
         monitor.getMonitorMetadataFields() != null &&
         !monitor.getMonitorMetadataFields().isEmpty()) {
       policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType(), true);
@@ -263,6 +273,22 @@ public class MetadataUtils {
       // this api request is avoided if there are no metadata fields to set
       policyMetadata = policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType(), true);
     }
+
+    log.debug("Setting policy metadata on {} fields for tenant {}", metadataFields.size(), tenantId);
+    MetadataUtils.setNewMetadataValues(plugin, metadataFields, policyMetadata);
+  }
+
+  public void setMetadataFieldsForClonedPlugin(String tenantId, Monitor monitor, Object plugin) {
+    List<String> metadataFields = monitor.getPluginMetadataFields();
+
+    if (metadataFields.isEmpty()) {
+      log.debug("No unset metadata fields were found on monitor={}", monitor);
+      return;
+    }
+
+    TargetClassName className = TargetClassName.getTargetClassName(plugin);
+    Map<String, MonitorMetadataPolicyDTO> policyMetadata =
+        policyApi.getEffectiveMonitorMetadataMap(tenantId, className, monitor.getMonitorType(), true);
 
     log.debug("Setting policy metadata on {} fields for tenant {}", metadataFields.size(), tenantId);
     MetadataUtils.setNewMetadataValues(plugin, metadataFields, policyMetadata);

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -23,6 +23,7 @@ import com.rackspace.salus.monitor_management.services.MonitorConversionService;
 import com.rackspace.salus.monitor_management.services.MonitorManagement;
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorsRequest;
+import com.rackspace.salus.monitor_management.web.model.CloneMonitorRequest;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.monitor_management.web.model.ValidationGroups;
@@ -195,6 +196,20 @@ public class MonitorApiController {
     return monitorConversionService.convertToOutput(
         monitorManagement.createPolicyMonitor(
             monitorConversionService.convertFromInput(Monitor.POLICY_TENANT, null, input)));
+  }
+
+  @PostMapping("/admin/clone-monitor")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiOperation(value = "Clones a monitor from one tenant to another")
+  @ApiResponses(value = {@ApiResponse(code = 201, message = "Successfully Cloned Monitor")})
+  public DetailedMonitorOutput cloneMonitor(@RequestBody final CloneMonitorRequest input)
+      throws IllegalArgumentException {
+    return monitorConversionService.convertToOutput(
+        monitorManagement.cloneMonitor(
+            input.getOriginalTenant(),
+            input.getNewTenant(),
+            input.getMonitorId()
+        ));
   }
 
   @DeleteMapping("/admin/policy-monitors/{uuid}")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/CloneMonitorRequest.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/CloneMonitorRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model;
+
+import java.util.UUID;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CloneMonitorRequest {
+
+  @NotEmpty
+  String originalTenant;
+  @NotEmpty
+  String newTenant;
+  @NotNull
+  UUID monitorId;
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -50,6 +50,7 @@ import com.rackspace.salus.monitor_management.services.MonitorManagement;
 import com.rackspace.salus.monitor_management.utils.MetadataUtils;
 import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
+import com.rackspace.salus.monitor_management.web.model.CloneMonitorRequest;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
@@ -891,6 +892,31 @@ public class MonitorApiControllerTest {
         .andExpect(httpMessageNotReadable(
             "Cannot deserialize value of type `java.time.Duration` from String \"30\""));
 
+  }
+
+  @Test
+  public void testCloneMonitor() throws Exception {
+    Monitor monitor = podamFactory.manufacturePojo(Monitor.class);
+    monitor.setSelectorScope(ConfigSelectorScope.LOCAL);
+    monitor.setAgentType(AgentType.TELEGRAF);
+    monitor.setContent("{\"type\":\"mem\"}");
+    monitor.setLabelSelectorMethod(LabelSelectorMethod.OR);
+    when(monitorManagement.cloneMonitor(anyString(), anyString(), any()))
+        .thenReturn(monitor);
+
+    String url = "/api/admin/clone-monitor";
+    CloneMonitorRequest request = new CloneMonitorRequest()
+        .setMonitorId(UUID.randomUUID())
+        .setNewTenant(RandomStringUtils.randomAlphabetic(10))
+        .setOriginalTenant(RandomStringUtils.randomAlphanumeric(10));
+
+    mockMvc.perform(post(url)
+        .content(objectMapper.writeValueAsString(request))
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding(StandardCharsets.UTF_8.name()))
+        .andExpect(status().isCreated())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
   }
 
   private class UpdateMonitorTestSetup {


### PR DESCRIPTION
# What

Adds the ability to clone monitors across different tenants.

# How

The original monitor's tenant is modified, id is removed, and any metadata fields will be updated to reflect the metadata in place for the new tenant.  The monitor is then stored under the new tenant (which generates a new id) and then bound to that tenant's resources.

An admin api endpoint is introduced to perform this now.

# Why

This may be needed on its own for the case of devices moving between accounts or whole accounts being taken over by a different account...

...but the current reason for adding it is as part of the changes required to improve the usability/flexibility of policy monitors.

Rather than a policy monitor only being bound to a tenant's devices, the entire monitor will be cloned to the account so that customer can modify the monitor if required.

More info on this will be added to https://github.com/racker/salus-docs