### PR TITLE
changed rebalanceStandardDeviations to 0.2f

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/config/ZonesProperties.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/config/ZonesProperties.java
@@ -40,5 +40,5 @@ public class ZonesProperties {
    * assignment count will be considered over-assigned. Those Envoys that are over-assigned will
    * have bound monitors reassigned to other Envoys in the zone.
    */
-  float rebalanceStandardDeviations = 1.0f;
+  float rebalanceStandardDeviations = 0.2f;
 }


### PR DESCRIPTION
# Resolves

[SALUS-986](https://jira.rax.io/browse/SALUS-986)

# What

Zones assignments are not getting rebalanced.

# How

Changing rebalanceStandardDeviations config to 0.2f to ensure the rebalancing is more aggressive.

# How to test

Create private zone and 50 ping monitors, using the apis.
Create 2 pollers.
Check zone-assignment counts from api. Should be 50 on each poller.
Turn off 1 poller for 10 minutes. (The etcd lease expires after 2 minutes, so this is not a reconnect.)
Check zone-assignment counts. Now 1 poller has 100 assignments. 
Turn back poller on.
Get zone-assignment counts. (Since not reconnect, all the monitors remain with the old poller)
Run rebalance, (api call).
Get zone-assignment counts.
Expected result: Now they should be rebalanced again meaning each poller has 50 assignments.
Actual result: 1 poller has 100 assignments and another has 0.
