### PR TITLE
Ability to get bound monitors by resourceId and monitorId

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -2091,12 +2091,18 @@ public class MonitorManagement {
     return boundMonitorRepository.findAllByTenantId(tenantId, page);
   }
 
-  private List<BoundMonitor> getAllBoundPolicyMonitorsByTenantId(String tenantId) {
-    return boundMonitorRepository.findAllByTenantIdAndMonitor_TenantId(tenantId, POLICY_TENANT);
+  public Page<BoundMonitor> getAllBoundMonitorsByResourceIdAndTenantId(String resourceId, String tenantId, Pageable page) {
+    return boundMonitorRepository.findAllByResourceIdAndMonitor_TenantId(resourceId, tenantId, page);
   }
 
-  private List<BoundMonitor> getAllBoundMonitorsByMonitorIdAndTenantId(UUID monitorId, String tenantId) {
-    return boundMonitorRepository.findAllByMonitor_IdAndMonitor_TenantId(monitorId, tenantId);
+  public Page<BoundMonitor> getAllBoundMonitorsByMonitorIdAndTenantId(UUID monitorId, String tenantId, Pageable page) {
+    return boundMonitorRepository.findAllByMonitor_IdAndMonitor_TenantId(monitorId, tenantId, page);
+  }
+
+  public Page<BoundMonitor> getAllBoundMonitorsByResourceIdAndMonitorIdAndTenantId(
+      String resourceId, UUID monitorId, String tenantId, Pageable page) {
+    return boundMonitorRepository.findAllByResourceIdAndMonitor_IdAndMonitor_TenantId(
+        resourceId, monitorId, tenantId, page);
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -56,6 +57,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -213,7 +215,29 @@ public class MonitorApiController {
 
   @GetMapping("/tenant/{tenantId}/bound-monitors")
   public PagedContent<BoundMonitorDTO> getBoundMonitorsForTenant(@PathVariable String tenantId,
+                                                                 @RequestParam(required = false) String resourceId,
+                                                                 @RequestParam(required = false) UUID monitorId,
                                                                  Pageable pageable) {
+
+    if (StringUtils.isNotBlank(resourceId) && monitorId != null) {
+      return PagedContent.fromPage(
+          monitorManagement
+              .getAllBoundMonitorsByResourceIdAndMonitorIdAndTenantId(resourceId, monitorId, tenantId, pageable)
+              .map(BoundMonitorDTO::new)
+      );
+    } else if (StringUtils.isNotBlank(resourceId)) {
+      return PagedContent.fromPage(
+          monitorManagement
+              .getAllBoundMonitorsByResourceIdAndTenantId(resourceId, tenantId, pageable)
+              .map(BoundMonitorDTO::new)
+      );
+    } else if (monitorId != null) {
+      return PagedContent.fromPage(
+          monitorManagement
+              .getAllBoundMonitorsByMonitorIdAndTenantId(monitorId, tenantId, pageable)
+              .map(BoundMonitorDTO::new)
+      );
+    }
     return PagedContent.fromPage(
         monitorManagement.getAllBoundMonitorsByTenantId(tenantId, pageable)
             .map(BoundMonitorDTO::new)

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
@@ -65,6 +65,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEnti
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -174,11 +176,11 @@ public class MonitorManagementExcludeResourceIdsTest {
     final Monitor retrieved = entityManager.find(Monitor.class, monitor.getId());
     assertThat(retrieved.getExcludedResourceIds()).containsExactlyInAnyOrder("r-3", "r-5");
 
-    final List<BoundMonitor> bound = boundMonitorRepository
-        .findAllByMonitor_IdAndMonitor_TenantId(monitor.getId(), "t-1");
+    final Page<BoundMonitor> bound = boundMonitorRepository
+        .findAllByMonitor_IdAndMonitor_TenantId(monitor.getId(), "t-1", Pageable.unpaged());
 
     assertThat(bound).hasSize(1);
-    assertThat(bound.get(0).getResourceId()).isEqualTo("r-1");
+    assertThat(bound.getContent().get(0).getResourceId()).isEqualTo("r-1");
 
     verify(resourceApi).getResourcesWithLabels("t-1", emptyMap(), LabelSelectorMethod.AND);
 
@@ -271,8 +273,8 @@ public class MonitorManagementExcludeResourceIdsTest {
     );
 
     // sanity check bindings
-    final List<BoundMonitor> origBound = boundMonitorRepository
-        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1");
+    final Page<BoundMonitor> origBound = boundMonitorRepository
+        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1", Pageable.unpaged());
     assertThat(origBound).extracting(BoundMonitor::getResourceId)
         .containsExactlyInAnyOrder("r-include-include", "r-include-exclude");
 
@@ -294,8 +296,8 @@ public class MonitorManagementExcludeResourceIdsTest {
 
     // VERIFY
 
-    final List<BoundMonitor> updatedBound = boundMonitorRepository
-        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1");
+    final Page<BoundMonitor> updatedBound = boundMonitorRepository
+        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1", Pageable.unpaged());
     assertThat(updatedBound).extracting(BoundMonitor::getResourceId)
         .containsExactlyInAnyOrder("r-include-include", "r-exclude-include");
 
@@ -370,8 +372,8 @@ public class MonitorManagementExcludeResourceIdsTest {
     );
 
     // sanity check bindings
-    final List<BoundMonitor> origBound = boundMonitorRepository
-        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1");
+    final Page<BoundMonitor> origBound = boundMonitorRepository
+        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1", Pageable.unpaged());
     assertThat(origBound).extracting(BoundMonitor::getResourceId)
         .containsExactlyInAnyOrder("r-include-include");
 
@@ -393,8 +395,8 @@ public class MonitorManagementExcludeResourceIdsTest {
 
     // VERIFY
 
-    final List<BoundMonitor> updatedBound = boundMonitorRepository
-        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1");
+    final Page<BoundMonitor> updatedBound = boundMonitorRepository
+        .findAllByMonitor_IdAndMonitor_TenantId(original.getId(), "t-1", Pageable.unpaged());
     assertThat(updatedBound).extracting(BoundMonitor::getResourceId)
         .containsExactlyInAnyOrder("r-include-include", "r-absent-include");
 


### PR DESCRIPTION
# What

Ability to specify one or both of `resourceId`/`monitorId` as a query param to the bound monitor endpoint.

# How

Adds optional query params and adds new repository methods.

## How to test

I tested this manually.

If anyone wants tests added specifically for these params I'll do that sometime over the next week or so.

Some queries from Insomnia:
```
# get all
{{ monitor_mgmt  }}/api/tenant/aaaaaa/bound-monitors

# get all for resource
{{ monitor_mgmt  }}/api/tenant/aaaaaa/bound-monitors?resourceId=defaultServer1

# get all for monitor
{{ monitor_mgmt  }}/api/tenant/aaaaaa/bound-monitors?monitorId=c5d9d8a1-9dd3-40fb-afec-7577c329a1f9

# get all for resource and monitor
{{ monitor_mgmt  }}/api/tenant/aaaaaa/bound-monitors?resourceId=defaultServer1&monitorId=c5d9d8a1-9dd3-40fb-afec-7577c329a1f9
```

# Why

Helps intelligence show the things they care about without having to filter a potentially large payload on the client side.