### PR TITLE
Added monitor type and scope for test-monitor content translation

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
@@ -26,6 +26,8 @@ import com.rackspace.salus.telemetry.entities.BoundMonitor;
 import com.rackspace.salus.telemetry.entities.MonitorTranslationOperator;
 import com.rackspace.salus.telemetry.errors.MonitorContentTranslationException;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.repositories.MonitorTranslationOperatorRepository;
 import com.rackspace.salus.telemetry.translators.MonitorTranslator;
@@ -153,7 +155,11 @@ public class MonitorContentTranslationService {
             return new BoundMonitorDTO(boundMonitor)
                 .setRenderedContent(
                     translateMonitorContent(
-                        getOperatorsForMonitor(operatorsByAgentType, boundMonitor),
+                        prepareOperatorsForMonitor(
+                            operatorsByAgentType.get(boundMonitor.getMonitor().getAgentType()),
+                            boundMonitor.getMonitor().getMonitorType(),
+                            boundMonitor.getMonitor().getSelectorScope()
+                        ),
                         boundMonitor.getRenderedContent()
                     )
                 );
@@ -259,14 +265,20 @@ public class MonitorContentTranslationService {
             .collect(Collectors.toList());
   }
 
-  private List<MonitorTranslationOperator> getOperatorsForMonitor(
-      Map<AgentType, List<MonitorTranslationOperator>> operatorsByAgentType,
-      BoundMonitor bound) {
+  /**
+   * Filters and orders the given operators for just the specifically given monitor type and scope.
+   * @param operators the superset of operators for an agent type and version
+   * @param monitorType the monitor type to evaluate
+   * @param selectorScope the scope to evaluate
+   * @return operators filtered and ordered for given monitor type and scope
+   */
+  public List<MonitorTranslationOperator> prepareOperatorsForMonitor(
+      List<MonitorTranslationOperator> operators, MonitorType monitorType,
+      ConfigSelectorScope selectorScope) {
 
-    List<MonitorTranslationOperator> operators = operatorsByAgentType.get(bound.getMonitor().getAgentType());
     return operators.stream()
-        .filter(o -> o.getMonitorType() == null || o.getMonitorType() == bound.getMonitor().getMonitorType())
-        .filter(o -> o.getSelectorScope() == null || o.getSelectorScope() == bound.getMonitor().getSelectorScope())
+        .filter(o -> o.getMonitorType() == null || o.getMonitorType() == monitorType)
+        .filter(o -> o.getSelectorScope() == null || o.getSelectorScope() == selectorScope)
         .sorted(Comparator.comparingInt(MonitorTranslationOperator::getOrder))
         .collect(Collectors.toList());
   }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorContentTranslationService.java
@@ -261,7 +261,6 @@ public class MonitorContentTranslationService {
                   }
                 }
             )
-            .sorted(MonitorContentTranslationService::highestPrecedenceFirst)
             .collect(Collectors.toList());
   }
 
@@ -283,19 +282,4 @@ public class MonitorContentTranslationService {
         .collect(Collectors.toList());
   }
 
