### PR TITLE
Add endpoint to view all monitor translations

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
@@ -130,10 +130,10 @@ public class MonitorContentTranslationService {
                             Collectors.mapping(op -> op.getTranslatorSpec().info(), Collectors.toList())),
 
                         // then generate a MonitorTranslationDetails for each monitor type
-                        typeMap -> typeMap.entrySet().stream().map(
-                            typeEntry -> new MonitorTranslationDetails()
-                                .setMonitorType(typeEntry.getKey())
-                                .setTranslations(typeEntry.getValue())))),
+                        monitorMap -> monitorMap.entrySet().stream().map(
+                            monitorEntry -> new MonitorTranslationDetails()
+                                .setMonitorType(monitorEntry.getKey())
+                                .setTranslations(monitorEntry.getValue())))),
 
                 // then assign the agent type to each MonitorTranslationDetails
                 agentMap -> agentMap.entrySet().stream()

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
@@ -141,8 +141,8 @@ public class MonitorContentTranslationService {
                         .map(detail -> detail.setAgentType(agentEntry.getKey())))))
 
         // then sort it by agent type and then monitor type
-        .sorted(Comparator.comparing(MonitorTranslationDetails::getAgentType).reversed()
-            .thenComparing(MonitorTranslationDetails::getMonitorType).reversed())
+        .sorted(Comparator.comparing(MonitorTranslationDetails::getAgentType, Comparator.comparing(Enum::toString))
+            .thenComparing(v -> v.getMonitorType().toString()))
         // then build the final list.
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorTranslationApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorTranslationApiController.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.web.controller;
 
 import com.rackspace.salus.monitor_management.services.MonitorContentTranslationService;
+import com.rackspace.salus.monitor_management.web.model.MonitorTranslationDetails;
 import com.rackspace.salus.monitor_management.web.model.MonitorTranslationOperatorCreate;
 import com.rackspace.salus.monitor_management.web.model.MonitorTranslationOperatorDTO;
 import com.rackspace.salus.telemetry.model.PagedContent;
@@ -26,6 +27,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
+import java.util.List;
 import java.util.UUID;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +60,12 @@ public class MonitorTranslationApiController {
   public MonitorTranslationApiController(
       MonitorContentTranslationService monitorContentTranslationService) {
     this.monitorContentTranslationService = monitorContentTranslationService;
+  }
+
+  @GetMapping("/tenant/{tenantId}/monitor-translations")
+  @ApiOperation("Gets all monitor translation details")
+  public List<MonitorTranslationDetails> getMonitorTranslationDetails() {
+    return monitorContentTranslationService.getMonitorTranslationDetails();
   }
 
   @GetMapping("/admin/monitor-translations")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationDetails.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationDetails.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model;
+
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class MonitorTranslationDetails {
+  AgentType agentType;
+  MonitorType monitorType;
+  List<String> translations;
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorCreate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorCreate.java
@@ -46,7 +46,7 @@ public class MonitorTranslationOperatorCreate {
   String agentVersions;
 
   /**
-   * Optional field, when set, indicates that the translation should only apply to monitors of this type.
+   * Indicates that the translation should only apply to monitors of this type.
    */
   @NotNull
   MonitorType monitorType;


### PR DESCRIPTION
# Related PR
https://github.com/racker/salus-telemetry-model/pull/133

# What

Adds a new API endpoint to list all the translations in place for each monitor type.

# How

Don't hate me.  It's all using streams.  I group the list of translators by agentType then monitorType and consolidate all the `info()` details into a list for that type.

The end result is a list of `MonitorTranslationDetails`.

## How to test

Added a test and manual.  This is what gets shown in dev:

```
[
  {
    "agentType": "TELEGRAF",
    "monitorType": "apache",
    "translations": [
      "'url' becomes the singleton array named 'urls'",
      "'timeout' becomes a Golang formatted duration",
      "The key 'timeout' is renamed to 'responseTimeout'"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "disk",
    "translations": [
      "'mount' becomes the singleton array named 'mountPoints'"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "diskio",
    "translations": [
      "'device' becomes the singleton array named 'devices'"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "dns",
    "translations": [
      "'timeout' becomes a number of seconds",
      "The monitor's type is renamed to 'dns_query'",
      "'dnsServer' becomes the singleton array named 'servers'",
      "'domain' becomes the singleton array named 'domains'"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "http",
    "translations": [
      "The monitor's type is renamed to 'http_response'",
      "'url' becomes the singleton array named 'urls'",
      "'timeout' becomes a Golang formatted duration",
      "The key 'timeout' is renamed to 'responseTimeout'"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "mysql",
    "translations": [
      "'intervalSlow' becomes a Golang formatted duration",
      "The value of 'metric_version' is set to 2"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "net",
    "translations": [
      "'interface' becomes the singleton array named 'interfaces'"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "net_response",
    "translations": [
      "The value of 'host' and 'port' are combined into 'host:port' and named 'address'",
      "'readTimeout' becomes a Golang formatted duration",
      "'timeout' becomes a Golang formatted duration"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "ping",
    "translations": [
      "'timeout' becomes a number of seconds",
      "'pingInterval' becomes a number of seconds",
      "'target' becomes the singleton array named 'urls'",
      "'deadline' becomes a number of seconds"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "postgresql",
    "translations": [
      "'maxLifetime' becomes a Golang formatted duration"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "redis",
    "translations": [
      "'url' becomes the singleton array named 'servers'"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "smtp",
    "translations": [
      "The value of 'host' and 'port' are combined into 'host:port' and named 'address'"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "sqlserver",
    "translations": [
      "The value of 'query_version' is set to 2",
      "The key 'queryExclusions' is renamed to 'exclude_queries'"
    ]
  },
  {
    "agentType": "TELEGRAF",
    "monitorType": "ssl",
    "translations": [
      "The monitor's type is renamed to 'x509_cert'",
      "'timeout' becomes a Golang formatted duration",
      "'target' becomes the singleton array named 'sources'"
    ]
  }
]
```

# Why

To help with the documentation of Monitors.  We link to telegraf plugins but due to the translations we do they do not map 1:1.  This endpoint can be referenced in the documentation as the place to see how things differ.

# TODO

1. Add endpoint to public api service.
1. Modifications may be needed but I wasn't sure if it was worth digging into that yet.
    * Agent Version and Selector Scope fields may be needed as we grow the list of translators
    * I wasn't sure the best way to display all that.
       * Maybe the endpoint would require the agent version to be provided and only the relevant  translations would be shown.
    * Currently we don't set selectorScope for any translation and if it stays that way it helps keep things simpler.
