### PR TITLE
Changed removePolicyMonitor to delete without retrieval

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -12,7 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.rackspace.salus.monitor_management.services;
@@ -1379,13 +1378,14 @@ public class MonitorManagement {
    * @throws DeletionNotAllowedException If the monitor is used by an active policy.
    */
   public void removePolicyMonitor(UUID id) {
-    Monitor monitor = getMonitor(POLICY_TENANT, id).orElseThrow(() ->
-        new NotFoundException(String.format("No policy monitor found for %s", id)));
+    if (!monitorRepository.existsByIdAndTenantId(id, POLICY_TENANT)) {
+      throw new NotFoundException(String.format("No policy monitor found for %s", id));
+    }
 
     if (monitorPolicyRepository.existsByMonitorId(id)) {
       throw new DeletionNotAllowedException("Cannot remove monitor that is in use by a policy");
     }
-    monitorRepository.delete(monitor);
+    monitorRepository.deleteById(id);
   }
 
   void handleMonitorPolicyEvent(MonitorPolicyEvent event) {


### PR DESCRIPTION
# What

When trying to delete a policy-monitor with an invalid `monitor_type` the delete API call fails with:

```json
{
  "timestamp": "2020-08-12T16:36:40.634+0000",
  "status": 400,
  "error": "Bad Request",
  "message": "No enum constant com.rackspace.salus.telemetry.model.MonitorType.http_response; nested exception is java.lang.IllegalArgumentException: No enum constant com.rackspace.salus.telemetry.model.MonitorType.http_response",
  "app": "salus-telemetry-monitor-management",
  "host": "monitor-management-85fb576699-zrpvn",
  "traceId": "9d3ecc26293194de"
}
```

# How

Check for existence of the policy-monitor rather than fully retrieving it and then delete by ID. That way old, invalid policy-monitors can be safely deleted.

## How to test

Ran all existing unit tests
