### PR TITLE
added getTestMonitor functionality

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package com.rackspace.salus.monitor_management.web.client;
 
-import com.rackspace.salus.monitor_management.web.model.*;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
+import com.rackspace.salus.monitor_management.web.model.TestMonitorInput;
+import com.rackspace.salus.monitor_management.web.model.TestMonitorOutput;
 import com.rackspace.salus.telemetry.model.AgentType;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
@@ -31,5 +31,5 @@ public interface MonitorApi {
 
   DetailedMonitorOutput createMonitor(String tenantId, DetailedMonitorInput input, MultiValueMap<String, String> headers);
 
-  TestMonitorOutput getTestMonitor(String tenantId, TestMonitorInput input);
+  TestMonitorOutput performTestMonitor(String tenantId, TestMonitorInput input, MultiValueMap<String, String> headers);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
@@ -16,9 +16,7 @@
 
 package com.rackspace.salus.monitor_management.web.client;
 
-import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
-import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
-import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
+import com.rackspace.salus.monitor_management.web.model.*;
 import com.rackspace.salus.telemetry.model.AgentType;
 import java.util.List;
 import java.util.Map;
@@ -32,4 +30,6 @@ public interface MonitorApi {
   DetailedMonitorOutput getPolicyMonitorById(String monitorId);
 
   DetailedMonitorOutput createMonitor(String tenantId, DetailedMonitorInput input, MultiValueMap<String, String> headers);
+
+  TestMonitorOutput getTestMonitor(String tenantId, TestMonitorInput input);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
@@ -31,5 +31,5 @@ public interface MonitorApi {
 
   DetailedMonitorOutput createMonitor(String tenantId, DetailedMonitorInput input, MultiValueMap<String, String> headers);
 
-  TestMonitorOutput performTestMonitor(String tenantId, TestMonitorInput input, MultiValueMap<String, String> headers);
+  TestMonitorOutput performTestMonitor(String tenantId, TestMonitorInput input);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,28 @@
 
 package com.rackspace.salus.monitor_management.web.client;
 
-import com.rackspace.salus.monitor_management.web.model.*;
+import static com.rackspace.salus.common.web.RemoteOperations.mapRestClientExceptions;
+
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
+import com.rackspace.salus.monitor_management.web.model.BoundMonitorsRequest;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
+import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
+import com.rackspace.salus.monitor_management.web.model.TestMonitorInput;
+import com.rackspace.salus.monitor_management.web.model.TestMonitorOutput;
 import com.rackspace.salus.telemetry.model.AgentType;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-
-import static com.rackspace.salus.common.web.RemoteOperations.mapRestClientExceptions;
 
 /**
  * This client component provides a small subset of Monitor Management REST operations that

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -18,10 +18,7 @@ package com.rackspace.salus.monitor_management.web.client;
 
 import static com.rackspace.salus.common.web.RemoteOperations.mapRestClientExceptions;
 
-import com.rackspace.salus.monitor_management.web.model.BoundMonitorDTO;
-import com.rackspace.salus.monitor_management.web.model.BoundMonitorsRequest;
-import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
-import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
+import com.rackspace.salus.monitor_management.web.model.*;
 import com.rackspace.salus.telemetry.model.AgentType;
 import java.util.List;
 import java.util.Map;
@@ -139,5 +136,24 @@ public class MonitorApiClient implements MonitorApi {
             new HttpEntity<>(input, reqHeaders),
             DetailedMonitorOutput.class
         ).getBody());
+  }
+
+  @Override
+  public TestMonitorOutput getTestMonitor(String tenantId, TestMonitorInput input) {
+    String uriString = UriComponentsBuilder
+            .fromUriString("/api/tenant/{tenantId}/test-monitor")
+            .buildAndExpand(tenantId)
+            .toUriString();
+
+    HttpHeaders reqHeaders = new HttpHeaders();
+    reqHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+    return mapRestClientExceptions(
+            SERVICE_NAME,
+            () -> restTemplate.postForEntity(
+                    uriString,
+                    new HttpEntity<>(input, reqHeaders),
+                    TestMonitorOutput.class
+            ).getBody());
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -16,23 +16,20 @@
 
 package com.rackspace.salus.monitor_management.web.client;
 
-import static com.rackspace.salus.common.web.RemoteOperations.mapRestClientExceptions;
-
 import com.rackspace.salus.monitor_management.web.model.*;
 import com.rackspace.salus.telemetry.model.AgentType;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
+import org.springframework.http.*;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.rackspace.salus.common.web.RemoteOperations.mapRestClientExceptions;
 
 /**
  * This client component provides a small subset of Monitor Management REST operations that
@@ -139,7 +136,7 @@ public class MonitorApiClient implements MonitorApi {
   }
 
   @Override
-  public TestMonitorOutput getTestMonitor(String tenantId, TestMonitorInput input) {
+  public TestMonitorOutput performTestMonitor(String tenantId, TestMonitorInput input, MultiValueMap<String, String> headers) {
     String uriString = UriComponentsBuilder
             .fromUriString("/api/tenant/{tenantId}/test-monitor")
             .buildAndExpand(tenantId)
@@ -147,6 +144,9 @@ public class MonitorApiClient implements MonitorApi {
 
     HttpHeaders reqHeaders = new HttpHeaders();
     reqHeaders.setContentType(MediaType.APPLICATION_JSON);
+    if (headers != null) {
+      reqHeaders.addAll(headers);
+    }
 
     return mapRestClientExceptions(
             SERVICE_NAME,

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -136,23 +136,17 @@ public class MonitorApiClient implements MonitorApi {
   }
 
   @Override
-  public TestMonitorOutput performTestMonitor(String tenantId, TestMonitorInput input, MultiValueMap<String, String> headers) {
+  public TestMonitorOutput performTestMonitor(String tenantId, TestMonitorInput input) {
     String uriString = UriComponentsBuilder
             .fromUriString("/api/tenant/{tenantId}/test-monitor")
             .buildAndExpand(tenantId)
             .toUriString();
 
-    HttpHeaders reqHeaders = new HttpHeaders();
-    reqHeaders.setContentType(MediaType.APPLICATION_JSON);
-    if (headers != null) {
-      reqHeaders.addAll(headers);
-    }
-
     return mapRestClientExceptions(
             SERVICE_NAME,
             () -> restTemplate.postForEntity(
                     uriString,
-                    new HttpEntity<>(input, reqHeaders),
+                    new HttpEntity<>(input),
                     TestMonitorOutput.class
             ).getBody());
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClientTest.java
@@ -141,19 +141,22 @@ public class MonitorApiClientTest {
 
   @Test
   public void testPerformTestMonitor() throws IOException {
-    String expectedReqJson = readContent("MonitorApiClientTest/testPerformTestMonitor_req.json");
-    TestMonitorInput testMonitorInput = objectMapper.readValue(expectedReqJson, TestMonitorInput.class);
+    TestMonitorInput testMonitorInput = objectMapper
+        .readValue(readContent("MonitorApiClientTest/testPerformTestMonitor_req.json"),
+            TestMonitorInput.class);
 
     String tenantId = RandomStringUtils.randomAlphabetic(8);
     TestMonitorOutput testMonitorOutput = podamFactory.manufacturePojo(TestMonitorOutput.class);
 
-    mockServer.expect(requestToUriTemplate("/api/tenant/{tenantId}/test-monitor",tenantId))
+    mockServer.expect(requestToUriTemplate("/api/tenant/{tenantId}/test-monitor", tenantId))
         .andExpect(method(HttpMethod.POST))
         .andExpect(content().json(objectMapper.writeValueAsString(testMonitorInput)))
         .andRespond(
-            withSuccess(objectMapper.writeValueAsString(testMonitorOutput), MediaType.APPLICATION_JSON));
+            withSuccess(objectMapper.writeValueAsString(testMonitorOutput),
+                MediaType.APPLICATION_JSON));
 
-    TestMonitorOutput testMonitorOutputActual = monitorApiClient.performTestMonitor(tenantId, testMonitorInput);
+    TestMonitorOutput testMonitorOutputActual = monitorApiClient
+        .performTestMonitor(tenantId, testMonitorInput);
     assertThat(testMonitorOutput, equalTo(testMonitorOutputActual));
   }
 }

--- a/src/test/resources/MonitorApiClientTest/testPerformTestMonitor_req.json
+++ b/src/test/resources/MonitorApiClientTest/testPerformTestMonitor_req.json
@@ -1,41 +1,9 @@
 {
-  "testMonitorInput":{
-    "resourceId":"{% prompt 'Resource ID', '', 'development:0', '', false, true %}",
-    "details":{
-      "type":"local",
-      "plugin":{
-        "type":"cpu"
-      }
+  "resourceId": "{% prompt 'Resource ID', '', 'development:0', '', false, true %}",
+  "details": {
+    "type": "local",
+    "plugin": {
+      "type": "cpu"
     }
-  },
-  "testTaskRequest":{
-    "task":{
-      "measurement":"mem",
-      "taskParameters":{
-        "criticalStateDuration":2,
-        "warningStateDuration":2,
-        "infoStateDuration":2,
-        "stateExpressions":[
-          {
-            "state":"INFO",
-            "message":"info threshold was hit",
-            "expression":{
-              "type":"comparison",
-              "comparator":"<",
-              "metricName":"free",
-              "comparisonValue":3000
-            }
-          }
-        ]
-      }
-    },
-    "metrics":[
-      {
-        "name":"mem",
-        "ivalues":{
-          "free":2000
-        }
-      }
-    ]
   }
 }

--- a/src/test/resources/MonitorApiClientTest/testPerformTestMonitor_req.json
+++ b/src/test/resources/MonitorApiClientTest/testPerformTestMonitor_req.json
@@ -1,5 +1,5 @@
 {
-  "resourceId": "{% prompt 'Resource ID', '', 'development:0', '', false, true %}",
+  "resourceId": "development",
   "details": {
     "type": "local",
     "plugin": {

--- a/src/test/resources/MonitorApiClientTest/testPerformTestMonitor_req.json
+++ b/src/test/resources/MonitorApiClientTest/testPerformTestMonitor_req.json
@@ -1,0 +1,41 @@
+{
+  "testMonitorInput":{
+    "resourceId":"{% prompt 'Resource ID', '', 'development:0', '', false, true %}",
+    "details":{
+      "type":"local",
+      "plugin":{
+        "type":"cpu"
+      }
+    }
+  },
+  "testTaskRequest":{
+    "task":{
+      "measurement":"mem",
+      "taskParameters":{
+        "criticalStateDuration":2,
+        "warningStateDuration":2,
+        "infoStateDuration":2,
+        "stateExpressions":[
+          {
+            "state":"INFO",
+            "message":"info threshold was hit",
+            "expression":{
+              "type":"comparison",
+              "comparator":"<",
+              "metricName":"free",
+              "comparisonValue":3000
+            }
+          }
+        ]
+      }
+    },
+    "metrics":[
+      {
+        "name":"mem",
+        "ivalues":{
+          "free":2000
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Resolves

[SALUS-569](https://jira.rax.io/browse/SALUS-569)

# What

Added getTestMonitor() functionality to MonitorApi to chain test-monitor and test-task operations via single API


