### PR TITLE
Added monitor name and summary to BoundMonitorDTO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-protocol</artifactId>
-      <version>0.2-SNAPSHOT</version>
+      <version>0.6-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -23,6 +23,7 @@ import com.rackspace.salus.monitor_management.utils.MetadataUtils;
 import com.rackspace.salus.monitor_management.web.converter.PatchHelper;
 import com.rackspace.salus.monitor_management.web.model.ApplicableAgentType;
 import com.rackspace.salus.monitor_management.web.model.ApplicableMonitorType;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.monitor_management.web.model.LocalMonitorDetails;
@@ -34,6 +35,7 @@ import com.rackspace.salus.monitor_management.web.model.RemotePlugin;
 import com.rackspace.salus.monitor_management.web.model.SummaryField;
 import com.rackspace.salus.monitor_management.web.model.ValidationGroups;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
+import com.rackspace.salus.telemetry.entities.BoundMonitor;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
@@ -433,5 +435,12 @@ public class MonitorConversionService {
       log.warn("Failed to serialize plugin details of monitor={}", monitor, e);
       throw new IllegalStateException("Failed to serialize plugin details");
     }
+  }
+
+  public BoundMonitorDTO convertToBoundMonitorDTO(BoundMonitor boundMonitor) {
+    final BoundMonitorDTO dto = new BoundMonitorDTO(boundMonitor);
+    final DetailedMonitorOutput detailedMonitorOutput = convertToOutput(boundMonitor.getMonitor());
+    dto.setMonitorSummary(buildSummaryFromDetails(detailedMonitorOutput.getDetails()));
+    return dto;
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -223,24 +223,24 @@ public class MonitorApiController {
       return PagedContent.fromPage(
           monitorManagement
               .getAllBoundMonitorsByResourceIdAndMonitorIdAndTenantId(resourceId, monitorId, tenantId, pageable)
-              .map(BoundMonitorDTO::new)
+              .map(monitorConversionService::convertToBoundMonitorDTO)
       );
     } else if (StringUtils.isNotBlank(resourceId)) {
       return PagedContent.fromPage(
           monitorManagement
               .getAllBoundMonitorsByResourceIdAndTenantId(resourceId, tenantId, pageable)
-              .map(BoundMonitorDTO::new)
+              .map(monitorConversionService::convertToBoundMonitorDTO)
       );
     } else if (monitorId != null) {
       return PagedContent.fromPage(
           monitorManagement
               .getAllBoundMonitorsByMonitorIdAndTenantId(monitorId, tenantId, pageable)
-              .map(BoundMonitorDTO::new)
+              .map(monitorConversionService::convertToBoundMonitorDTO)
       );
     }
     return PagedContent.fromPage(
         monitorManagement.getAllBoundMonitorsByTenantId(tenantId, pageable)
-            .map(BoundMonitorDTO::new)
+            .map(monitorConversionService::convertToBoundMonitorDTO)
     );
   }
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,14 @@ package com.rackspace.salus.monitor_management.web.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonView;
+import com.rackspace.salus.common.web.View;
 import com.rackspace.salus.telemetry.entities.BoundMonitor;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.MonitorType;
-import com.rackspace.salus.common.web.View;
 import java.time.Duration;
 import java.time.format.DateTimeFormatter;
