### PR TITLE
Handle tenant events in a transaction

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/PolicyEventListener.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/PolicyEventListener.java
@@ -77,6 +77,7 @@ public class PolicyEventListener {
   }
 
   @KafkaHandler
+  @Transactional
   public void consumeTenantChangeEvents(TenantPolicyChangeEvent tenantEvent) {
     monitorManagement.handleTenantChangeEvent(tenantEvent);
   }


### PR DESCRIPTION
This is needed so `cloneMonitor` can run these functions successfully:

```
    Hibernate.initialize(monitor.getMonitorMetadataFields());
    Hibernate.initialize(monitor.getPluginMetadataFields());
```

This is the same as what `consumeMonitorPolicyEvents` does.