### PR TITLE
Bind monitor to resource even if no envoy associated

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -501,23 +501,17 @@ public class MonitorManagement {
       // AGENT MONITOR
 
       for (ResourceDTO resource : resources) {
-
-        // agent monitors can only bind to resources that have (or had) an envoy
-        if (resource.isAssociatedWithEnvoy()) {
-
-          try {
-            boundMonitors.add(
-                bindAgentMonitor(monitor, resource,
-                    resource.getEnvoyId() != null ? resource.getEnvoyId() : null)
-            );
-          } catch (InvalidTemplateException e) {
-            log.warn("Unable to render monitor={} onto resource={}",
-                monitor, resource, e);
-            invalidTemplateErrors.increment();
-          }
+        try {
+          boundMonitors.add(
+              bindAgentMonitor(monitor, resource,
+                  resource.getEnvoyId() != null ? resource.getEnvoyId() : null)
+          );
+        } catch (InvalidTemplateException e) {
+          log.warn("Unable to render monitor={} onto resource={}",
+              monitor, resource, e);
+          invalidTemplateErrors.increment();
         }
       }
-
     } else {
       // REMOTE MONITOR
 
@@ -604,7 +598,7 @@ public class MonitorManagement {
         .forEach(monitorEventProducer::sendMonitorEvent);
   }
 
-  private BoundMonitor bindAgentMonitor(Monitor monitor, ResourceDTO resource, String envoyId)
+  protected BoundMonitor bindAgentMonitor(Monitor monitor, ResourceDTO resource, String envoyId)
       throws InvalidTemplateException {
     return new BoundMonitor()
         .setMonitor(monitor)

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -598,7 +598,7 @@ public class MonitorManagement {
         .forEach(monitorEventProducer::sendMonitorEvent);
   }
 
-  protected BoundMonitor bindAgentMonitor(Monitor monitor, ResourceDTO resource, String envoyId)
+  BoundMonitor bindAgentMonitor(Monitor monitor, ResourceDTO resource, String envoyId)
       throws InvalidTemplateException {
     return new BoundMonitor()
         .setMonitor(monitor)

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1666,19 +1666,15 @@ public class MonitorManagement {
 
         if (monitor.getSelectorScope() == ConfigSelectorScope.LOCAL) {
           // agent/local monitor
-
-          // but skip the resource if it doesn't have (or ever had) an envoy
-          if (resource.isAssociatedWithEnvoy()) {
-            try {
-              boundMonitors.add(
-                  bindAgentMonitor(monitor, resource,
-                      resourceInfo != null ? resourceInfo.getEnvoyId() : null)
-              );
-            } catch (InvalidTemplateException e) {
-              log.warn("Unable to render monitor={} onto resource={}",
-                  monitor, resource, e);
-              invalidTemplateErrors.increment();
-            }
+          try {
+            boundMonitors.add(
+                bindAgentMonitor(monitor, resource,
+                    resourceInfo != null ? resourceInfo.getEnvoyId() : null)
+            );
+          } catch (InvalidTemplateException e) {
+            log.warn("Unable to render monitor={} onto resource={}",
+                monitor, resource, e);
+            invalidTemplateErrors.increment();
           }
         } else {
           // remote monitor

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -2956,9 +2956,16 @@ public class MonitorManagementTest {
     assertThat(result, hasSize(0));
 
     verify(resourceApi).getResourcesWithLabels("t-1", monitor.getLabelSelector(), monitor.getLabelSelectorMethod());
-    BoundMonitor boundMonitor = monitorManagement.bindAgentMonitor(monitor, resource, null);
-    verify(boundMonitorRepository).saveAll(Collections.singletonList(boundMonitor));
 
+    verify(boundMonitorRepository).saveAll(captorOfBoundMonitorList.capture());
+    assertThat(captorOfBoundMonitorList.getValue(), hasSize(1));
+    assertThat(captorOfBoundMonitorList.getValue().get(0), equalTo(new BoundMonitor()
+      .setResourceId("r-1")
+      .setMonitor(monitor)
+      .setRenderedContent("static content")
+      .setEnvoyId(null)
+      .setZoneName("")
+    ));
     verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement, resourceApi);
   }
 
@@ -3324,6 +3331,18 @@ public class MonitorManagementTest {
     verify(envoyResourceManagement).getOne("t-1", "r-1");
 
     verify(boundMonitorRepository).findAllByMonitor_IdAndResourceId(m0, "r-1");
+
+    verify(boundMonitorRepository).saveAll(captorOfBoundMonitorList.capture());
+    assertThat(captorOfBoundMonitorList.getValue(), hasSize(1));
+    assertThat(captorOfBoundMonitorList.getValue().get(0), equalTo(new BoundMonitor()
+          .setResourceId("r-1")
+          .setTenantId("t-1")
+          .setMonitor(monitors.get(0))
+          .setRenderedContent("new local domain=prod")
+          .setEnvoyId(null)
+          .setZoneName("")
+    ));
+
 
     verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement,
         zoneStorage


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-887

# What

We want to make sure that local monitors still get bound to the resources even if there is no envoy yet.

# How

It removes the if statement checking to see if the resources is associated with an envoy. 

## How to test

The unit tests were updated. 

