### PR TITLE
Pin maven build image

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -51,8 +51,8 @@ steps:
       path: /root
 
   - id: DEPLOY
-    name: 'gcr.io/cloud-builders/mvn'
-    args: ['-B', 'deploy', '-s', '.mvn/settings.xml']
+    name: 'maven:3.6-jdk-11'
+    args: ['mvn', '-B', 'deploy', '-s', '.mvn/settings.xml']
     volumes:
     - name: user.home
       path: /root

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,7 +28,7 @@ steps:
       path: /root
 
   - id: VERIFY
-    name: 'gcr.io/cloud-builders/mvn'
+    name: 'maven:3.6-jdk-11'
     args: ['-B', 'verify', '-s', '.mvn/settings.xml']
     volumes:
     - name: user.home

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,7 +29,7 @@ steps:
 
   - id: VERIFY
     name: 'maven:3.6-jdk-11'
-    args: ['-B', 'verify', '-s', '.mvn/settings.xml']
+    args: ['mvn', '-B', 'verify', '-s', '.mvn/settings.xml']
     volumes:
     - name: user.home
       path: /root


### PR DESCRIPTION
# What

Unit tests that used embedded kafka were failing in Google Cloud Build and this 

```
Step #3 - "DEPLOY": 2020-04-07 22:45:08.195  WARN [salus-telemetry-monitor-management,,,] 65 --- [27.0.0.1:35835)] org.apache.zookeeper.ClientCnxn          : Session 0x0 for server 127.0.0.1/<unresolved>:35835, unexpected error, closing socket connection and attempting reconnect
Step #3 - "DEPLOY": 
Step #3 - "DEPLOY": java.lang.IllegalArgumentException: Unable to canonicalize address 127.0.0.1/<unresolved>:35835 because it's not resolvable
```

was one of the weird warning logs found prior to the unit test failure report:

```
Step #3 - "DEPLOY": [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 11.36 s <<< FAILURE! - in com.rackspace.salus.monitor_management.services.ResourceEventListenerTest
Step #3 - "DEPLOY": [ERROR] testReattachedEnvoyResourceEvent(com.rackspace.salus.monitor_management.services.ResourceEventListenerTest)  Time elapsed: 0.001 s  <<< ERROR!
Step #3 - "DEPLOY": java.lang.IllegalStateException: Failed to load ApplicationContext
Step #3 - "DEPLOY": Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'embeddedKafka': Invocation of init method failed; nested exception is kafka.zookeeper.ZooKeeperClientTimeoutException: Timed out waiting for connection while in state: CONNECTING
Step #3 - "DEPLOY": Caused by: kafka.zookeeper.ZooKeeperClientTimeoutException: Timed out waiting for connection while in state: CONNECTING
```

Elsewhere in the logs I noticed it's using Java 14

```
Step #3 - "DEPLOY": 2020-04-07 22:45:07.456  INFO [salus-telemetry-monitor-management,,,] 65 --- [           main] o.a.zookeeper.server.ZooKeeperServer     : Server environment:java.home=/usr/java/openjdk-14
```

which is certainly a version we want to eventually use, but it would be nice to be using a version of Java we expect for our codebase.

# How

Since [the GCR mvn image](https://console.cloud.google.com/gcr/images/cloud-builders/GLOBAL/mvn?gcrImageListsize=30) lacks useful tags, I switched us over to the Docker Hub official image, which has lots of fine grained tags:

https://hub.docker.com/_/maven

## How to test

Two builds have so far ran successfully.