### PR TITLE
Added inter-service admin endpoint to translate monitor content

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,14 +10,18 @@
 
 <How is the PR designed to solve the problem?>
 
-## How to test
+# How to test
 
 <instructions for verifying the changes specific to this PR>
 
 # Why
 
-<Why was the final approach taken? Were alternatives considered?>
+<OPTIONAL: Why was the final approach taken? Were alternatives considered?>
 
 # TODO
 
-<outstanding tasks before this PR is considered 'ready'>
+<OPTIONAL: outstanding tasks before this PR is considered 'ready'>
+
+# Depends on
+
+<OPTIONAL: list links to other PRs that this PR requires to compile/use>

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
@@ -36,4 +36,6 @@ public interface MonitorApi {
   DetailedMonitorOutput createMonitor(String tenantId, DetailedMonitorInput input, MultiValueMap<String, String> headers);
 
   TestMonitorResult performTestMonitor(String tenantId, TestMonitorInput input);
+
+  String translateMonitorContent(AgentType agentType, String agentVersion, String content);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -24,6 +24,7 @@ import com.rackspace.salus.monitor_management.web.model.DetailedMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.monitor_management.web.model.TestMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.TestMonitorResult;
+import com.rackspace.salus.monitor_management.web.model.TranslateMonitorContentRequest;
 import com.rackspace.salus.telemetry.model.AgentType;
 import java.util.List;
 import java.util.Map;
@@ -157,5 +158,22 @@ public class MonitorApiClient implements MonitorApi {
                     new HttpEntity<>(input),
                     TestMonitorResult.class
             ).getBody());
+  }
+
+  @Override
+  public String translateMonitorContent(AgentType agentType, String agentVersion, String content) {
+    return mapRestClientExceptions(
+        SERVICE_NAME,
+        () -> restTemplate.postForEntity(
+            "/api/admin/translate-monitor-content",
+            new HttpEntity<>(
+                new TranslateMonitorContentRequest()
+                    .setAgentType(agentType)
+                    .setAgentVersion(agentVersion)
+                    .setContent(content)
+            ),
+            String.class
+        ).getBody()
+    );
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/TranslateMonitorContentRequest.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/TranslateMonitorContentRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.web.model;
+
+import com.rackspace.salus.telemetry.model.AgentType;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class TranslateMonitorContentRequest {
+  @NotBlank
+  String content;
+  @NotNull
+  AgentType agentType;
+  @NotBlank
+  String agentVersion;
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService_Translations_Test.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService_Translations_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "1.12.0"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "1.12.0"));
 
     // VERIFY
 
@@ -108,7 +108,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "1.11.3"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "1.11.3"));
 
     // VERIFY
 
@@ -132,7 +132,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "2.0.0"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "2.0.0"));
 
     // VERIFY
 
@@ -156,7 +156,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "2.0.0"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "2.0.0"));
 
     // VERIFY
 
@@ -174,7 +174,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of());
+        service.translateBoundMonitors(boundMonitors, Map.of());
 
     // VERIFY
 
@@ -190,7 +190,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, null);
+        service.translateBoundMonitors(boundMonitors, null);
 
     // VERIFY
 
@@ -212,7 +212,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "1.11.3"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "1.11.3"));
 
     // VERIFY
 
@@ -263,7 +263,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "1.11.3"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "1.11.3"));
 
     assertThat(dtos).hasSize(1);
 
@@ -312,7 +312,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "1.11.3"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "1.11.3"));
 
     assertThat(dtos).hasSize(1);
 
@@ -362,7 +362,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "1.11.3"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "1.11.3"));
 
     assertThat(dtos).hasSize(1);
 
@@ -389,7 +389,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "1.12.0"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "1.12.0"));
 
     // VERIFY
 
@@ -422,7 +422,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "1.12.0"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "1.12.0"));
 
     // VERIFY
 
@@ -444,7 +444,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "0.1"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "0.1"));
 
     // VERIFY
 
@@ -478,7 +478,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "9.9.9"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "9.9.9"));
 
     // VERIFY
 
@@ -514,7 +514,7 @@ public class MonitorContentTranslationService_Translations_Test {
     // EXECUTE
 
     final List<BoundMonitorDTO> dtos =
-        service.translate(boundMonitors, Map.of(AgentType.TELEGRAF, "9.9.9"));
+        service.translateBoundMonitors(boundMonitors, Map.of(AgentType.TELEGRAF, "9.9.9"));
 
     // VERIFY
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-779

# What

Test-monitor operations were not going through monitor translation processing, which meant that telegraf was sometimes being given Salus-specific monitor/plugin configs that it didn't comprehend.

# How

Generalized and exposed an existing method of `MonitorContentTranslationService` so that it can be used for both bulk BoundMonitor translations and one-off content translations. In turn a new inter-service, admin REST API endpoint was added to enable calls to this endpoint, such as from the Ambassador building config instruction.

# How to test

Unit tests updated to cover the new method/endpoint.