-  private static int highestPrecedenceFirst(MonitorTranslationOperator lhs,
-                                            MonitorTranslationOperator rhs) {
-    if (lhs.getAgentVersions() == null && rhs.getAgentVersions() == null) {
-      return 0;
-    } else if (lhs.getAgentVersions() == null || rhs.getAgentVersions() == null) {
-      // ones with null versions are less specific, so sorted "greater than"
-      return rhs.getAgentVersions() != null ? 1 : -1;
-    } else {
-      // When both have versions, resort to a reverse textual comparison trying to put something
-      // like ">=1.12" ahead of ">=1.11". The ordering within these cases is not particularly
-      // important since loadOperators will filter down to operators that apply to the
-      // agent versions anyway.
-      return rhs.getAgentVersions().compareTo(lhs.getAgentVersions());
-    }
-  }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorService.java
@@ -114,6 +114,8 @@ public class TestMonitorService {
       event = new TestMonitorRequestEvent()
           .setCorrelationId(correlationId)
           .setAgentType(monitorCU.getAgentType())
+          .setMonitorType(monitorCU.getMonitorType())
+          .setScope(monitorCU.getSelectorScope())
           .setTenantId(tenantId)
           .setResourceId(resourceId);
       final Optional<Resource> optionalResource = resourceRepository

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApi.java
@@ -22,6 +22,8 @@ import com.rackspace.salus.monitor_management.web.model.DetailedMonitorOutput;
 import com.rackspace.salus.monitor_management.web.model.TestMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.TestMonitorResult;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
 import java.util.Map;
 import org.springframework.util.MultiValueMap;
@@ -37,5 +39,8 @@ public interface MonitorApi {
 
   TestMonitorResult performTestMonitor(String tenantId, TestMonitorInput input);
 
-  String translateMonitorContent(AgentType agentType, String agentVersion, String content);
+  String translateMonitorContent(AgentType agentType, String agentVersion,
+                                 MonitorType monitorType,
+                                 ConfigSelectorScope scope,
+                                 String content);
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClient.java
@@ -26,6 +26,8 @@ import com.rackspace.salus.monitor_management.web.model.TestMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.TestMonitorResult;
 import com.rackspace.salus.monitor_management.web.model.TranslateMonitorContentRequest;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -161,7 +163,10 @@ public class MonitorApiClient implements MonitorApi {
   }
 
   @Override
-  public String translateMonitorContent(AgentType agentType, String agentVersion, String content) {
+  public String translateMonitorContent(AgentType agentType, String agentVersion,
+                                        MonitorType monitorType,
+                                        ConfigSelectorScope scope,
+                                        String content) {
     return mapRestClientExceptions(
         SERVICE_NAME,
         () -> restTemplate.postForEntity(
@@ -170,6 +175,8 @@ public class MonitorApiClient implements MonitorApi {
                 new TranslateMonitorContentRequest()
                     .setAgentType(agentType)
                     .setAgentVersion(agentVersion)
+                    .setMonitorType(monitorType)
+                    .setScope(scope)
                     .setContent(content)
             ),
             String.class

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiController.java
@@ -124,7 +124,11 @@ public class MonitorApiController {
             );
 
     return monitorContentTranslationService.translateMonitorContent(
-        operatorsByType.get(request.getAgentType()),
+        monitorContentTranslationService.prepareOperatorsForMonitor(
+            operatorsByType.get(request.getAgentType()),
+            request.getMonitorType(),
+            request.getScope()
+        ),
         request.getContent()
     );
   }

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorCreate.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorTranslationOperatorCreate.java
@@ -41,7 +41,7 @@ public class MonitorTranslationOperatorCreate {
 
   /**
    * Optional field that conveys applicable version ranges
-   * <a href="https://github.com/zafarkhaja/jsemver#external-dsl"></a>in the form of jsemver's external DSL</a>
+   * <a href="https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html">in the form of Maven's version range spec</a>
    */
   String agentVersions;
 

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/TranslateMonitorContentRequest.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/TranslateMonitorContentRequest.java
@@ -17,6 +17,8 @@
 package com.rackspace.salus.monitor_management.web.model;
 
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -29,4 +31,8 @@ public class TranslateMonitorContentRequest {
   AgentType agentType;
   @NotBlank
   String agentVersion;
+  @NotNull
+  MonitorType monitorType;
+  @NotNull
+  ConfigSelectorScope scope;
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/client/MonitorApiClientTest.java
@@ -33,6 +33,8 @@ import com.rackspace.salus.monitor_management.web.model.TestMonitorInput;
 import com.rackspace.salus.monitor_management.web.model.TestMonitorResult;
 import com.rackspace.salus.monitor_management.web.model.TranslateMonitorContentRequest;
 import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.io.IOException;
 import java.util.Arrays;
@@ -165,6 +167,8 @@ public class MonitorApiClientTest {
     final TranslateMonitorContentRequest request = new TranslateMonitorContentRequest()
         .setAgentType(AgentType.TELEGRAF)
         .setAgentVersion("1.13.2")
+        .setMonitorType(MonitorType.cpu)
+        .setScope(ConfigSelectorScope.LOCAL)
         .setContent("original content");
 
     mockServer.expect(requestTo("/api/admin/translate-monitor-content"))
@@ -173,7 +177,9 @@ public class MonitorApiClientTest {
         .andRespond(withSuccess("converted content", MediaType.TEXT_PLAIN));
 
     final String result = monitorApiClient
-        .translateMonitorContent(AgentType.TELEGRAF, "1.13.2", "original content");
+        .translateMonitorContent(AgentType.TELEGRAF, "1.13.2",
+            MonitorType.cpu, ConfigSelectorScope.LOCAL,
+            "original content");
 
     assertThat(result).isEqualTo("converted content");
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/controller/MonitorApiControllerTest.java
@@ -1055,6 +1055,9 @@ public class MonitorApiControllerTest {
     when(monitorContentTranslationService.loadOperatorsByAgentTypeAndVersion(any()))
         .thenReturn(Map.of(AgentType.TELEGRAF, operators));
 
+    when(monitorContentTranslationService.prepareOperatorsForMonitor(any(), any(), any()))
+        .thenReturn(operators);
+
     when(monitorContentTranslationService.translateMonitorContent(any(), any()))
         .thenReturn("translated content");
 
@@ -1063,6 +1066,8 @@ public class MonitorApiControllerTest {
             new TranslateMonitorContentRequest()
                 .setAgentType(AgentType.TELEGRAF)
                 .setAgentVersion("1.13.2")
+                .setMonitorType(MonitorType.cpu)
+                .setScope(ConfigSelectorScope.LOCAL)
                 .setContent("original content")
         ))
         .contentType(MediaType.APPLICATION_JSON)
@@ -1074,6 +1079,9 @@ public class MonitorApiControllerTest {
     verify(monitorContentTranslationService).loadOperatorsByAgentTypeAndVersion(
         Map.of(AgentType.TELEGRAF, "1.13.2")
     );
+
+    verify(monitorContentTranslationService)
+        .prepareOperatorsForMonitor(operators, MonitorType.cpu, ConfigSelectorScope.LOCAL);
 
     verify(monitorContentTranslationService).translateMonitorContent(operators, "original content");
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-779

# What

The previous PR https://github.com/racker/salus-telemetry-monitor-management/pull/196 didn't take into consideration the monitor type and scope. As a result, the content translation for test-monitors was trying to apply ALL of the translation operations, which failed every time due to conversion of fields that didn't exist.

# How

Propagate the monitor type and scope of the original test-monitor request and use those in the same way as translations for bound-monitors.

While I was in there, I noticed that the translation operators retrieval was sorting by `agentVersions` and then later using the `order` field. The latter is what we are really using for deterministic ordering. 

# How to test

Added unit tests for the newly elevated methods.

# Depends on

https://github.com/racker/salus-telemetry-model/pull/149