### PR TITLE
Enable tenant id verification

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/TelemetryMonitorManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/TelemetryMonitorManagementApplication.java
@@ -22,6 +22,7 @@ import com.rackspace.salus.common.util.DumpConfigProperties;
 import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
 import com.rackspace.salus.common.web.EnableRoleBasedJsonViews;
 import com.rackspace.salus.telemetry.etcd.EnableEtcd;
+import com.rackspace.salus.telemetry.web.EnableTenantVerification;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -30,6 +31,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @EnableEtcd
 @EnableRoleBasedJsonViews
 @EnableExtendedErrorAttributes
+@EnableTenantVerification
 @AutoConfigureSalusAppMetrics
 public class TelemetryMonitorManagementApplication {
 

--- a/src/test/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClientTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
@@ -73,6 +75,9 @@ public class MonitorApiClientTest {
 
   @Autowired
   ObjectMapper objectMapper;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void testQueryBoundMonitors() throws IOException {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/client/ZoneApiClientTest.java
@@ -24,11 +24,13 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
@@ -52,6 +54,9 @@ public class ZoneApiClientTest {
 
     @Autowired
     ZoneApiClient zoneApiClient;
+
+    @MockBean
+    TenantMetadataRepository tenantMetadataRepository;
 
     private PodamFactory podamFactory = new PodamFactoryImpl();
 

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorSchemaControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorSchemaControllerTest.java
@@ -22,10 +22,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.rackspace.salus.monitor_management.services.SchemaService;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -37,6 +39,9 @@ import org.springframework.test.web.servlet.MockMvc;
 public class MonitorSchemaControllerTest {
   @Autowired
   MockMvc mockMvc;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void testGetMonitorPluginsSchema() throws Exception {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorTranslationApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorTranslationApiControllerTest.java
@@ -36,6 +36,7 @@ import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import com.rackspace.salus.telemetry.translators.RenameFieldKeyTranslator;
 import java.util.List;
 import java.util.UUID;
@@ -63,6 +64,9 @@ public class MonitorTranslationApiControllerTest {
 
   @MockBean
   MonitorContentTranslationService monitorContentTranslationService;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void testGetAll() throws Exception {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/TestMonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/TestMonitorApiControllerTest.java
@@ -29,6 +29,7 @@ import static com.rackspace.salus.common.util.SpringResourceUtils.readContent;
 import com.rackspace.salus.monitor_management.services.TestMonitorService;
 import com.rackspace.salus.monitor_management.web.model.TestMonitorOutput;
 import com.rackspace.salus.telemetry.model.SimpleNameTagValueMetric;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
@@ -50,6 +51,9 @@ public class TestMonitorApiControllerTest {
 
   @MockBean
   private TestMonitorService testMonitorService;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void testPerformTestMonitor_success() throws Exception {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiControllerTest.java
@@ -47,6 +47,7 @@ import com.rackspace.salus.monitor_management.web.model.ZoneDTO;
 import com.rackspace.salus.telemetry.model.ZoneState;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -89,6 +90,9 @@ public class ZoneApiControllerTest {
 
     @MockBean
     MonitorManagement monitorManagement;
+
+    @MockBean
+    TenantMetadataRepository tenantMetadataRepository;
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOJsonTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOJsonTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.UUID;
@@ -30,6 +31,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -42,6 +44,9 @@ public class BoundMonitorDTOJsonTest {
   @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") // IntelliJ has trouble resolving
   @Autowired
   private JacksonTester<BoundMonitorDTO> json;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void testEmptyZone_nonNullEnvoy() throws IOException {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Cpu;
 import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -33,6 +34,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
 import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -41,6 +43,9 @@ public class DetailedMonitorOutputTest {
 
   @Autowired
   private JacksonTester<DetailedMonitorOutput> json;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void testLocalMonitor() throws IOException {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/MonitorDTOTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/MonitorDTOTest.java
@@ -24,10 +24,12 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.lang.reflect.Field;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.ReflectionUtils;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -38,6 +40,9 @@ import uk.co.jemos.podam.api.PodamFactoryImpl;
 public class MonitorDTOTest {
 
   private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void testFieldsCoveredWithResourceId() {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/DataguardConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/DataguardConversionTest.java
@@ -33,6 +33,7 @@ import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -67,6 +68,9 @@ public class DataguardConversionTest {
 
   @Autowired
   MetadataUtils metadataUtils;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void convertToOutput_dataguard() throws IOException {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/RmanConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/RmanConversionTest.java
@@ -33,6 +33,7 @@ import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -67,6 +68,9 @@ public class RmanConversionTest {
 
   @Autowired
   MetadataUtils metadataUtils;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void convertToOutput_rman() throws IOException {

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/TablespaceConversionTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/oracle/TablespaceConversionTest.java
@@ -33,6 +33,7 @@ import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -66,6 +67,9 @@ public class TablespaceConversionTest {
 
   @Autowired
   MetadataUtils metadataUtils;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void convertToOutput_tablespace() throws IOException {


### PR DESCRIPTION
See https://github.com/racker/salus-telemetry-model/pull/124

Utilizes the `@EnableTenantVerification` annotations and adds some simple tests to show it took effect.