+import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -41,6 +42,8 @@ public class BoundMonitorDTO {
 
   UUID monitorId;
   MonitorType monitorType;
+  String monitorName;
+  Map<String,String> monitorSummary;
   @JsonView(View.Admin.class)
   String tenantId;
   @JsonInclude(Include.NON_EMPTY)
@@ -57,6 +60,7 @@ public class BoundMonitorDTO {
   public BoundMonitorDTO(BoundMonitor boundMonitor) {
     this.monitorId = boundMonitor.getMonitor().getId();
     this.monitorType = boundMonitor.getMonitor().getMonitorType();
+    this.monitorName = boundMonitor.getMonitor().getMonitorName();
     this.tenantId = boundMonitor.getTenantId();
     this.zoneName = boundMonitor.getZoneName();
     this.resourceId = boundMonitor.getResourceId();

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOJsonTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,6 +56,8 @@ public class BoundMonitorDTOJsonTest {
         .setZoneName("")
         .setMonitorId(UUID.fromString("00000000-0000-0000-0001-000000000000"))
         .setMonitorType(MonitorType.cpu)
+        .setMonitorName("name-1")
+        .setMonitorSummary(Map.of())
         .setTenantId("t-1")
         .setResourceId("r-1")
         .setSelectorScope(ConfigSelectorScope.LOCAL)
@@ -76,6 +79,8 @@ public class BoundMonitorDTOJsonTest {
         .setZoneName("")
         .setMonitorId(UUID.fromString("00000000-0000-0000-0001-000000000000"))
         .setMonitorType(MonitorType.cpu)
+        .setMonitorName("name-1")
+        .setMonitorSummary(Map.of())
         .setTenantId("t-1")
         .setResourceId("r-1")
         .setSelectorScope(ConfigSelectorScope.LOCAL)
@@ -97,6 +102,8 @@ public class BoundMonitorDTOJsonTest {
         .setZoneName("z-1")
         .setMonitorId(UUID.fromString("00000000-0000-0000-0001-000000000000"))
         .setMonitorType(MonitorType.cpu)
+        .setMonitorName("name-1")
+        .setMonitorSummary(Map.of())
         .setTenantId("t-1")
         .setResourceId("r-1")
         .setSelectorScope(ConfigSelectorScope.REMOTE)

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThat;
 
 import com.rackspace.salus.telemetry.entities.BoundMonitor;
 import java.lang.reflect.Field;
+import java.util.Map;
 import org.junit.Test;
 import org.springframework.util.ReflectionUtils;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -37,6 +38,8 @@ public class BoundMonitorDTOTest {
     final BoundMonitor boundMonitor = podamFactory.manufacturePojo(BoundMonitor.class);
 
     final BoundMonitorDTO dto = new BoundMonitorDTO(boundMonitor);
+    // manually fill summary since it gets populated by MonitorConversionService
+    dto.setMonitorSummary(Map.of());
 
     // First verification approach is to check that all fields are populated with something.
     // This approach makes sure that the verification further down doesn't miss a new field.
@@ -44,7 +47,7 @@ public class BoundMonitorDTOTest {
     for (Field field : BoundMonitorDTO.class.getDeclaredFields()) {
       field.setAccessible(true);
       final Object value = ReflectionUtils.getField(field, dto);
-      assertThat(value, notNullValue());
+      assertThat(field.getName(), value, notNullValue());
       if (value instanceof String) {
         assertThat(((String) value), not(isEmptyString()));
       }
@@ -53,6 +56,7 @@ public class BoundMonitorDTOTest {
     // and next verification is to check populated with correct values
 
     assertThat(dto.getMonitorId(), equalTo(boundMonitor.getMonitor().getId()));
+    assertThat(dto.getMonitorName(), equalTo(boundMonitor.getMonitor().getMonitorName()));
     assertThat(dto.getTenantId(), equalTo(boundMonitor.getTenantId()));
     assertThat(dto.getZoneName(), equalTo(boundMonitor.getZoneName()));
     assertThat(dto.getResourceId(), equalTo(boundMonitor.getResourceId()));

--- a/src/test/resources/BoundMonitorDTOJsonTest/testAllPopulated.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testAllPopulated.json
@@ -1,6 +1,8 @@
 {
   "monitorId": "00000000-0000-0000-0001-000000000000",
   "monitorType": "cpu",
+  "monitorName": "name-1",
+  "monitorSummary": {},
   "tenantId": "t-1",
   "resourceId": "r-1",
   "selectorScope": "REMOTE",

--- a/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nonNullEnvoy.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nonNullEnvoy.json
@@ -1,6 +1,8 @@
 {
   "monitorId": "00000000-0000-0000-0001-000000000000",
   "monitorType": "cpu",
+  "monitorName": "name-1",
+  "monitorSummary": {},
   "tenantId": "t-1",
   "resourceId": "r-1",
   "selectorScope": "LOCAL",

--- a/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nullEnvoy.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nullEnvoy.json
@@ -1,6 +1,8 @@
 {
   "monitorId": "00000000-0000-0000-0001-000000000000",
   "monitorType": "cpu",
+  "monitorName": "name-1",
+  "monitorSummary": {},
   "tenantId": "t-1",
   "resourceId": "r-1",
   "selectorScope": "LOCAL",


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-890

# What

For the resource details page, Intelligence is needing the monitor name to be part of the GET bound-monitors response. Talking more we remembered that since monitor name is optional then the "summary" field is also needed.

# How

Added fields to DTO. Bringing over the monitor name was easy. Incorporating the summary required jumping through a couple small hoops via a new method in the MonitorConversionService.

Bump in version for salus-telemetry-protocol was totally unrelated, but I had forgotten to push that earlier when that module was updated.

## How to test

Updated unit tests