### PR TITLE
Allow monitoring zones to use metadata

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1156,7 +1156,7 @@ public class MonitorManagement {
     }
 
     final List<BoundMonitor> boundMonitors = boundMonitorRepository
-      .findAllByMonitor_Id(monitor.getId());
+        .findAllByMonitor_Id(monitor.getId());
 
     final MultiValueMap<String/*resourceId*/, BoundMonitor> groupedByResourceId = new LinkedMultiValueMap<>();
     for (BoundMonitor boundMonitor : boundMonitors) {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.services;
 
 import static com.rackspace.salus.telemetry.entities.Monitor.POLICY_TENANT;
+import static com.rackspace.salus.telemetry.entities.Resource.REGION_METADATA;
 import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPrivateZone;
 import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPublicZone;
 import static org.springframework.util.CollectionUtils.isEmpty;
@@ -103,6 +104,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
@@ -446,7 +448,7 @@ public class MonitorManagement {
       throw new IllegalArgumentException("Local monitors cannot have zones");
     }
 
-    if (providedZones == null || providedZones.isEmpty()) {
+    if (CollectionUtils.isEmpty(providedZones)) {
       return;
     }
     List<String> availableZones = zoneManagement.getAvailableZonesForTenant(tenantId, Pageable.unpaged())
@@ -479,7 +481,8 @@ public class MonitorManagement {
   /**
    * Performs label selection of the given monitor to locate resources for bindings.
    * For remote monitors, this will only perform binding within the given zones.
-   * If no zones are provided it will bind to all zones on the monitor.
+   * If no zones list is provided this will bind to all zones within the monitor object,
+   * or the global defaults if the monitor has no zones.
    * @return affected envoy IDs
    */
   Set<String> bindMonitor(String tenantId, Monitor monitor, List<String> zones) {
@@ -530,7 +533,7 @@ public class MonitorManagement {
       for (ResourceDTO resource : resources) {
         List<String> zonesForResource = zones;
 
-        if (zonesForResource == null || zonesForResource.isEmpty()) {
+        if (CollectionUtils.isEmpty(zonesForResource)) {
           zonesForResource = determineMonitoringZones(monitor, resource);
         }
 
@@ -750,12 +753,12 @@ public class MonitorManagement {
     if (monitor.getSelectorScope() != ConfigSelectorScope.REMOTE) {
       return Collections.emptyList();
     }
-    return determineMonitoringZones(monitor.getZones(), resource.getMetadata().get("region"));
+    return determineMonitoringZones(monitor.getZones(), resource.getMetadata().get(REGION_METADATA));
   }
 
   List<String> determineMonitoringZones(List<String> zones, String region) {
     log.debug("getting zones for region={}, provided zones={}", region, zones);
-    if (zones == null || zones.isEmpty()) {
+    if (CollectionUtils.isEmpty(zones)) {
       zones = metadataUtils.getDefaultZonesForResource(region, false);
       if (zones.isEmpty()) {
         log.error("Failed to discovered monitoring zones for region={}", region);
@@ -790,31 +793,15 @@ public class MonitorManagement {
 
     final Set<String> affectedEnvoys = new HashSet<>();
 
+    // each of the following 'process' methods may modify properties of the monitor in place
     affectedEnvoys.addAll(
         processResourceIdChange(monitor, updatedValues.getResourceId(), patchOperation));
     affectedEnvoys.addAll(
         processLabelSelectorChange(tenantId, monitor, updatedValues, patchOperation));
-
-    if (updatedValues.getContent() != null &&
-        !updatedValues.getContent().equals(monitor.getContent())) {
-      // Process potential changes to bound resource rendered content
-      // ...only need to process changed bindings
-
-      affectedEnvoys.addAll(
-          processMonitorContentModified(tenantId, monitor, updatedValues.getContent())
-      );
-
-      monitor.setContent(updatedValues.getContent());
-    }
-
-    PropertyMapper map;
-    if (patchOperation) {
-      map = PropertyMapper.get();
-    } else {
-      map = PropertyMapper.get().alwaysApplyingWhenNonNull();
-    }
-    map.from(updatedValues.getMonitorName())
-        .to(monitor::setMonitorName);
+    affectedEnvoys.addAll(
+        processMonitorContentModified(tenantId, monitor, updatedValues.getContent()));
+    affectedEnvoys.addAll(
+        processMonitorZonesModified(tenantId, monitor, updatedValues.getZones(), patchOperation));
 
     // Detect and process interval changes
     if (intervalChanged(updatedValues.getInterval(), monitor.getInterval(), patchOperation)) {
@@ -823,33 +810,17 @@ public class MonitorManagement {
       monitor.setInterval(updatedValues.getInterval());
     }
 
-    // Detect zone changes
-    List<String> originalZones = monitor.getZones();
-    if (zonesChanged(updatedValues.getZones(), originalZones, patchOperation)) {
-      // give JPA a modifiable copy of the given list
-      if (updatedValues.getZones() == null) {
-        monitor.setZones(null);
-      } else {
-        monitor.setZones(new ArrayList<>(updatedValues.getZones()));
-      }
-    } else if (monitor.getZones() != null) {
-      // See above regarding:
-      // JPA's EntityManager is a little strange with re-saving (aka merging) an entity
-      monitor.setZones(new ArrayList<>(monitor.getZones()));
+    // Update the monitor name if needed
+    if (patchOperation) {
+      monitor.setMonitorName(updatedValues.getMonitorName());
+    } else if (updatedValues.getMonitorName() != null) {
+      monitor.setMonitorName(updatedValues.getMonitorName());
     }
 
+    // Update any metadata fields on the monitor if required.
+    // Plugin metadata was already handled by monitor conversion service.
     metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, patchOperation);
     monitor.setPluginMetadataFields(updatedValues.getPluginMetadataFields());
-
-    // test things again once metadata has been put in place
-    if (monitor.getZones() != null && zonesChanged(monitor.getZones(), originalZones, patchOperation)) {
-      // Process potential changes to bound zones
-      // we must perform this after the metadata has been set in case zones was set to null
-      // and the default must first be populated.
-      affectedEnvoys.addAll(
-          processMonitorZonesModified(tenantId, monitor, originalZones)
-      );
-    }
 
     monitor = monitorRepository.save(monitor);
 
@@ -1064,16 +1035,100 @@ public class MonitorManagement {
    * @return affected envoy IDs
    */
   private Set<String> processMonitorZonesModified(String tenantId, Monitor monitor,
-      List<String> originalZones) {
+      @NotNull List<String> updatedZones, boolean patchOperation) {
 
-    // determine new zones
+    List<String> originalZones = monitor.getZones();
+
+    if (!zonesChanged(updatedZones, originalZones, patchOperation)) {
+      monitor.setZones(new ArrayList<>(originalZones));
+      return Collections.emptySet();
+    }
+    monitor.setZones(new ArrayList<>(updatedZones));
+
+    if (monitor.getZones().isEmpty() && !originalZones.isEmpty()) {
+      // handle case where policies are now being used and weren't before
+      return handleZoneChangePerResource(monitor, originalZones);
+    } else if (!monitor.getZones().isEmpty() && originalZones.isEmpty()) {
+      // handle case where policies were being used and are not anymore
+      return handleZoneChangePerResource(monitor, originalZones);
+    } else {
+      // handle case where zones were specified in original monitor and in updated values
+      return handleZoneChangeForMonitor(monitor, originalZones);
+    }
+  }
+
+  /**
+   *
+   * @param monitor
+   * @param originalZones
+   * @return
+   */
+  Set<String> handleZoneChangePerResource(Monitor monitor, List<String> originalZones) {
+    final Set<String> affectedEnvoys = new HashSet<>();
+
+    List<BoundMonitor> boundMonitors = boundMonitorRepository.findAllByMonitor_Id(monitor.getId());
+    Set<String> boundResourceIds = boundMonitors.stream().map(BoundMonitor::getResourceId).collect(
+        Collectors.toSet());
+
+    // handle the bound monitor changes for each individual resource
+    for (String resourceId : boundResourceIds) {
+      Optional<Resource> resource = resourceRepository.findByTenantIdAndResourceId(monitor.getTenantId(), resourceId);
+      if (resource.isEmpty()) {
+        // remove any orphaned bound monitors
+        affectedEnvoys.addAll(unbindByResourceId(monitor.getId(), List.of(resourceId)));
+        continue;
+      }
+
+      // set originalZones to the currently configured regions for this resource if empty
+      if (originalZones.isEmpty()) {
+        originalZones = boundMonitors.stream()
+            .filter(b -> b.getResourceId().equals(resourceId))
+            .map(BoundMonitor::getZoneName)
+            .collect(Collectors.toList());
+      }
+
+      // set newZones to the policy configured regions for this resource if currently empty.
+      List<String> newZones = monitor.getZones();
+      if (newZones.isEmpty()) {
+        newZones = metadataUtils.getDefaultZonesForResource(resource.get().getMetadata().get(REGION_METADATA), true);
+      }
+
+      // calculate which zones have been removed and unbind them
+      List<String> removedZones = new ArrayList<>(originalZones);
+      removedZones.removeAll(newZones);
+
+      affectedEnvoys.addAll(
+          unbindByMonitorAndZoneAndResource(monitor.getId(), removedZones, resourceId));
+
+      // calculate which zones have been added and bind them
+      List<String> addedZones = new ArrayList<>(newZones);
+      addedZones.removeAll(originalZones);
+
+      List<BoundMonitor> newBoundMonitors = new ArrayList<>();
+      for (String zone : addedZones) {
+        try {
+          newBoundMonitors.add(
+              bindRemoteMonitor(monitor, new ResourceDTO(resource.get()), zone));
+        } catch (InvalidTemplateException e) {
+          log.warn("Unable to render monitor={} onto resource={}",
+              monitor, resource.get(), e);
+          invalidTemplateErrors.increment();
+        }
+      }
+      saveBoundMonitors(newBoundMonitors);
+      affectedEnvoys.addAll(extractEnvoyIds(newBoundMonitors));
+    }
+
+    return affectedEnvoys;
+  }
+
+  private Set<String> handleZoneChangeForMonitor(Monitor monitor, List<String> originalZones) {
+    // determine new zones by removing zones on currently stored monitor
     final List<String> newZones = new ArrayList<>(monitor.getZones());
-    // ...by removing zones on currently stored monitor
     newZones.removeAll(originalZones);
 
-    // determine old zones
+    // determine old zones by removing the ones still in the update
     final List<String> oldZones = new ArrayList<>(originalZones);
-    // ...by removing the ones still in the update
     oldZones.removeAll(monitor.getZones());
 
     // this will also delete the unbound bindings
@@ -1081,7 +1136,7 @@ public class MonitorManagement {
 
     affectedEnvoys.addAll(
         // this will also save the new bindings
-        bindMonitor(tenantId, monitor, newZones)
+        bindMonitor(monitor.getTenantId(), monitor, newZones)
     );
 
     return affectedEnvoys;
@@ -1094,8 +1149,14 @@ public class MonitorManagement {
    */
   private Set<String> processMonitorContentModified(String tenantId, Monitor monitor,
       String updatedContent) {
+    if (updatedContent == null || updatedContent.equals(monitor.getContent())) {
+      // Process potential changes to bound resource rendered content
+      // ...only need to process changed bindings
+      return Collections.emptySet();
+    }
+
     final List<BoundMonitor> boundMonitors = boundMonitorRepository
-        .findAllByMonitor_Id(monitor.getId());
+      .findAllByMonitor_Id(monitor.getId());
 
     final MultiValueMap<String/*resourceId*/, BoundMonitor> groupedByResourceId = new LinkedMultiValueMap<>();
     for (BoundMonitor boundMonitor : boundMonitors) {
@@ -1136,6 +1197,8 @@ public class MonitorManagement {
       log.debug("Saving bound monitors with re-rendered content: {}", modified);
       saveBoundMonitors(modified);
     }
+
+    monitor.setContent(updatedContent);
 
     return extractEnvoyIds(modified);
   }
@@ -1253,11 +1316,11 @@ public class MonitorManagement {
                                                   @NotNull LabelSelectorMethod labelSelectorMethod,
                                                   Set<String> excludedResourceIds) {
     final Set<String> finalExcludedResourceIds;
-    if(excludedResourceIds != null) {
+    if (excludedResourceIds != null) {
       finalExcludedResourceIds = excludedResourceIds.stream()
           .map(String::toLowerCase)
           .collect(Collectors.toSet());
-    }else {
+    } else {
       finalExcludedResourceIds = null;
     }
     return resourceApi
@@ -1746,6 +1809,22 @@ public class MonitorManagement {
   }
 
   /**
+   * Removes all bindings associated with the given monitor, resource, and zones.
+   * @return affected envoy IDs
+   */
+  private Set<String> unbindByMonitorAndZoneAndResource(UUID monitorId, List<String> zones, String resourceId) {
+    final List<BoundMonitor> needToDelete = boundMonitorRepository
+        .findAllByMonitor_IdAndResourceIdAndZoneNameIn(monitorId, resourceId, zones);
+
+    log.debug("Unbinding monitorId={} on resourceId={} from zones={}: {}", monitorId, resourceId, zones, needToDelete);
+    boundMonitorRepository.deleteAll(needToDelete);
+
+    decrementBoundCounts(needToDelete);
+
+    return extractEnvoyIds(needToDelete);
+  }
+
+  /**
    * Extracts the distinct, non-null envoy IDs from the given bindings.
    */
   static Set<String> extractEnvoyIds(List<BoundMonitor> boundMonitors) {
@@ -1790,7 +1869,7 @@ public class MonitorManagement {
    */
   @SuppressWarnings("Duplicates")
   public Page<Monitor> getMonitorsFromLabels(Map<String, String> labels, String tenantId, Pageable page) {
-    if(labels == null || labels.isEmpty()) {
+    if (CollectionUtils.isEmpty(labels)) {
       return monitorRepository.findByTenantIdAndResourceIdIsNullAndLabelSelectorIsNull(tenantId, page);
     }
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorService.java
@@ -16,6 +16,8 @@
 
 package com.rackspace.salus.monitor_management.services;
 
+import static com.rackspace.salus.telemetry.entities.Resource.REGION_METADATA;
+
 import com.rackspace.salus.monitor_management.config.TestMonitorProperties;
 import com.rackspace.salus.monitor_management.errors.InvalidTemplateException;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
@@ -117,7 +119,7 @@ public class TestMonitorService {
       final RemoteMonitorDetails remoteMonitorDetails = (RemoteMonitorDetails) details;
       List<String> monitoringZones = monitorManagement.determineMonitoringZones(
           remoteMonitorDetails.getMonitoringZones(),
-          resource.getMetadata().get("region"));
+          resource.getMetadata().get(REGION_METADATA));
       envoyId = resolveRemoteEnvoy(tenantId, monitoringZones);
     } else {
       envoyId = resolveLocalEnvoy(tenantId, resourceId);

--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.monitor_management.utils;
 import com.rackspace.salus.monitor_management.web.model.MonitorCU;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
+import com.rackspace.salus.telemetry.entities.MetadataPolicy;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.NonMetadataField;
 import com.rackspace.salus.telemetry.model.TargetClassName;
@@ -293,5 +294,13 @@ public class MetadataUtils {
 
     log.debug("Setting policy metadata on {} fields for tenant {}", metadataFields.size(), tenantId);
     MetadataUtils.setNewMetadataValues(plugin, metadataFields, policyMetadata);
+  }
+
+  public List<String> getDefaultZonesForResource(String region, boolean useCache) {
+    if (region == null || region.isBlank()) {
+      region = MetadataPolicy.DEFAULT_ZONE;
+    }
+    log.debug("Querying policy api for monitoring zones for region={}", region);
+    return policyApi.getDefaultMonitoringZones(region, useCache);
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
@@ -22,6 +22,7 @@ import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import java.io.Serializable;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -55,7 +56,7 @@ public class MonitorCU implements Serializable {
 
     ConfigSelectorScope selectorScope = ConfigSelectorScope.LOCAL;
 
-    List<String> zones;
+    List<String> zones = new ArrayList<>();
 
     Set<String> excludedResourceIds;
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/RemoteMonitorDetails.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/RemoteMonitorDetails.java
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.monitor_management.web.model;
 
+import java.util.ArrayList;
 import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -31,7 +32,7 @@ public class RemoteMonitorDetails extends MonitorDetails {
    * The zone names where this remote monitor should operate.
    * If not specified, a set of default zones will be used for remote monitoring.
    */
-  List<String> monitoringZones;
+  List<String> monitoringZones = new ArrayList<>();
 
   @NotNull @Valid
   RemotePlugin plugin;

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -2283,7 +2283,7 @@ public class MonitorManagementTest {
         .setAgentType(AgentType.TELEGRAF)
         .setContent("{}");
 
-    final Set<String> affectedEnvoys = monitorManagement.bindNewMonitor("t-1", monitor);
+    final Set<String> affectedEnvoys = monitorManagement.bindMonitor("t-1", monitor, monitor.getZones());
 
     final List<BoundMonitor> expected = Collections.singletonList(
         new BoundMonitor()
@@ -2349,7 +2349,7 @@ public class MonitorManagementTest {
         .setAgentType(AgentType.TELEGRAF)
         .setContent("{\"type\": \"ping\", \"urls\": [\"${resource.metadata.public_ip}\"]}");
 
-    final Set<String> affectedEnvoys = monitorManagement.bindNewMonitor("t-1", monitor);
+    final Set<String> affectedEnvoys = monitorManagement.bindMonitor("t-1", monitor, monitor.getZones());
 
     final List<BoundMonitor> expected = Arrays.asList(
         new BoundMonitor()
@@ -2417,7 +2417,7 @@ public class MonitorManagementTest {
         .setAgentType(AgentType.TELEGRAF)
         .setContent("{}");
 
-    final Set<String> affectedEnvoys = monitorManagement.bindNewMonitor("t-1", monitor);
+    final Set<String> affectedEnvoys = monitorManagement.bindMonitor("t-1", monitor, monitor.getZones());
 
     verify(zoneStorage).findLeastLoadedEnvoy(zone1);
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -358,7 +358,7 @@ public class MonitorManagementTest {
   public void testCreateNewMonitor_usingLabelSelector() {
     MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
     create.setSelectorScope(ConfigSelectorScope.LOCAL);
-    create.setZones(null);
+    create.setZones(Collections.emptyList());
     create.setResourceId(null);
     create.setLabelSelectorMethod(LabelSelectorMethod.AND);
 
@@ -406,7 +406,7 @@ public class MonitorManagementTest {
   public void testCreateNewMonitor_usingResourceId() {
     MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
     create.setSelectorScope(ConfigSelectorScope.LOCAL);
-    create.setZones(null);
+    create.setZones(Collections.emptyList());
     create.setLabelSelector(null);
 
 
@@ -456,7 +456,7 @@ public class MonitorManagementTest {
 
     MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
     create.setSelectorScope(ConfigSelectorScope.LOCAL);
-    create.setZones(null);
+    create.setZones(Collections.emptyList());
     create.setLabelSelector(null);
     create.setInterval(interval);
 
@@ -488,7 +488,7 @@ public class MonitorManagementTest {
   public void testCreateNewMonitor_EmptyLabelSelector() {
     MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
     create.setSelectorScope(ConfigSelectorScope.LOCAL);
-    create.setZones(null);
+    create.setZones(Collections.emptyList());
     create.setLabelSelector(Collections.emptyMap());
 
     String tenantId = RandomStringUtils.randomAlphanumeric(10);
@@ -515,7 +515,7 @@ public class MonitorManagementTest {
   public void testCreateNewMonitor_nullLabelSelectorMethod() {
     MonitorCU create = podamFactory.manufacturePojo(MonitorCU.class);
     create.setSelectorScope(ConfigSelectorScope.LOCAL);
-    create.setZones(null);
+    create.setZones(Collections.emptyList());
     create.setLabelSelector(Collections.emptyMap());
     create.setLabelSelectorMethod(null);
 
@@ -994,7 +994,7 @@ public class MonitorManagementTest {
                 .setAgentType(AgentType.TELEGRAF)
                 .setMonitorType(MonitorType.ping)
                 .setContent("address=${resource.metadata.address}")
-                .setMonitorMetadataFields(List.of("monitorName", "zones"))
+                .setMonitorMetadataFields(List.of("monitorName"))
                 .setTenantId("t-1")
                 .setSelectorScope(ConfigSelectorScope.REMOTE)
                 .setLabelSelector(Collections.singletonMap("os", "linux"))
@@ -1158,7 +1158,7 @@ public class MonitorManagementTest {
                 .setAgentType(AgentType.TELEGRAF)
                 .setMonitorType(MonitorType.cpu)
                 .setContent("static content")
-                .setMonitorMetadataFields(List.of("monitorName", "zones"))
+                .setMonitorMetadataFields(List.of("monitorName"))
                 .setTenantId("t-1")
                 .setSelectorScope(ConfigSelectorScope.LOCAL)
                 .setResourceId("r-2")
@@ -1246,7 +1246,7 @@ public class MonitorManagementTest {
         .setSelectorScope(ConfigSelectorScope.LOCAL)
         .setLabelSelectorMethod(LabelSelectorMethod.AND)
         .setLabelSelector(null)
-        .setZones(null)
+        .setZones(Collections.emptyList())
         .setInterval(Duration.ofSeconds(60));
     entityManager.persist(monitor);
 
@@ -1297,7 +1297,7 @@ public class MonitorManagementTest {
                 .setAgentType(AgentType.TELEGRAF)
                 .setMonitorType(MonitorType.cpu)
                 .setContent("static content")
-                .setMonitorMetadataFields(List.of("monitorName", "zones"))
+                .setMonitorMetadataFields(List.of("monitorName"))
                 .setTenantId("t-1")
                 .setSelectorScope(ConfigSelectorScope.LOCAL)
                 .setResourceId(null)
@@ -1361,7 +1361,7 @@ public class MonitorManagementTest {
         .setSelectorScope(ConfigSelectorScope.LOCAL)
         .setLabelSelectorMethod(LabelSelectorMethod.AND)
         .setLabelSelector(Map.of("os", "linux"))
-        .setZones(null)
+        .setZones(Collections.emptyList())
         .setInterval(Duration.ofSeconds(60));
     entityManager.persist(monitor);
 
@@ -1438,7 +1438,7 @@ public class MonitorManagementTest {
                 .setAgentType(AgentType.TELEGRAF)
                 .setMonitorType(MonitorType.cpu)
                 .setContent("static content")
-                .setMonitorMetadataFields(List.of("monitorName", "zones"))
+                .setMonitorMetadataFields(List.of("monitorName"))
                 .setTenantId("t-1")
                 .setSelectorScope(ConfigSelectorScope.LOCAL)
                 .setResourceId(newResourceIdBinding)

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest_UpdateMonitor.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest_UpdateMonitor.java
@@ -52,7 +52,6 @@ import com.rackspace.salus.test.EnableTestContainersDatabase;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -273,9 +272,9 @@ public class MonitorManagementTest_UpdateMonitor {
     verify(boundMonitorRepository, times(2)).deleteAll(captorOfDeletedBoundMonitors.capture());
     List<BoundMonitor> allUnbound = captorOfDeletedBoundMonitors.getAllValues().stream().flatMap(List::stream).collect(Collectors.toList());
     assertThat(allUnbound).hasSize(2);
-    assertThat(transform(allUnbound, BoundMonitor::getZoneName)).containsOnly("public/originalZone");
-    assertThat(transform(allUnbound, BoundMonitor::getEnvoyId)).containsOnly(oldEnvoy1, oldEnvoy2);
-    assertThat(transform(allUnbound, BoundMonitor::getResourceId)).containsExactlyElementsOf(transform(resources, Resource::getResourceId));
+    assertThat(allUnbound).extracting(BoundMonitor::getZoneName).containsOnly("public/originalZone");
+    assertThat(allUnbound).extracting(BoundMonitor::getEnvoyId).containsOnly(oldEnvoy1, oldEnvoy2);
+    assertThat(allUnbound).extracting(BoundMonitor::getResourceId).containsExactlyElementsOf(transform(resources, Resource::getResourceId));
 
     // verify bind operations / each operation is performed once per resource
     ResolvedZone newResolvedZone = ResolvedZone.createPublicZone("public/newZone");
@@ -285,9 +284,9 @@ public class MonitorManagementTest_UpdateMonitor {
 
     List<BoundMonitor> allBound = captorOfSavedBoundMonitors.getAllValues().stream().flatMap(List::stream).collect(Collectors.toList());
     assertThat(allBound).hasSize(2);
-    assertThat(transform(allBound, BoundMonitor::getZoneName)).containsOnly("public/newZone");
-    assertThat(transform(allBound, BoundMonitor::getEnvoyId)).containsOnly(newEnvoy);
-    assertThat(transform(allBound, BoundMonitor::getResourceId)).containsExactlyElementsOf(transform(resources, Resource::getResourceId));
+    assertThat(allBound).extracting(BoundMonitor::getZoneName).containsOnly("public/newZone");
+    assertThat(allBound).extracting(BoundMonitor::getEnvoyId).containsOnly(newEnvoy);
+    assertThat(allBound).extracting(BoundMonitor::getResourceId).containsExactlyElementsOf(transform(resources, Resource::getResourceId));
   }
 
   /**
@@ -395,9 +394,9 @@ public class MonitorManagementTest_UpdateMonitor {
     verify(boundMonitorRepository, times(2)).deleteAll(captorOfDeletedBoundMonitors.capture());
     List<BoundMonitor> allUnbound = captorOfDeletedBoundMonitors.getAllValues().stream().flatMap(List::stream).collect(Collectors.toList());
     assertThat(allUnbound).hasSize(2);
-    assertThat(transform(allUnbound, BoundMonitor::getZoneName)).containsOnly("public/originalZone");
-    assertThat(transform(allUnbound, BoundMonitor::getEnvoyId)).containsOnly(oldEnvoy1, oldEnvoy2);
-    assertThat(transform(allUnbound, BoundMonitor::getResourceId)).containsOnlyElementsOf(transform(resources, Resource::getResourceId));
+    assertThat(allUnbound).extracting(BoundMonitor::getZoneName).containsOnly("public/originalZone");
+    assertThat(allUnbound).extracting(BoundMonitor::getEnvoyId).containsOnly(oldEnvoy1, oldEnvoy2);
+    assertThat(allUnbound).extracting(BoundMonitor::getResourceId).containsOnlyElementsOf(transform(resources, Resource::getResourceId));
 
     // verify bind operations / each operation is performed twice per zone per resource
     verify(boundMonitorRepository, times(2)).saveAll(captorOfSavedBoundMonitors.capture());
@@ -410,9 +409,9 @@ public class MonitorManagementTest_UpdateMonitor {
 
     List<BoundMonitor> allBound = captorOfSavedBoundMonitors.getAllValues().stream().flatMap(List::stream).collect(Collectors.toList());
     assertThat(allBound).hasSize(4);
-    assertThat(transform(allBound, BoundMonitor::getZoneName)).containsOnlyElementsOf(allNewZones);
-    assertThat(transform(allBound, BoundMonitor::getEnvoyId)).containsOnly(newEnvoy);
-    assertThat(transform(allBound, BoundMonitor::getResourceId)).containsOnlyElementsOf(transform(resources, Resource::getResourceId));
+    assertThat(allBound).extracting(BoundMonitor::getZoneName).containsOnlyElementsOf(allNewZones);
+    assertThat(allBound).extracting(BoundMonitor::getEnvoyId).containsOnly(newEnvoy);
+    assertThat(allBound).extracting(BoundMonitor::getResourceId).containsOnlyElementsOf(transform(resources, Resource::getResourceId));
   }
 
   /**

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest_UpdateMonitor.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest_UpdateMonitor.java
@@ -1,0 +1,465 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.services;
+
+import static com.google.common.collect.Collections2.transform;
+import static com.rackspace.salus.telemetry.entities.Resource.REGION_METADATA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.monitor_management.config.DatabaseConfig;
+import com.rackspace.salus.monitor_management.config.MonitorContentProperties;
+import com.rackspace.salus.monitor_management.config.ServicesProperties;
+import com.rackspace.salus.monitor_management.config.ZonesProperties;
+import com.rackspace.salus.monitor_management.utils.MetadataUtils;
+import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
+import com.rackspace.salus.policy.manage.web.client.PolicyApi;
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.telemetry.entities.BoundMonitor;
+import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.entities.Resource;
+import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
+import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
+import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import com.rackspace.salus.telemetry.repositories.ResourceRepository;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+
+@SuppressWarnings("SameParameterValue")
+@RunWith(SpringRunner.class)
+@EnableTestContainersDatabase
+@DataJpaTest(showSql = false)
+@Import({ServicesProperties.class, ObjectMapper.class, MonitorManagement.class,
+    MonitorContentRenderer.class,
+    MonitorContentProperties.class,
+    MetadataUtils.class,
+    DatabaseConfig.class})
+public class MonitorManagementTest_UpdateMonitor {
+
+  @TestConfiguration
+  public static class Config {
+    @Bean
+    public ZonesProperties zonesProperties() {
+      return new ZonesProperties();
+    }
+
+    @Bean
+    public ServicesProperties servicesProperties() {
+      return new ServicesProperties()
+          .setResourceManagementUrl("");
+    }
+
+    @Bean
+    MeterRegistry meterRegistry() {
+      return new SimpleMeterRegistry();
+    }
+  }
+
+  @MockBean
+  MonitorConversionService monitorConversionService;
+
+  @MockBean
+  MonitorEventProducer monitorEventProducer;
+
+  @MockBean
+  EnvoyResourceManagement envoyResourceManagement;
+
+  @MockBean
+  ZoneStorage zoneStorage;
+
+  @MockBean
+  BoundMonitorRepository boundMonitorRepository;
+
+  @MockBean
+  ResourceRepository resourceRepository;
+
+  @MockBean
+  ResourceApi resourceApi;
+
+  @MockBean
+  PolicyApi policyApi;
+
+  @MockBean
+  ZoneManagement zoneManagement;
+
+  @MockBean
+  PatchHelper patchHelper;
+
+  @Autowired
+  ObjectMapper objectMapper;
+  @Autowired
+  MonitorRepository monitorRepository;
+  @Autowired
+  EntityManager entityManager;
+  @Autowired
+  JdbcTemplate jdbcTemplate;
+  @Autowired
+  MetadataUtils metadataUtils;
+
+  @Autowired
+  private MonitorManagement monitorManagement;
+
+  private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  @Captor
+  private ArgumentCaptor<List<BoundMonitor>> captorOfDeletedBoundMonitors;
+
+  @Captor
+  private ArgumentCaptor<List<BoundMonitor>> captorOfSavedBoundMonitors;
+
+  private Monitor persistNewRemoteMonitor(
+      String tenantId, List<String> zones) {
+    return monitorRepository.save(
+        new Monitor()
+            .setTenantId(tenantId)
+            .setAgentType(AgentType.TELEGRAF)
+            .setSelectorScope(ConfigSelectorScope.REMOTE)
+            .setLabelSelector(Collections.emptyMap())
+            .setLabelSelectorMethod(LabelSelectorMethod.AND)
+            .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
+            .setZones(zones)
+            .setInterval(Duration.ofSeconds(60))
+            .setContent("{}")
+    );
+  }
+
+  /**
+   * Tests the case where a remote monitor was previously configured with an empty list of
+   * zones and is now updated to have the zones explictly set.
+   *
+   * When a monitor is created with no zones, they will be discovered when binding to each resource
+   * as they may vary for each resource.
+   *
+   * In this case there are two resources each using different zones.
+   * The updating of the monitor to a completely different zone will lead to the previous
+   * bound monitors being removed from the old zones and two new ones being created on the
+   * single zone specified on the monitor.
+   */
+  @Test
+  public void testHandleZoneChangePerResource_oldZonesEmpty() {
+    String tenantId = RandomStringUtils.randomAlphanumeric(5);
+    // when the old zones are empty the bound monitor zone is based on the policy values.
+    // for this test we use this one zone to represent that.
+    String originalZoneForResource = "public/originalZone";
+
+    String oldEnvoy1 = RandomStringUtils.randomAlphabetic(5);
+    String oldEnvoy2 = RandomStringUtils.randomAlphabetic(5);
+    String newEnvoy = RandomStringUtils.randomAlphabetic(5);
+
+    // the updated monitor has zones explicitly set
+    Monitor monitor = persistNewRemoteMonitor(tenantId, List.of("public/newZone"));
+
+    final List<Resource> resources = List.of(
+        podamFactory.manufacturePojo(Resource.class)
+            .setResourceId("r-1")
+            .setTenantId(tenantId),
+        podamFactory.manufacturePojo(Resource.class)
+            .setResourceId("r-2")
+            .setTenantId(tenantId));
+
+    List<BoundMonitor> originalBoundMonitors = List.of(
+        new BoundMonitor()
+            .setResourceId(resources.get(0).getResourceId())
+            .setZoneName(originalZoneForResource)
+            .setEnvoyId(oldEnvoy1)
+            .setMonitor(monitor),
+        new BoundMonitor()
+            .setResourceId(resources.get(1).getResourceId())
+            .setZoneName(originalZoneForResource)
+            .setEnvoyId(oldEnvoy2)
+            .setMonitor(monitor)
+    );
+
+    // DISCOVERY OPERATIONS
+
+    when(boundMonitorRepository.findAllByMonitor_Id(any()))
+        .thenReturn(originalBoundMonitors);
+
+    when(resourceRepository.findByTenantIdAndResourceId(anyString(), anyString()))
+        .thenReturn(Optional.of(resources.get(0)))
+        .thenReturn(Optional.of(resources.get(1)));
+
+    // UNBIND OPERATIONS
+
+    when(boundMonitorRepository.findAllByMonitor_IdAndResourceIdAndZoneNameIn(any(), anyString(), any()))
+        .thenReturn(List.of(originalBoundMonitors.get(0)))
+        .thenReturn(List.of(originalBoundMonitors.get(1)));
+
+    when(zoneStorage.getEnvoyIdToResourceIdMap(any()))
+        .thenReturn(CompletableFuture.completedFuture(Collections.singletonMap(oldEnvoy1, "resourceValueDoesntMatter")))
+        .thenReturn(CompletableFuture.completedFuture(Collections.singletonMap(oldEnvoy2, "resourceValueDoesntMatter")));
+
+    // BIND OPERATIONS
+
+    when(zoneStorage.findLeastLoadedEnvoy(any()))
+        .thenReturn(CompletableFuture.completedFuture(
+            Optional.of(
+                new EnvoyResourcePair().setEnvoyId(newEnvoy).setResourceId("new-envoy-resource"))));
+
+    when(zoneStorage.incrementBoundCount(any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(1));
+
+
+    // EXECUTE
+
+    Set<String> affectedEnvoys = monitorManagement.handleZoneChangePerResource(monitor, Collections.emptyList());
+
+    // VERIFY
+
+    // the old monitors were allocated an envoy each, the new ones were added to the sole new envoy
+    assertThat(affectedEnvoys).containsOnlyOnce(oldEnvoy1, oldEnvoy2, newEnvoy);
+
+    // verify discovery operations
+    verify(boundMonitorRepository).findAllByMonitor_Id(monitor.getId());
+    verify(resourceRepository).findByTenantIdAndResourceId(tenantId, resources.get(0).getResourceId());
+    verify(resourceRepository).findByTenantIdAndResourceId(tenantId, resources.get(1).getResourceId());
+
+    // verify unbind operations / each operation is performed once per resource
+    verify(boundMonitorRepository, times(2)).deleteAll(captorOfDeletedBoundMonitors.capture());
+    List<BoundMonitor> allUnbound = captorOfDeletedBoundMonitors.getAllValues().stream().flatMap(List::stream).collect(Collectors.toList());
+    assertThat(allUnbound).hasSize(2);
+    assertThat(transform(allUnbound, BoundMonitor::getZoneName)).containsOnly("public/originalZone");
+    assertThat(transform(allUnbound, BoundMonitor::getEnvoyId)).containsOnly(oldEnvoy1, oldEnvoy2);
+    assertThat(transform(allUnbound, BoundMonitor::getResourceId)).containsExactlyElementsOf(transform(resources, Resource::getResourceId));
+
+    // verify bind operations / each operation is performed once per resource
+    ResolvedZone newResolvedZone = ResolvedZone.createPublicZone("public/newZone");
+    verify(boundMonitorRepository, times(2)).saveAll(captorOfSavedBoundMonitors.capture());
+    verify(zoneStorage, times(2)).findLeastLoadedEnvoy(newResolvedZone);
+    verify(zoneStorage, times(2)).incrementBoundCount(newResolvedZone, "new-envoy-resource");
+
+    List<BoundMonitor> allBound = captorOfSavedBoundMonitors.getAllValues().stream().flatMap(List::stream).collect(Collectors.toList());
+    assertThat(allBound).hasSize(2);
+    assertThat(transform(allBound, BoundMonitor::getZoneName)).containsOnly("public/newZone");
+    assertThat(transform(allBound, BoundMonitor::getEnvoyId)).containsOnly(newEnvoy);
+    assertThat(transform(allBound, BoundMonitor::getResourceId)).containsExactlyElementsOf(transform(resources, Resource::getResourceId));
+  }
+
+  /**
+   * Tests the case where a remote monitor was previously configured with explicitly set
+   * zones and is now updated to have an empty list.
+   *
+   * When a monitor is updated to use an empty list of zones, the zones will instead be discovered
+   * when binding to each resource as they may vary depending on the region the resource is in.
+   *
+   * In this case there are two resources initially using the same one zone.
+   * The updating of the monitor to an empty list will lead to the previous bound monitors
+   * being removed from the old zone and new monitors bound to two zones per resource.
+   */
+  @Test
+  public void testHandleZoneChangePerResource_newZonesEmpty() {
+    String tenantId = RandomStringUtils.randomAlphanumeric(5);
+    // when the old zones are empty the bound monitor zone is based on the policy values.
+    // for this test we use this one zone to represent that.
+    List<String> originalZones = List.of("public/originalZone");
+    List<String> newZones1 = List.of("public/mz-r1-1", "public/mz-r1-2");
+    List<String> newZones2 = List.of("public/mz-r2-1", "public/mz-r2-2");
+
+    String oldEnvoy1 = RandomStringUtils.randomAlphabetic(5);
+    String oldEnvoy2 = RandomStringUtils.randomAlphabetic(5);
+    String newEnvoy = RandomStringUtils.randomAlphabetic(5);
+
+    // the updated monitor has no zones
+    Monitor monitor = persistNewRemoteMonitor(tenantId, Collections.emptyList());
+
+    final List<Resource> resources = List.of(
+        podamFactory.manufacturePojo(Resource.class)
+            .setResourceId("r-1")
+            .setTenantId(tenantId)
+            .setMetadata(Map.of("region", "testRegion1")),
+        podamFactory.manufacturePojo(Resource.class)
+            .setResourceId("r-2")
+            .setTenantId(tenantId)
+            .setMetadata(Map.of("region", "testRegion2")));
+
+    List<BoundMonitor> originalBoundMonitors = List.of(
+        new BoundMonitor()
+            .setResourceId(resources.get(0).getResourceId())
+            .setZoneName(originalZones.get(0))
+            .setEnvoyId(oldEnvoy1)
+            .setMonitor(monitor),
+        new BoundMonitor()
+            .setResourceId(resources.get(1).getResourceId())
+            .setZoneName(originalZones.get(0))
+            .setEnvoyId(oldEnvoy2)
+            .setMonitor(monitor)
+    );
+
+    // DISCOVERY OPERATIONS
+
+    when(boundMonitorRepository.findAllByMonitor_Id(any()))
+        .thenReturn(originalBoundMonitors);
+
+    when(resourceRepository.findByTenantIdAndResourceId(anyString(), anyString()))
+        .thenReturn(Optional.of(resources.get(0)))
+        .thenReturn(Optional.of(resources.get(1)));
+
+    when(policyApi.getDefaultMonitoringZones(resources.get(0).getMetadata().get(REGION_METADATA), true))
+        .thenReturn(newZones1);
+    when(policyApi.getDefaultMonitoringZones(resources.get(1).getMetadata().get(REGION_METADATA), true))
+        .thenReturn(newZones2);
+
+    // UNBIND OPERATIONS
+
+    when(boundMonitorRepository.findAllByMonitor_IdAndResourceIdAndZoneNameIn(any(), anyString(), any()))
+        .thenReturn(List.of(originalBoundMonitors.get(0)))
+        .thenReturn(List.of(originalBoundMonitors.get(1)));
+
+    when(zoneStorage.getEnvoyIdToResourceIdMap(any()))
+        .thenReturn(CompletableFuture.completedFuture(Collections.singletonMap(oldEnvoy1, "resourceValueDoesntMatter")))
+        .thenReturn(CompletableFuture.completedFuture(Collections.singletonMap(oldEnvoy2, "resourceValueDoesntMatter")));
+
+    // BIND OPERATIONS
+
+    when(zoneStorage.findLeastLoadedEnvoy(any()))
+        .thenReturn(CompletableFuture.completedFuture(
+            Optional.of(
+                new EnvoyResourcePair().setEnvoyId(newEnvoy).setResourceId("new-envoy-resource"))));
+
+    when(zoneStorage.incrementBoundCount(any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(1));
+
+
+    // EXECUTE
+
+    Set<String> affectedEnvoys = monitorManagement.handleZoneChangePerResource(monitor, originalZones);
+
+    // VERIFY
+
+    // the old monitors were allocated an envoy each, the new ones were added to the sole new envoy
+    assertThat(affectedEnvoys).containsOnlyOnce(oldEnvoy1, oldEnvoy2, newEnvoy);
+
+    // verify discovery operations
+    verify(boundMonitorRepository).findAllByMonitor_Id(monitor.getId());
+    verify(resourceRepository).findByTenantIdAndResourceId(tenantId, resources.get(0).getResourceId());
+    verify(resourceRepository).findByTenantIdAndResourceId(tenantId, resources.get(1).getResourceId());
+    verify(policyApi).getDefaultMonitoringZones("testRegion1", true);
+    verify(policyApi).getDefaultMonitoringZones("testRegion2", true);
+
+    // verify unbind operations / each operation is performed once per resource
+    verify(boundMonitorRepository, times(2)).deleteAll(captorOfDeletedBoundMonitors.capture());
+    List<BoundMonitor> allUnbound = captorOfDeletedBoundMonitors.getAllValues().stream().flatMap(List::stream).collect(Collectors.toList());
+    assertThat(allUnbound).hasSize(2);
+    assertThat(transform(allUnbound, BoundMonitor::getZoneName)).containsOnly("public/originalZone");
+    assertThat(transform(allUnbound, BoundMonitor::getEnvoyId)).containsOnly(oldEnvoy1, oldEnvoy2);
+    assertThat(transform(allUnbound, BoundMonitor::getResourceId)).containsOnlyElementsOf(transform(resources, Resource::getResourceId));
+
+    // verify bind operations / each operation is performed twice per zone per resource
+    verify(boundMonitorRepository, times(2)).saveAll(captorOfSavedBoundMonitors.capture());
+    verify(zoneStorage, times(4)).findLeastLoadedEnvoy(any());
+    verify(zoneStorage, times(4)).incrementBoundCount(any(), anyString());
+
+    Set<String> allNewZones = new HashSet<>();
+    allNewZones.addAll(newZones1);
+    allNewZones.addAll(newZones2);
+
+    List<BoundMonitor> allBound = captorOfSavedBoundMonitors.getAllValues().stream().flatMap(List::stream).collect(Collectors.toList());
+    assertThat(allBound).hasSize(4);
+    assertThat(transform(allBound, BoundMonitor::getZoneName)).containsOnlyElementsOf(allNewZones);
+    assertThat(transform(allBound, BoundMonitor::getEnvoyId)).containsOnly(newEnvoy);
+    assertThat(transform(allBound, BoundMonitor::getResourceId)).containsOnlyElementsOf(transform(resources, Resource::getResourceId));
+  }
+
+  /**
+   * This tests verifies that if a bound monitor is found for a resource that no longer exists
+   * that the orphaned bound monitor will be removed.
+   */
+  @Test
+  public void testHandleZoneChangePerResource_orphanedBoundMonitors() {
+    String tenantId = RandomStringUtils.randomAlphanumeric(5);
+    String resourceId = RandomStringUtils.randomAlphabetic(5);
+
+    Monitor monitor = persistNewRemoteMonitor(tenantId, List.of("public/z-1"));
+
+    BoundMonitor orphanedBoundMonitor = new BoundMonitor()
+        .setResourceId(resourceId)
+        .setZoneName("public/z-1")
+        .setEnvoyId("e-1")
+        .setMonitor(monitor);
+
+    // return no resource for an orphaned bound monitor
+    when(resourceRepository.findByTenantIdAndResourceId(anyString(), anyString()))
+        .thenReturn(Optional.empty());
+
+    when(boundMonitorRepository.findAllByMonitor_Id(any()))
+        .thenReturn(List.of(orphanedBoundMonitor));
+
+    when(boundMonitorRepository.findAllByMonitor_IdAndResourceIdIn(any(), any()))
+        .thenReturn(List.of(orphanedBoundMonitor));
+
+    when(zoneStorage.getEnvoyIdToResourceIdMap(any()))
+        .thenReturn(CompletableFuture.completedFuture(Collections.singletonMap("e-1", "resourceValueDoesntMatter")));
+
+    // EXECUTE
+
+    Set<String> affectedEnvoys = monitorManagement.handleZoneChangePerResource(monitor, Collections.emptyList());
+
+    // VERIFY
+
+    assertThat(affectedEnvoys).containsOnly("e-1");
+
+    verify(boundMonitorRepository).findAllByMonitor_Id(monitor.getId());
+    verify(boundMonitorRepository).findAllByMonitor_IdAndResourceIdIn(monitor.getId(), List.of(resourceId));
+    verify(resourceRepository).findByTenantIdAndResourceId(tenantId, resourceId);
+    verify(zoneStorage).getEnvoyIdToResourceIdMap(ResolvedZone.createPublicZone("public/z-1"));
+
+    verify(boundMonitorRepository).deleteAll(captorOfDeletedBoundMonitors.capture());
+    List<BoundMonitor> allUnbound = captorOfDeletedBoundMonitors.getAllValues().stream().flatMap(List::stream).collect(Collectors.toList());
+    assertThat(allUnbound).containsExactly(orphanedBoundMonitor);
+  }
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
@@ -17,7 +17,6 @@
 package com.rackspace.salus.monitor_management.services;
 
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
@@ -29,6 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -50,7 +50,9 @@ import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
 import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.entities.BoundMonitor;
+import com.rackspace.salus.telemetry.entities.MetadataPolicy;
 import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.entities.Resource;
 import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
@@ -67,6 +69,7 @@ import com.rackspace.salus.telemetry.model.TargetClassName;
 import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
 import com.rackspace.salus.telemetry.repositories.MonitorPolicyRepository;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import com.rackspace.salus.telemetry.repositories.ResourceRepository;
 import com.rackspace.salus.test.EnableTestContainersDatabase;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -166,6 +169,9 @@ public class MonitorManagement_MetadataPolicyTest {
 
   @MockBean
   MonitorPolicyRepository monitorPolicyRepository;
+
+  @MockBean
+  ResourceRepository resourceRepository;
 
   @MockBean
   ResourceApi resourceApi;
@@ -273,16 +279,18 @@ public class MonitorManagement_MetadataPolicyTest {
     String tenantId = RandomStringUtils.randomAlphabetic(10);
 
     when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any(), anyBoolean()))
-        .thenReturn(Map.of("zones",
-            (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
-                .setKey("zones")
-                .setValue("public/defaultZone1,public/defaultZone2")
-                .setValueType(MetadataValueType.STRING_LIST),
+        .thenReturn(Map.of(
             "interval",
             (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setKey("interval")
                 .setValue("PT42S")
                 .setValueType(MetadataValueType.DURATION)));
+
+    when(policyApi.getDefaultMonitoringZones(anyString(), anyBoolean()))
+        .thenReturn(List.of("public/defaultZone1" ,"public/defaultZone2"));
+
+    when(resourceRepository.findByTenantIdAndResourceId(anyString(), anyString()))
+        .thenReturn(Optional.of(new Resource()));
 
     final Monitor monitor = saveAssortmentOfPingMonitors(tenantId).get(0);
 
@@ -310,8 +318,8 @@ public class MonitorManagement_MetadataPolicyTest {
     assertThat(updatedMonitor.getInterval(), equalTo(Duration.ofSeconds(42)));
     assertThat(updatedMonitor.getMonitorName(), nullValue());
     assertThat(updatedMonitor.getLabelSelectorMethod(), equalTo(LabelSelectorMethod.AND));
-    assertThat(updatedMonitor.getZones(), hasSize(2));
-    assertThat(updatedMonitor.getZones(), containsInAnyOrder("public/defaultZone1", "public/defaultZone2"));
+    // no zones set, so zone metadata will be used when binding.
+    assertThat(updatedMonitor.getZones(), hasSize(0));
     // null gets returned when we store the value, but {} gets retrieved when we do a get (as shown farther below)
     // the null does not get exposed via the api
     assertThat(updatedMonitor.getLabelSelector(), nullValue());
@@ -320,13 +328,16 @@ public class MonitorManagement_MetadataPolicyTest {
     Optional<Monitor> retrieved = monitorManagement.getMonitor(tenantId, updatedMonitor.getId());
     assertTrue(retrieved.isPresent());
     assertThat(retrieved.get().getInterval(), equalTo(Duration.ofSeconds(42)));
-    assertThat(retrieved.get().getZones(), containsInAnyOrder("public/defaultZone1", "public/defaultZone2"));
+    assertThat(retrieved.get().getZones(), hasSize(0));
     // Retrieving nothing/null from an element collection leads to an empty collection being returned
     assertThat(retrieved.get().getLabelSelector(), equalTo(Collections.emptyMap()));
 
-    verify(boundMonitorRepository).findAllByMonitor_Id(monitor.getId());
-    // one save when changing zones and one for label selector change
+    // once for interval change and once for zone change
+    verify(boundMonitorRepository, times(2)).findAllByMonitor_Id(monitor.getId());
+    // one save when adding the extra zone and one for label selector change
     verify(boundMonitorRepository, times(2)).saveAll(any());
+
+    verify(policyApi).getDefaultMonitoringZones(MetadataPolicy.DEFAULT_ZONE, true);
 
     // only one event is sent
     // since the same envoy is used in the existing bound monitor
@@ -343,16 +354,16 @@ public class MonitorManagement_MetadataPolicyTest {
     String tenantId = RandomStringUtils.randomAlphabetic(10);
 
     when(policyApi.getEffectiveMonitorMetadataMap(anyString(), any(), any(), anyBoolean()))
-        .thenReturn(Map.of("zones",
-            (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
-                .setKey("zones")
-                .setValue("public/defaultZone1,public/defaultZone2")
-                .setValueType(MetadataValueType.STRING_LIST),
-            "interval",
+        .thenReturn(Map.of("interval",
             (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
                 .setKey("interval")
                 .setValue("42")
-                .setValueType(MetadataValueType.DURATION)));
+                .setValueType(MetadataValueType.DURATION),
+            "monitorName",
+            (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+                .setKey("monitorName")
+                .setValue("nameFromPolicy")
+                .setValueType(MetadataValueType.STRING)));
 
     final Monitor monitor = saveAssortmentOfPingMonitors(tenantId).get(0);
 
@@ -367,14 +378,21 @@ public class MonitorManagement_MetadataPolicyTest {
     when(boundMonitorRepository.findAllByMonitor_Id(monitor.getId()))
         .thenReturn(List.of(bound1));
 
+    List<Zone> zones = monitor.getZones().stream().map(z -> new Zone().setName(z))
+        .collect(Collectors.toList());
+
+    when(zoneManagement.getAvailableZonesForTenant(anyString(), any()))
+        .thenReturn(new PageImpl<>(zones, Pageable.unpaged(), zones.size()));
+
     // EXECUTE
 
-    // update will contain null zones but a new interval
+    // update will contain empty zones but a new interval
     final MonitorCU update = getBaseMonitorCUFromMonitor(monitor);
 
     final Duration newInterval = monitor.getInterval().plusSeconds(120L);
     update.setInterval(newInterval);
-    update.setZones(null);
+    update.setMonitorName(null);
+    update.setZones(monitor.getZones()); // avoid any zone change logic
 
     final Monitor updatedMonitor = monitorManagement.updateMonitor(
         tenantId, monitor.getId(), update, true);
@@ -383,20 +401,20 @@ public class MonitorManagement_MetadataPolicyTest {
 
     // new interval is set using provided value, not metadata
     assertThat(updatedMonitor.getInterval(), equalTo(newInterval));
-    assertThat(updatedMonitor.getMonitorName(), nullValue());
+    // monitorName is set with metadata policy info
+    assertThat(updatedMonitor.getMonitorName(), equalTo("nameFromPolicy"));
     assertThat(updatedMonitor.getLabelSelectorMethod(), equalTo(LabelSelectorMethod.AND));
-    assertThat(updatedMonitor.getZones(), hasSize(2));
-    // zones are set with metadata policy info
-    assertThat(updatedMonitor.getZones(), containsInAnyOrder("public/defaultZone1", "public/defaultZone2"));
+    assertThat(updatedMonitor.getZones(), hasSize(1));
 
     // and verify the stored entity
     Optional<Monitor> retrieved = monitorManagement.getMonitor(tenantId, updatedMonitor.getId());
     assertTrue(retrieved.isPresent());
     assertThat(retrieved.get().getInterval(), equalTo(newInterval));
-    assertThat(retrieved.get().getZones(), containsInAnyOrder("public/defaultZone1", "public/defaultZone2"));
+    assertThat(retrieved.get().getMonitorName(), equalTo("nameFromPolicy"));
 
     verify(boundMonitorRepository).findAllByMonitor_Id(monitor.getId());
-    verify(boundMonitorRepository, times(1)).saveAll(any());
+    // no fields on the plugin changed so the bound monitor did not need to be re-saved
+    verify(boundMonitorRepository, never()).saveAll(any());
 
     // only one event is sent
     // since the same envoy is used in the existing bound monitor

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
@@ -290,7 +290,7 @@ public class MonitorManagement_MetadataPolicyTest {
         .thenReturn(List.of("public/defaultZone1" ,"public/defaultZone2"));
 
     when(resourceRepository.findByTenantIdAndResourceId(anyString(), anyString()))
-        .thenReturn(Optional.of(new Resource()));
+        .thenReturn(Optional.of(podamFactory.manufacturePojo(Resource.class)));
 
     final Monitor monitor = saveAssortmentOfPingMonitors(tenantId).get(0);
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/TestMonitorServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/TestMonitorServiceTest.java
@@ -43,7 +43,6 @@ import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.messaging.TestMonitorRequestEvent;
 import com.rackspace.salus.telemetry.messaging.TestMonitorResultsEvent;
 import com.rackspace.salus.telemetry.model.AgentType;
-import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.model.SimpleNameTagValueMetric;
 import com.rackspace.salus.telemetry.repositories.ResourceRepository;
@@ -376,8 +375,8 @@ public class TestMonitorServiceTest {
         .thenReturn(Optional.of(resource));
 
     // just return the zones given
-    when(monitorManagement.determineMonitoringZones(any(), any()))
-        .then(invocationOnMock -> invocationOnMock.getArgument(1));
+    when(monitorManagement.determineMonitoringZones(any(), (String) any()))
+        .then(invocationOnMock -> invocationOnMock.getArgument(0));
 
     when(monitorManagement.findLeastLoadedEnvoyInZone(any(), any()))
         .thenReturn("e-1");
@@ -448,7 +447,7 @@ public class TestMonitorServiceTest {
       return true;
     }));
 
-    verify(monitorManagement).determineMonitoringZones(ConfigSelectorScope.REMOTE, monitoringZones);
+    verify(monitorManagement).determineMonitoringZones(monitoringZones, null);
     verify(monitorManagement).findLeastLoadedEnvoyInZone("t-1", "z-1");
 
     verifyNoMoreInteractions(
@@ -492,8 +491,8 @@ public class TestMonitorServiceTest {
         .thenReturn(Optional.of(resource));
 
     // just return the zones given
-    when(monitorManagement.determineMonitoringZones(any(), any()))
-        .then(invocationOnMock -> invocationOnMock.getArgument(1));
+    when(monitorManagement.determineMonitoringZones(any(), (String) any()))
+        .then(invocationOnMock -> invocationOnMock.getArgument(0));
 
     // EXECUTE
 
@@ -522,7 +521,7 @@ public class TestMonitorServiceTest {
 
     verify(resourceRepository).findByTenantIdAndResourceId("t-1", "r-1");
 
-    verify(monitorManagement).determineMonitoringZones(ConfigSelectorScope.REMOTE, monitoringZones);
+    verify(monitorManagement).determineMonitoringZones(monitoringZones, null);
 
     verifyNoMoreInteractions(
         monitorConversionService, monitorContentRenderer, resourceRepository,
@@ -550,8 +549,8 @@ public class TestMonitorServiceTest {
         .thenReturn(Optional.of(resource));
 
     // just return the zones given
-    when(monitorManagement.determineMonitoringZones(any(), any()))
-        .then(invocationOnMock -> invocationOnMock.getArgument(1));
+    when(monitorManagement.determineMonitoringZones(any(), (String) any()))
+        .then(invocationOnMock -> invocationOnMock.getArgument(0));
 
     //noinspection ConstantConditions
     when(monitorManagement.findLeastLoadedEnvoyInZone(any(), any()))
@@ -584,7 +583,7 @@ public class TestMonitorServiceTest {
 
     verify(resourceRepository).findByTenantIdAndResourceId("t-1", "r-1");
 
-    verify(monitorManagement).determineMonitoringZones(ConfigSelectorScope.REMOTE, monitoringZones);
+    verify(monitorManagement).determineMonitoringZones(monitoringZones, null);
     verify(monitorManagement).findLeastLoadedEnvoyInZone("t-1", "z-1");
 
     verifyNoMoreInteractions(

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -284,10 +284,10 @@ public class MetadataUtilsTest {
                 .setValueType(MetadataValueType.DURATION)
                 .setValue("PT1S")
                 .setKey("interval"),
-            "zones", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
-                .setValueType(MetadataValueType.STRING_LIST)
-                .setValue("zone1,zone2")
-                .setKey("zones")
+            "monitorName", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+                .setValueType(MetadataValueType.STRING)
+                .setValue("default monitor name")
+                .setKey("name")
         ));
 
     String tenantId = RandomStringUtils.randomAlphabetic(10);
@@ -295,24 +295,24 @@ public class MetadataUtilsTest {
     assertThat(monitor.getMonitorMetadataFields()).isNull();
 
     metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
-    assertThat(monitor.getMonitorMetadataFields()).hasSize(3);
-    assertThat(monitor.getMonitorMetadataFields()).containsExactlyInAnyOrder("monitorName", "interval", "zones");
+    assertThat(monitor.getMonitorMetadataFields()).hasSize(2);
+    assertThat(monitor.getMonitorMetadataFields()).containsExactlyInAnyOrder("monitorName", "interval");
 
     // set a value different from the policy to remove it from metadata fields
     monitor.setInterval(Duration.ofSeconds(10));
     metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
-    assertThat(monitor.getMonitorMetadataFields()).hasSize(2);
-    assertThat(monitor.getMonitorMetadataFields()).containsExactly("monitorName", "zones");
+    assertThat(monitor.getMonitorMetadataFields()).hasSize(1);
+    assertThat(monitor.getMonitorMetadataFields()).containsExactly("monitorName");
 
     // set a value the same as the policy and it should remain in metadata fields.
-    monitor.setZones(List.of("zone1", "zone2"));
-    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
-    assertThat(monitor.getMonitorMetadataFields()).hasSize(2);
-
-    // set a value different from the policy to remove it from metadata fields
-    monitor.setZones(List.of("zone"));
+    monitor.setMonitorName("default monitor name");
     metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
     assertThat(monitor.getMonitorMetadataFields()).hasSize(1);
+
+    // set a value different from the policy to remove it from metadata fields
+    monitor.setMonitorName("non policy monitor name");
+    metadataUtils.setMetadataFieldsForMonitor(tenantId, monitor, false);
+    assertThat(monitor.getMonitorMetadataFields()).hasSize(0);
 
     verify(policyApi, times(4)).getEffectiveMonitorMetadataMap(tenantId, TargetClassName.Monitor, null, true);
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/utils/MetadataUtilsTest.java
@@ -38,7 +38,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -214,7 +213,6 @@ public class MetadataUtilsTest {
   }
 
   @Test
-  @Ignore
   public void setUpdateMetadataValue_STRING() {
     Disk plugin = new Disk();
     MonitorMetadataPolicyDTO policy = (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()


### PR DESCRIPTION
# What

`null` zones will now be populated when the monitor is bound to the resource.  It will use the values stored in policy management.

# How

If zones are set to `null`, query policy mgmt when creating bound monitors and attempt to set the value to those specific to the region of the resource.

This expects that there is a `region` field set in the `metadata` of a resource.  If there is no value a `default` region will be used instead, which should have a corresponding policy.

The api client also has caching enabled to limit the number of queries made.

## How to test

New tests + manually

# Why

We should be opinionated about what zones get configured.  If the customer does not need to specify them at creation it makes them less important to them and most customers should not care where we are monitoring from.

However, default zones only really make sense when you can consider the location of the item being monitored.  e.g. you do not want to monitor a website in Australia from all US locations.  Zones closer to that region should be used instead.

# TODO

I want to move a bunch of the other `update` tests from MonitorManagementTest to the new file I've created for tests related to updating monitors.