### PR TITLE
added code to delete a resource and its associated bound-monitor.

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1681,7 +1681,8 @@ public class MonitorManagement {
       return;
     }
 
-    final List<Monitor> monitorsWithResourceId = monitorRepository.findByTenantIdAndResourceId(tenantId, resourceId);
+    final List<Monitor> monitorsWithResourceId = monitorRepository
+        .findByTenantIdAndResourceId(tenantId, resourceId);
 
     final List<UUID> boundMonitorIds =
         boundMonitorRepository.findMonitorIdsBoundToTenantAndResource(tenantId, resourceId);
@@ -1691,7 +1692,8 @@ public class MonitorManagement {
     final Set<UUID> monitorIdsToUnbind = new HashSet<>(boundMonitorIds);
 
     List<Monitor> selectedMonitors;
-    final Optional<Resource> resource = resourceRepository.findByTenantIdAndResourceId(tenantId, resourceId);
+    final Optional<Resource> resource = resourceRepository
+        .findByTenantIdAndResourceId(tenantId, resourceId);
     if (resource.isPresent()) {
       // resource created or updated
 
@@ -1718,16 +1720,20 @@ public class MonitorManagement {
 
       // ...the setminus operation upon monitorIdsToUnbind
       monitorIdsToUnbind.removeAll(selectedMonitorIds);
-    }
-    else {
+    } else {
       // resource deleted
 
       selectedMonitors = Collections.emptyList();
       // ...and monitorIdsToUnbind remains ALL of the currently bound
     }
 
+    Set<String> affectedEnvoys = null;
     // this needs to be updated to only unbind my tenant and resourceId
-    final Set<String> affectedEnvoys = unbindByTenantAndResourceId(tenantId, event.getResourceId(), monitorIdsToUnbind);
+    if (monitorIdsToUnbind.isEmpty()) {
+      affectedEnvoys = new HashSet<>();
+    } else  {
+      affectedEnvoys = unbindByTenantAndResourceId(tenantId, event.getResourceId());
+    }
 
     if (!selectedMonitors.isEmpty()) {
       affectedEnvoys.addAll(
@@ -1912,13 +1918,9 @@ public class MonitorManagement {
    * @return affected envoy IDs
    */
   Set<String> unbindByTenantAndResourceId(String tenantId,
-      String resourceId, Collection<UUID> monitorIdsToUnbind) {
-    if (monitorIdsToUnbind.isEmpty()) {
-      return new HashSet<>();
-    }
-
+      String resourceId) {
     final List<BoundMonitor> boundMonitors = boundMonitorRepository
-        .findMonitorsBoundToResourceAndTenant(tenantId, resourceId);
+        .findMonitorsBoundToTenantAndResource(tenantId, resourceId);
 
     log.debug("Unbinding {} from resourceId={}",
         boundMonitors, resourceId);

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1684,7 +1684,7 @@ public class MonitorManagement {
     final List<Monitor> monitorsWithResourceId = monitorRepository.findByTenantIdAndResourceId(tenantId, resourceId);
 
     final List<UUID> boundMonitorIds =
-        boundMonitorRepository.findMonitorsBoundToResource(tenantId, resourceId);
+        boundMonitorRepository.findMonitorIdsBoundToTenantAndResource(tenantId, resourceId);
 
     // monitorIdsToUnbind := boundMonitorIds \setminus selectedMonitorIds
     // ...so start with populating with boundMonitorIds
@@ -1727,7 +1727,7 @@ public class MonitorManagement {
     }
 
     // this needs to be updated to only unbind my tenant and resourceId
-    final Set<String> affectedEnvoys = unbindByTenantAndResourceId(tenantId, event.getResourceId());
+    final Set<String> affectedEnvoys = unbindByTenantAndResourceId(tenantId, event.getResourceId(), monitorIdsToUnbind);
 
     if (!selectedMonitors.isEmpty()) {
       affectedEnvoys.addAll(
@@ -1912,7 +1912,11 @@ public class MonitorManagement {
    * @return affected envoy IDs
    */
   Set<String> unbindByTenantAndResourceId(String tenantId,
-      String resourceId) {
+      String resourceId, Collection<UUID> monitorIdsToUnbind) {
+    if (monitorIdsToUnbind.isEmpty()) {
+      return new HashSet<>();
+    }
+
     final List<BoundMonitor> boundMonitors = boundMonitorRepository
         .findMonitorsBoundToResourceAndTenant(tenantId, resourceId);
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1726,8 +1726,8 @@ public class MonitorManagement {
       // ...and monitorIdsToUnbind remains ALL of the currently bound
     }
 
-    // this needs to be updated to only unbind my tenant and monitor id
-    final Set<String> affectedEnvoys = unbindByTenantAndMonitorId(tenantId, monitorIdsToUnbind);
+    // this needs to be updated to only unbind my tenant and resourceId
+    final Set<String> affectedEnvoys = unbindByTenantAndResourceId(tenantId, event.getResourceId());
 
     if (!selectedMonitors.isEmpty()) {
       affectedEnvoys.addAll(
@@ -1900,6 +1900,24 @@ public class MonitorManagement {
 
     log.debug("Unbinding {} from monitorIds={}",
         boundMonitors, monitorIdsToUnbind);
+    boundMonitorRepository.deleteAll(boundMonitors);
+    decrementBoundCounts(boundMonitors);
+
+    return extractEnvoyIds(boundMonitors);
+  }
+
+  /**
+   * Removes all bindings associated with the given monitor IDs and resource id.
+   *
+   * @return affected envoy IDs
+   */
+  Set<String> unbindByTenantAndResourceId(String tenantId,
+      String resourceId) {
+    final List<BoundMonitor> boundMonitors = boundMonitorRepository
+        .findMonitorsBoundToResourceAndTenant(tenantId, resourceId);
+
+    log.debug("Unbinding {} from resourceId={}",
+        boundMonitors, resourceId);
     boundMonitorRepository.deleteAll(boundMonitors);
     decrementBoundCounts(boundMonitors);
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1727,13 +1727,8 @@ public class MonitorManagement {
       // ...and monitorIdsToUnbind remains ALL of the currently bound
     }
 
-    Set<String> affectedEnvoys = null;
     // this needs to be updated to only unbind my tenant and resourceId
-    if (monitorIdsToUnbind.isEmpty()) {
-      affectedEnvoys = new HashSet<>();
-    } else  {
-      affectedEnvoys = unbindByTenantAndResourceId(tenantId, event.getResourceId());
-    }
+    Set<String> affectedEnvoys = unbindByTenantAndResourceIdAndMonitorIds(tenantId, event.getResourceId(), monitorIdsToUnbind);
 
     if (!selectedMonitors.isEmpty()) {
       affectedEnvoys.addAll(
@@ -1917,13 +1912,16 @@ public class MonitorManagement {
    *
    * @return affected envoy IDs
    */
-  Set<String> unbindByTenantAndResourceId(String tenantId,
-      String resourceId) {
+  Set<String> unbindByTenantAndResourceIdAndMonitorIds(String tenantId,
+      String resourceId, Set<UUID> monitorIdsToUnbind) {
+    if (monitorIdsToUnbind.isEmpty()) {
+      return new HashSet<>();
+    }
     final List<BoundMonitor> boundMonitors = boundMonitorRepository
-        .findMonitorsBoundToTenantAndResource(tenantId, resourceId);
+        .findMonitorsBoundToTenantAndResourceAndMonitor_IdIn(tenantId, resourceId, monitorIdsToUnbind);
 
-    log.debug("Unbinding {} from resourceId={}",
-        boundMonitors, resourceId);
+    log.debug("Unbinding {} from resourceId={} and monitorIdsToUnbind={}",
+        boundMonitors, resourceId, monitorIdsToUnbind);
     boundMonitorRepository.deleteAll(boundMonitors);
     decrementBoundCounts(boundMonitors);
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -3904,7 +3904,7 @@ public class MonitorManagementTest {
     when(boundMonitorRepository.findAllByMonitor_IdAndResourceId(any(), any()))
         .thenReturn(Collections.singletonList(boundMonitor));
 
-    when(boundMonitorRepository.findMonitorsBoundToTenantAndResource(anyString(),anyString()))
+    when(boundMonitorRepository.findMonitorsBoundToTenantAndResourceAndMonitor_IdIn(anyString(),anyString(), any()))
         .thenReturn(Collections.singletonList(boundMonitor));
 
     // EXERCISE
@@ -3928,8 +3928,11 @@ public class MonitorManagementTest {
         Collections.singletonList(boundMonitor)
     );
 
+    verify(boundMonitorRepository).findMonitorsBoundToTenantAndResourceAndMonitor_IdIn(
+        "t-1","r-1",Collections.singleton(monitor.getId()));
+
     verifyNoInteractions(policyApi);
-    verifyNoMoreInteractions(envoyResourceManagement,
+    verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement,
         zoneStorage, monitorEventProducer, resourceApi, resourceRepository);
   }
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -3406,7 +3406,7 @@ public class MonitorManagementTest {
 
     verify(envoyResourceManagement).getOne("t-1", "r-1");
 
-    verify(boundMonitorRepository).findMonitorsBoundToResource("t-1", "r-1");
+    verify(boundMonitorRepository).findMonitorIdsBoundToTenantAndResource("t-1", "r-1");
 
     verify(boundMonitorRepository).saveAll(captorOfBoundMonitorList.capture());
     final List<BoundMonitor> savedBoundMonitors = captorOfBoundMonitorList.getValue();
@@ -3461,7 +3461,7 @@ public class MonitorManagementTest {
 
     verify(envoyResourceManagement).getOne("t-1", "r-1");
 
-    verify(boundMonitorRepository).findMonitorsBoundToResource("t-1", "r-1");
+    verify(boundMonitorRepository).findMonitorIdsBoundToTenantAndResource("t-1", "r-1");
 
     verify(boundMonitorRepository).saveAll(captorOfBoundMonitorList.capture());
     final List<BoundMonitor> savedBoundMonitors = captorOfBoundMonitorList.getValue();
@@ -3539,13 +3539,13 @@ public class MonitorManagementTest {
           .setRenderedContent(boundContent)
           .setEnvoyId("e-1");
 
-      when(boundMonitorRepository.findMonitorsBoundToResource(any(), any()))
+      when(boundMonitorRepository.findMonitorIdsBoundToTenantAndResource(any(), any()))
           .thenReturn(Collections.singletonList(monitor.getId()));
 
       when(boundMonitorRepository.findAllByMonitor_IdAndResourceId(any(), any()))
           .thenReturn(Collections.singletonList(boundMonitor));
     } else {
-      when(boundMonitorRepository.findMonitorsBoundToResource(any(), any()))
+      when(boundMonitorRepository.findMonitorIdsBoundToTenantAndResource(any(), any()))
           .thenReturn(Collections.emptyList());
 
       when(boundMonitorRepository.findAllByMonitor_IdAndResourceId(any(), any()))
@@ -3577,7 +3577,7 @@ public class MonitorManagementTest {
 
     verify(envoyResourceManagement).getOne("t-1", "r-1");
 
-    verify(boundMonitorRepository).findMonitorsBoundToResource("t-1", "r-1");
+    verify(boundMonitorRepository).findMonitorIdsBoundToTenantAndResource("t-1", "r-1");
 
     verify(boundMonitorRepository).saveAll(captorOfBoundMonitorList.capture());
     final List<BoundMonitor> savedBoundMonitors = captorOfBoundMonitorList.getValue();
@@ -3708,7 +3708,7 @@ public class MonitorManagementTest {
         .setRenderedContent("custom=old")
         .setEnvoyId("e-old");
 
-    when(boundMonitorRepository.findMonitorsBoundToResource("t-1", "r-1"))
+    when(boundMonitorRepository.findMonitorIdsBoundToTenantAndResource("t-1", "r-1"))
         .thenReturn(Collections.singletonList(monitor.getId()));
 
     when(boundMonitorRepository.findAllByMonitor_IdAndResourceId(any(), any()))
@@ -3730,7 +3730,7 @@ public class MonitorManagementTest {
 
     verify(envoyResourceManagement).getOne("t-1", "r-1");
 
-    verify(boundMonitorRepository).findMonitorsBoundToResource("t-1", "r-1");
+    verify(boundMonitorRepository).findMonitorIdsBoundToTenantAndResource("t-1", "r-1");
 
     verify(boundMonitorRepository).saveAll(captorOfBoundMonitorList.capture());
     final List<BoundMonitor> savedBoundMonitors = captorOfBoundMonitorList.getValue();
@@ -3785,7 +3785,7 @@ public class MonitorManagementTest {
     // VERIFY
     verify(resourceRepository).findByTenantIdAndResourceId("t-1", "r-1");
     verify(envoyResourceManagement).getOne("t-1", "r-1");
-    verify(boundMonitorRepository).findMonitorsBoundToResource("t-1", "r-1");
+    verify(boundMonitorRepository).findMonitorIdsBoundToTenantAndResource("t-1", "r-1");
     verify(boundMonitorRepository).findAllByMonitor_IdAndResourceId(monitor.getId(), "r-1");
 
     verify(boundMonitorRepository).deleteAll(captorOfBoundMonitorList.capture());
@@ -3829,7 +3829,7 @@ public class MonitorManagementTest {
     // VERIFY
     verify(resourceRepository).findByTenantIdAndResourceId("t-1", "r-1");
     verify(envoyResourceManagement).getOne("t-1", "r-1");
-    verify(boundMonitorRepository).findMonitorsBoundToResource("t-1", "r-1");
+    verify(boundMonitorRepository).findMonitorIdsBoundToTenantAndResource("t-1", "r-1");
     verify(boundMonitorRepository).findAllByMonitor_IdAndResourceId(monitor.getId(), "r-1");
 
     // nothing new bound and no affected envoy events
@@ -3865,7 +3865,7 @@ public class MonitorManagementTest {
     // VERIFY
     verify(resourceRepository).findByTenantIdAndResourceId("t-1", "r-1");
     verify(envoyResourceManagement).getOne("t-1", "r-1");
-    verify(boundMonitorRepository).findMonitorsBoundToResource("t-1", "r-1");
+    verify(boundMonitorRepository).findMonitorIdsBoundToTenantAndResource("t-1", "r-1");
     verify(boundMonitorRepository).findAllByMonitor_IdAndResourceId(monitor.getId(), "r-1");
     verify(policyApi).getDefaultMonitoringZones(MetadataPolicy.DEFAULT_ZONE, true);
     // nothing new bound and no affected envoy events
@@ -3898,13 +3898,13 @@ public class MonitorManagementTest {
         .setRenderedContent("content is ignored")
         .setEnvoyId("e-1");
 
-    when(boundMonitorRepository.findMonitorsBoundToResource(any(), any()))
+    when(boundMonitorRepository.findMonitorIdsBoundToTenantAndResource(any(), any()))
         .thenReturn(Collections.singletonList(monitor.getId()));
 
     when(boundMonitorRepository.findAllByMonitor_IdAndResourceId(any(), any()))
         .thenReturn(Collections.singletonList(boundMonitor));
 
-    when(boundMonitorRepository.findAllByTenantIdAndMonitor_IdIn(anyString(), any()))
+    when(boundMonitorRepository.findMonitorsBoundToResourceAndTenant(anyString(),anyString()))
         .thenReturn(Collections.singletonList(boundMonitor));
 
     // EXERCISE
@@ -3922,19 +3922,13 @@ public class MonitorManagementTest {
             .setEnvoyId("e-1")
     );
 
-    verify(boundMonitorRepository).findMonitorsBoundToResource("t-1", "r-1");
-
-    verify(boundMonitorRepository).findAllByTenantIdAndMonitor_IdIn("t-1",
-        new HashSet<>(Collections.singletonList(monitor.getId()))
-    );
+    verify(boundMonitorRepository).findMonitorIdsBoundToTenantAndResource("t-1", "r-1");
 
     verify(boundMonitorRepository).deleteAll(
         Collections.singletonList(boundMonitor)
     );
 
     verifyNoInteractions(policyApi);
-    verifyNoMoreInteractions(boundMonitorRepository, envoyResourceManagement,
-        zoneStorage, monitorEventProducer, resourceApi, resourceRepository);
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -3929,6 +3929,8 @@ public class MonitorManagementTest {
     );
 
     verifyNoInteractions(policyApi);
+    verifyNoMoreInteractions(envoyResourceManagement,
+        zoneStorage, monitorEventProducer, resourceApi, resourceRepository);
   }
 
   @Test

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -3904,7 +3904,7 @@ public class MonitorManagementTest {
     when(boundMonitorRepository.findAllByMonitor_IdAndResourceId(any(), any()))
         .thenReturn(Collections.singletonList(boundMonitor));
 
-    when(boundMonitorRepository.findMonitorsBoundToResourceAndTenant(anyString(),anyString()))
+    when(boundMonitorRepository.findMonitorsBoundToTenantAndResource(anyString(),anyString()))
         .thenReturn(Collections.singletonList(boundMonitor));
 
     // EXERCISE

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ResourceEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ResourceEventListenerTest.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.services;
 
 import static org.mockito.Mockito.after;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
@@ -77,7 +78,7 @@ public class ResourceEventListenerTest {
 
     kafkaTemplate.send(TOPIC, "t-1:r-1", event);
 
-    verify(monitorManagement, after(5000)).handleResourceChangeEvent(event);
+    verify(monitorManagement, timeout(5000)).handleResourceChangeEvent(event);
   }
 
   @Test
@@ -90,6 +91,6 @@ public class ResourceEventListenerTest {
 
     kafkaTemplate.send(TOPIC, "t-1:r-1", event);
 
-    verify(monitorManagement, after(5000)).handleResourceChangeEvent(event);
+    verify(monitorManagement, timeout(5000)).handleResourceChangeEvent(event);
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ResourceEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ResourceEventListenerTest.java
@@ -80,17 +80,4 @@ public class ResourceEventListenerTest {
 
     verify(monitorManagement, timeout(5000)).handleResourceChangeEvent(event);
   }
-
-  @Test
-  public void testResourceDeletedEvent() throws InterruptedException {
-    final ResourceEvent event = new ResourceEvent()
-        .setLabelsChanged(false)
-        .setTenantId("t-1")
-        .setResourceId("r-1")
-        .setDeleted(true);
-
-    kafkaTemplate.send(TOPIC, "t-1:r-1", event);
-
-    verify(monitorManagement, timeout(5000)).handleResourceChangeEvent(event);
-  }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ResourceEventListenerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ResourceEventListenerTest.java
@@ -79,4 +79,17 @@ public class ResourceEventListenerTest {
 
     verify(monitorManagement, after(5000)).handleResourceChangeEvent(event);
   }
+
+  @Test
+  public void testResourceDeletedEvent() throws InterruptedException {
+    final ResourceEvent event = new ResourceEvent()
+        .setLabelsChanged(false)
+        .setTenantId("t-1")
+        .setResourceId("r-1")
+        .setDeleted(true);
+
+    kafkaTemplate.send(TOPIC, "t-1:r-1", event);
+
+    verify(monitorManagement, after(5000)).handleResourceChangeEvent(event);
+  }
 }


### PR DESCRIPTION
# Resolves

[SALUS-980](https://jira.rax.io/browse/SALUS-980)

# What

Resolved - Deleting resource also deletes bound monitors for other resources.

# Depends on

https://github.com/racker/salus-telemetry-model/pull/148