### PR TITLE
Added swagger-codegen-maven-plugin to try out its static html generator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,24 @@
       </plugin>
 
       <plugin>
+        <groupId>io.swagger</groupId>
+        <artifactId>swagger-codegen-maven-plugin</artifactId>
+        <version>2.4.13</version>
+        <executions>
+          <execution>
+            <id>generate-html</id>
+            <goals><goal>generate</goal></goals>
+            <configuration>
+              <inputSpec>${project.build.directory}/generated/swagger/swagger.json</inputSpec>
+              <language>html</language>
+              <output>${project.build.directory}/generated/swagger/</output>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.2.1</version>


### PR DESCRIPTION
Trying out this maven plugin

https://github.com/swagger-api/swagger-codegen/tree/master/modules/swagger-codegen-maven-plugin

as a companion to our current swagger plugin, which still remains necessary for Spring MVC -> swagger.json. In fact the ordering of the plugins is important because this additional plugin takes the `swagger.json` produced by the first one, both during the `generate` phase.

With the language "html" it produces good old fashioned HTML without any of that "xmp" stuff:

https://gist.github.com/itzg/f0dfcf27ba56f67ebd6cce121a14ea97