### PR TITLE
Add field to monitor payload to show whether it is tied to a policy

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -114,6 +114,7 @@ public class MonitorConversionService {
         .setExcludedResourceIds(monitor.getExcludedResourceIds())
         .setInterval(monitor.getInterval())
         .setDetails(convertContentToDetails(monitor))
+        .setPolicy(monitor.getPolicyId() != null)
         .setCreatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(monitor.getCreatedTimestamp()))
         .setUpdatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(monitor.getUpdatedTimestamp()));
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
@@ -36,6 +36,7 @@ public class DetailedMonitorOutput {
     Duration interval;
     @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\", \"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false, \"reportActive\": false, \"totalcpu\": true} }")
     MonitorDetails details;
+    boolean isPolicy;
     String createdTimestamp;
     String updatedTimestamp;
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorConversionServiceTest.java
@@ -518,6 +518,33 @@ public class MonitorConversionServiceTest {
   }
 
   @Test
+  public void testConvertTo_usingPolicy() {
+    Monitor monitor = new Monitor()
+        .setId(UUID.randomUUID())
+        .setPolicyId(UUID.randomUUID())
+        .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setAgentType(AgentType.TELEGRAF)
+        .setContent("{\"type\":\"cpu\"}")
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
+    final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
+    assertThat(result.isPolicy()).isTrue();
+  }
+
+  @Test
+  public void testConvertTo_notUsingPolicy() {
+    Monitor monitor = new Monitor()
+        .setId(UUID.randomUUID())
+        .setSelectorScope(ConfigSelectorScope.LOCAL)
+        .setAgentType(AgentType.TELEGRAF)
+        .setContent("{\"type\":\"cpu\"}")
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
+    final DetailedMonitorOutput result = conversionService.convertToOutput(monitor);
+    assertThat(result.isPolicy()).isFalse();
+  }
+
+  @Test
   public void testConvertFrom_Interval_Explicit() {
     final Duration interval = Duration.ofSeconds(60);
 

--- a/src/test/resources/DetailedMonitorOutputTest/local.json
+++ b/src/test/resources/DetailedMonitorOutputTest/local.json
@@ -19,6 +19,7 @@
       "totalcpu": true
     }
   },
+  "policy": false,
   "summary": {"key": "value"},
   "createdTimestamp": "1970-01-01T00:00:00Z",
   "updatedTimestamp": "1970-01-01T00:00:01Z"

--- a/src/test/resources/DetailedMonitorOutputTest/remote.json
+++ b/src/test/resources/DetailedMonitorOutputTest/remote.json
@@ -21,6 +21,7 @@
       "timeout": "PT20S"
     }
   },
+  "policy": false,
   "summary": {"key": "value"},
   "createdTimestamp": "1970-01-01T00:00:00Z",
   "updatedTimestamp": "1970-01-01T00:00:01Z"


### PR DESCRIPTION
Adds a boolean `policy` field to the payload returned from any api query for a monitor.

This will allow the customer to know which monitors were created via Policy Mgmt and which monitors were created by themselves.

I purposely chose not to return the actual policyId it relates to since policies are not customer facing objects.