### PR TITLE
Calculate and maintain zone binding counts in SQL

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -2042,14 +2042,16 @@ public class MonitorManagement {
    */
   @SuppressWarnings("WeakerAccess")
   public void handleExpiredEnvoy(@Nullable String zoneTenantId, String zoneName, String envoyId) {
-    log.debug("Reassigning bound monitors for disconnected envoy={} with zoneName={} and zoneTenantId={}",
-        envoyId, zoneName, zoneTenantId);
     List<BoundMonitor> boundMonitors = getAllBoundMonitorsByEnvoyId(envoyId);
     if (boundMonitors.isEmpty()) {
       return;
     }
+    log.info("Reassigning bound monitors for disconnected envoy={} with zoneName={} and zoneTenantId={}",
+        envoyId, zoneName, zoneTenantId);
     for (BoundMonitor boundMonitor : boundMonitors) {
-      boundMonitor.setEnvoyId(null);
+      boundMonitor
+          .setEnvoyId(null)
+          .setPollerResourceId(null);
     }
 
     saveBoundMonitors(boundMonitors);
@@ -2083,7 +2085,7 @@ public class MonitorManagement {
   public CompletableFuture<Integer> rebalanceZone(@Nullable String zoneTenantId, String zoneName) {
     final ResolvedZone zone = resolveZone(zoneTenantId, zoneName);
 
-    log.debug("Rebalancing zone={}", zone);
+    log.info("Rebalancing zone={}", zone);
 
     return zoneAllocationResolverFactory.create()
         .getZoneBindingCounts(zone)

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -2046,8 +2046,8 @@ public class MonitorManagement {
     if (boundMonitors.isEmpty()) {
       return;
     }
-    log.info("Reassigning bound monitors for disconnected envoy={} with zoneName={} and zoneTenantId={}",
-        envoyId, zoneName, zoneTenantId);
+    log.info("Reassigning bound monitors count={} for disconnected envoy={} with zoneName={} and zoneTenantId={}",
+        boundMonitors.size(), envoyId, zoneName, zoneTenantId);
     for (BoundMonitor boundMonitor : boundMonitors) {
       boundMonitor
           .setEnvoyId(null)

--- a/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorService.java
@@ -196,15 +196,12 @@ public class TestMonitorService {
           "test-monitor requires only one monitoring zone to be given");
     }
 
-    final Optional<EnvoyResourcePair> leastLoaded = monitorManagement
-        .findLeastLoadedEnvoyInZone(resolveZone(tenantId, monitoringZones.get(0)));
+    final EnvoyResourcePair leastLoaded = monitorManagement
+        .findLeastLoadedEnvoyInZone(resolveZone(tenantId, monitoringZones.get(0)))
+        .orElseThrow(() -> new MissingRequirementException(
+            "No envoys were available in the given monitoring zone"));
 
-    if (leastLoaded.isEmpty()) {
-      throw new MissingRequirementException(
-          "No envoys were available in the given monitoring zone");
-    }
-
-    return leastLoaded.get().getEnvoyId();
+    return leastLoaded.getEnvoyId();
   }
 
   private String resolveLocalEnvoy(String tenantId, String resourceId) {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/TestMonitorService.java
@@ -17,6 +17,7 @@
 package com.rackspace.salus.monitor_management.services;
 
 import static com.rackspace.salus.telemetry.entities.Resource.REGION_METADATA;
+import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.resolveZone;
 
 import com.rackspace.salus.monitor_management.config.TestMonitorProperties;
 import com.rackspace.salus.monitor_management.errors.InvalidTemplateException;
@@ -30,6 +31,7 @@ import com.rackspace.salus.resource_management.web.model.ResourceDTO;
 import com.rackspace.salus.telemetry.entities.Resource;
 import com.rackspace.salus.telemetry.errors.MissingRequirementException;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
+import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
 import com.rackspace.salus.telemetry.messaging.TestMonitorRequestEvent;
 import com.rackspace.salus.telemetry.messaging.TestMonitorResultsEvent;
 import com.rackspace.salus.telemetry.model.AgentType;
@@ -194,15 +196,15 @@ public class TestMonitorService {
           "test-monitor requires only one monitoring zone to be given");
     }
 
-    final String envoyId = monitorManagement
-        .findLeastLoadedEnvoyInZone(tenantId, monitoringZones.get(0));
+    final Optional<EnvoyResourcePair> leastLoaded = monitorManagement
+        .findLeastLoadedEnvoyInZone(resolveZone(tenantId, monitoringZones.get(0)));
 
-    if (envoyId == null) {
+    if (leastLoaded.isEmpty()) {
       throw new MissingRequirementException(
           "No envoys were available in the given monitoring zone");
     }
 
-    return envoyId;
+    return leastLoaded.get().getEnvoyId();
   }
 
   private String resolveLocalEnvoy(String tenantId, String resourceId) {

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolver.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolver.java
@@ -34,10 +34,10 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 /**
- * This stateful component is used once per monitor operation to locate the poller-envoy
+ * This component is used once per monitor operation to locate the poller-envoy
  * with the least number of bound monitors.
- * It is recommended to use {@link ZoneAllocationResolverFactory} to create
- * instances of this component prior to iterating over monitor binding changes.
+ * This component <b>must not be directly injected</b>, but instead instances should be created by calling
+ * {@link ZoneAllocationResolverFactory} prior to iterating over a set of monitor binding changes.
  * <p>
  *   The stateful behavior optimizes for the common scenario where a remote monitor is binding to a
  *   potentially large number of resources.

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolver.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolver.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.services;
+
+import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
+import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import javax.persistence.Tuple;
+import javax.persistence.TypedQuery;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * This stateful component encapsulates and caches the resolving of poller-envoys to allocate for
+ * monitor binding. It is recommended to use {@link ZoneAllocationResolverFactory} to create
+ * instances of this component prior to iterating over monitor binding changes.
+ * <p>
+ *   The caching optimizes for the common scenario where a remote monitor is binding to a potentially
+ *   large number of resources. Rather than query etcd and SQL for the poller-envoy loads repeatedly,
+ *   a snapshot of each zone is retrieved as needed and tracks across repeated use.
+ *   The downside of using mutable snapshots is that concurrent use of these resolvers across the
+ *   system can result in potential imbalance in poller-envoy allocations; however, some amount of
+ *   imbalance is fine and can be rectified by a rebalance operation.
+ * </p>
+ */
+@Component
+@Scope("prototype")
+public class ZoneAllocationResolver {
+
+  private final ZoneStorage zoneStorage;
+  private final EntityManager entityManager;
+
+  private final Map<ResolvedZone, CompletableFuture<Map<String, String>>> resourceIdToEnvoyIdCache = new HashMap<>();
+  private final Map<ResolvedZone, CompletableFuture<Map<String, Integer>>> pollerCountCache = new HashMap<>();
+
+  @Autowired
+  public ZoneAllocationResolver(ZoneStorage zoneStorage, EntityManager entityManager) {
+    this.zoneStorage = zoneStorage;
+    this.entityManager = entityManager;
+  }
+
+  public Optional<EnvoyResourcePair> findLeastLoadedEnvoy(ResolvedZone zone) {
+
+    // Get the (cached) poller-envoy binding counts for the zone
+    return getPollerResourceCounts(zone)
+        .thenCompose(pollerResourceCounts ->
+            // ...and get a mapping of poller resourceIds to current envoyIds
+            getResourceIdToEnvoyIdMap(zone)
+                .thenApply(resourceIdToEnvoyId ->
+                    pollerResourceCounts.entrySet().stream()
+                        // Pick the smallest, least-assigned entry
+                        .min(Comparator.comparingLong(Entry::getValue))
+                        .map(entry -> {
+                          // In our cache, count a binding to that poller-envoy
+                          // setValue works here since getPollerResourceCounts provides
+                          // a map for us to mutate
+                          entry.setValue(entry.getValue() + 1);
+
+                          final String resourceId = entry.getKey();
+                          return new EnvoyResourcePair()
+                              .setResourceId(resourceId)
+                              .setEnvoyId(resourceIdToEnvoyId.get(resourceId));
+                        }))
+        )
+        .join();
+  }
+
+  private CompletableFuture<Map<String, Integer>> getPollerResourceCounts(ResolvedZone zone) {
+    return pollerCountCache.computeIfAbsent(
+        zone,
+        this::retrievePollerResourceCounts
+    );
+  }
+
+  /**
+   * Combines tracking of active poller-envoys with the currently bound monitors into a count of
+   * of bound monitors per poller-envoy
+   *
+   * @param zone the zone to retrieve
+   * @return mapping of envoy-pollers to bound monitor counts
+   */
+  public CompletableFuture<Map<EnvoyResourcePair, Integer>> getZoneBindingCounts(ResolvedZone zone) {
+    // Combine the poller counts by resourceId
+    return getPollerResourceCounts(zone)
+        .thenCompose(pollerResourceCounts ->
+            // ...with the resourceId to envoyId mappings
+            getResourceIdToEnvoyIdMap(zone)
+                .thenApply(resourceIdToEnvoyIdMap ->
+                    // ...and re-map each key into an EnvoyResourcePair
+                    pollerResourceCounts.entrySet().stream()
+                        .collect(Collectors.toMap(
+                            entry ->
+                                new EnvoyResourcePair()
+                                    .setResourceId(entry.getKey())
+                                    .setEnvoyId(resourceIdToEnvoyIdMap.get(entry.getKey())),
+                            Entry::getValue
+                        ))
+                ));
+  }
+
+  /**
+   * Grabs a snapshot of active envoy-pollers from the etcd zone tracking and merges in the
+   * counts of bound monitors per envoy-poller
+   * @param zone the zone to retrieve
+   * @return a mutable map of envoy-poller resourceId to binding counts
+   */
+  private CompletableFuture<Map<String, Integer>> retrievePollerResourceCounts(ResolvedZone zone) {
+    return zoneStorage.getActivePollerResourceIdsInZone(zone)
+        .thenApply(activePollerResources -> {
+          // Start with a count of 0 for all active poller resource IDs
+          // ...that ensures that pollers with no bindings are considered
+          final Map<String, Integer> pollerResourceLoading = new HashMap<>(
+              activePollerResources.size());
+          for (String resourceId : activePollerResources) {
+            pollerResourceLoading.put(resourceId, 0);
+          }
+
+          // Count bindings per poller resource ID
+          final TypedQuery<Tuple> query;
+          if (zone.isPublicZone()) {
+            query = entityManager
+                .createNamedQuery("BoundMonitor.publicPollerLoading", Tuple.class)
+                .setParameter("zoneName", zone.getName());
+          } else {
+            query = entityManager
+                .createNamedQuery("BoundMonitor.privatePollerLoading", Tuple.class)
+                .setParameter("tenantId", zone.getTenantId())
+                .setParameter("zoneName", zone.getName());
+          }
+
+          // Merge bindings counts into the active poller mappings
+          query
+              .getResultStream()
+              .forEach(tuple -> {
+                pollerResourceLoading.put(
+                    // resourceId
+                    (String) tuple.get(0),
+                    // count
+                    ((Number) tuple.get(1)).intValue()
+                );
+              });
+
+          return pollerResourceLoading;
+        });
+  }
+
+  private CompletableFuture<Map<String, String>> getResourceIdToEnvoyIdMap(ResolvedZone zone) {
+    return resourceIdToEnvoyIdCache.computeIfAbsent(
+        zone,
+        zoneStorage::getResourceIdToEnvoyIdMap
+    );
+  }
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolverFactory.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolverFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.services;
+
+import org.springframework.beans.factory.annotation.Lookup;
+import org.springframework.stereotype.Service;
+
+/**
+ * Creates instances of the stateful, prototype-scoped component {@link ZoneAllocationResolver}
+ */
+@Service
+public abstract class ZoneAllocationResolverFactory {
+
+  @Lookup
+  public abstract ZoneAllocationResolver create();
+}

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
@@ -53,7 +53,9 @@ public class BoundMonitorDTO {
   ConfigSelectorScope selectorScope;
   AgentType agentType;
   String renderedContent;
+  @JsonView(View.Internal.class)
   String envoyId;
+  @JsonView(View.Admin.class)
   String pollerResourceId;
   String createdTimestamp;
   String updatedTimestamp;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTO.java
@@ -54,6 +54,7 @@ public class BoundMonitorDTO {
   AgentType agentType;
   String renderedContent;
   String envoyId;
+  String pollerResourceId;
   String createdTimestamp;
   String updatedTimestamp;
 
@@ -69,6 +70,7 @@ public class BoundMonitorDTO {
     this.agentType = boundMonitor.getMonitor().getAgentType();
     this.renderedContent = boundMonitor.getRenderedContent();
     this.envoyId = boundMonitor.getEnvoyId();
+    this.pollerResourceId = boundMonitor.getPollerResourceId();
     this.createdTimestamp = DateTimeFormatter.ISO_INSTANT.format(boundMonitor.getCreatedTimestamp());
     this.updatedTimestamp = DateTimeFormatter.ISO_INSTANT.format(boundMonitor.getUpdatedTimestamp());
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/BoundMonitorMatcher.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/BoundMonitorMatcher.java
@@ -17,18 +17,28 @@
 package com.rackspace.salus.monitor_management.services;
 
 import com.rackspace.salus.telemetry.entities.BoundMonitor;
+import com.rackspace.salus.telemetry.entities.Monitor;
 import java.util.Objects;
-import lombok.AllArgsConstructor;
+import java.util.UUID;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
-@AllArgsConstructor
 public class BoundMonitorMatcher extends BaseMatcher<BoundMonitor> {
 
-  final String tenantId;
-  final String zoneName;
-  final String resourceId;
-  final String envoyId;
+  final private UUID monitorId;
+  final private String tenantId;
+  final private String zoneName;
+  final private String resourceId;
+  final private String envoyId;
+
+  public BoundMonitorMatcher(Monitor monitor, String zoneName, String resourceId,
+                             String envoyId) {
+    this.tenantId = monitor.getTenantId();
+    this.monitorId = monitor.getId();
+    this.zoneName = zoneName;
+    this.resourceId = resourceId;
+    this.envoyId = envoyId;
+  }
 
   @Override
   public boolean matches(Object o) {
@@ -36,7 +46,9 @@ public class BoundMonitorMatcher extends BaseMatcher<BoundMonitor> {
       return false;
     }
     final BoundMonitor boundMonitor = (BoundMonitor) o;
-    return Objects.equals(boundMonitor.getTenantId(), tenantId) &&
+    return
+        Objects.equals(boundMonitor.getMonitor().getId(), monitorId) &&
+        Objects.equals(boundMonitor.getTenantId(), tenantId) &&
         Objects.equals(boundMonitor.getZoneName(), zoneName) &&
         Objects.equals(boundMonitor.getResourceId(), resourceId) &&
         Objects.equals(boundMonitor.getEnvoyId(), envoyId);
@@ -44,8 +56,9 @@ public class BoundMonitorMatcher extends BaseMatcher<BoundMonitor> {
 
   @Override
   public void describeTo(Description description) {
-    description.appendText("BoundMonitor with ")
-        .appendText("tenantId=").appendValue(tenantId)
+    description.appendText("BoundMonitor with")
+        .appendText(" monitorId=").appendValue(monitorId)
+        .appendText(" tenantId=").appendValue(tenantId)
         .appendText(" zoneName=").appendValue(zoneName)
         .appendText(" resourceId=").appendValue(resourceId)
         .appendText(" envoyId=").appendValue(envoyId);

--- a/src/test/java/com/rackspace/salus/monitor_management/services/BoundMonitorMatcher.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/BoundMonitorMatcher.java
@@ -17,28 +17,18 @@
 package com.rackspace.salus.monitor_management.services;
 
 import com.rackspace.salus.telemetry.entities.BoundMonitor;
-import com.rackspace.salus.telemetry.entities.Monitor;
 import java.util.Objects;
-import java.util.UUID;
+import lombok.AllArgsConstructor;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 
+@AllArgsConstructor
 public class BoundMonitorMatcher extends BaseMatcher<BoundMonitor> {
 
-  final private UUID monitorId;
-  final private String tenantId;
-  final private String zoneName;
-  final private String resourceId;
-  final private String envoyId;
-
-  public BoundMonitorMatcher(Monitor monitor, String zoneName, String resourceId,
-                             String envoyId) {
-    this.tenantId = monitor.getTenantId();
-    this.monitorId = monitor.getId();
-    this.zoneName = zoneName;
-    this.resourceId = resourceId;
-    this.envoyId = envoyId;
-  }
+  final String tenantId;
+  final String zoneName;
+  final String resourceId;
+  final String envoyId;
 
   @Override
   public boolean matches(Object o) {
@@ -46,9 +36,7 @@ public class BoundMonitorMatcher extends BaseMatcher<BoundMonitor> {
       return false;
     }
     final BoundMonitor boundMonitor = (BoundMonitor) o;
-    return
-        Objects.equals(boundMonitor.getMonitor().getId(), monitorId) &&
-        Objects.equals(boundMonitor.getTenantId(), tenantId) &&
+    return Objects.equals(boundMonitor.getTenantId(), tenantId) &&
         Objects.equals(boundMonitor.getZoneName(), zoneName) &&
         Objects.equals(boundMonitor.getResourceId(), resourceId) &&
         Objects.equals(boundMonitor.getEnvoyId(), envoyId);
@@ -56,9 +44,8 @@ public class BoundMonitorMatcher extends BaseMatcher<BoundMonitor> {
 
   @Override
   public void describeTo(Description description) {
-    description.appendText("BoundMonitor with")
-        .appendText(" monitorId=").appendValue(monitorId)
-        .appendText(" tenantId=").appendValue(tenantId)
+    description.appendText("BoundMonitor with ")
+        .appendText("tenantId=").appendValue(tenantId)
         .appendText(" zoneName=").appendValue(zoneName)
         .appendText(" resourceId=").appendValue(resourceId)
         .appendText(" envoyId=").appendValue(envoyId);

--- a/src/test/java/com/rackspace/salus/monitor_management/services/BoundMonitorMatcher.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/BoundMonitorMatcher.java
@@ -25,19 +25,21 @@ import org.hamcrest.Description;
 
 public class BoundMonitorMatcher extends BaseMatcher<BoundMonitor> {
 
-  final private UUID monitorId;
-  final private String tenantId;
-  final private String zoneName;
-  final private String resourceId;
-  final private String envoyId;
+  private final UUID monitorId;
+  private final String tenantId;
+  private final String zoneName;
+  private final String resourceId;
+  private final String envoyId;
+  private final String pollerResourceId;
 
   public BoundMonitorMatcher(Monitor monitor, String zoneName, String resourceId,
-                             String envoyId) {
+                             String envoyId, String pollerResourceId) {
     this.tenantId = monitor.getTenantId();
     this.monitorId = monitor.getId();
     this.zoneName = zoneName;
     this.resourceId = resourceId;
     this.envoyId = envoyId;
+    this.pollerResourceId = pollerResourceId;
   }
 
   @Override
@@ -51,7 +53,8 @@ public class BoundMonitorMatcher extends BaseMatcher<BoundMonitor> {
         Objects.equals(boundMonitor.getTenantId(), tenantId) &&
         Objects.equals(boundMonitor.getZoneName(), zoneName) &&
         Objects.equals(boundMonitor.getResourceId(), resourceId) &&
-        Objects.equals(boundMonitor.getEnvoyId(), envoyId);
+        Objects.equals(boundMonitor.getEnvoyId(), envoyId) &&
+        Objects.equals(boundMonitor.getPollerResourceId(), pollerResourceId);
   }
 
   @Override
@@ -61,6 +64,8 @@ public class BoundMonitorMatcher extends BaseMatcher<BoundMonitor> {
         .appendText(" tenantId=").appendValue(tenantId)
         .appendText(" zoneName=").appendValue(zoneName)
         .appendText(" resourceId=").appendValue(resourceId)
-        .appendText(" envoyId=").appendValue(envoyId);
+        .appendText(" envoyId=").appendValue(envoyId)
+        .appendText(" pollerResourceId=").appendValue(pollerResourceId)
+    ;
   }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
@@ -74,7 +74,8 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest(classes = {
     DatabaseConfig.class,
     MonitorManagement.class,
-    ZonesProperties.class
+    ZonesProperties.class,
+    ZoneAllocationResolverFactory.class,
 })
 @EnableTestContainersDatabase
 @AutoConfigureDataJpa
@@ -120,6 +121,9 @@ public class MonitorManagementExcludeResourceIdsTest {
 
   @MockBean
   ResourceApi resourceApi;
+
+  @MockBean
+  ZoneAllocationResolver zoneAllocationResolver;
 
   @Test
   public void testCreate_noResources() {

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementTest.java
@@ -140,7 +140,6 @@ import uk.co.jemos.podam.api.PodamFactoryImpl;
     ZoneAllocationResolverFactory.class,
     ZonesProperties.class,
     SimpleMeterRegistry.class,
-
 })
 @TestPropertySource(properties = {
     "salus.services.resourceManagementUrl=http://this-is-a-non-null-value",

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
@@ -1226,7 +1226,6 @@ public class MonitorManagement_ZoneBindingsTest {
                     .setMonitor(monitor)
                     .setTenantId(monitor.getTenantId())
                     .setEnvoyId(pollerEnvoyId)
-                    .setPollerResourceId(pollerResourceId)
                     .setZoneName(zoneName)
                     .setResourceId(String.format("r-%d", i))
             )

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
@@ -20,6 +20,7 @@ import static com.rackspace.salus.telemetry.entities.Resource.REGION_METADATA;
 import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.PUBLIC_PREFIX;
 import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPrivateZone;
 import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.createPublicZone;
+import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.resolveZone;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -87,6 +88,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -104,20 +106,27 @@ import uk.co.jemos.podam.api.PodamFactoryImpl;
 @RunWith(SpringRunner.class)
 @EnableTestContainersDatabase
 @DataJpaTest(showSql = false)
-@Import({ServicesProperties.class, ObjectMapper.class, MonitorManagement.class,
-    MonitorContentRenderer.class,
-    MonitorContentProperties.class,
-    MetadataUtils.class,
-    DatabaseConfig.class,
-    ServicesProperties.class,
-    ZonesProperties.class,
-    SimpleMeterRegistry.class,
-})
 @TestPropertySource(properties = {
     "salus.services.resourceManagementUrl=http://this-is-a-non-null-value",
     "salus.services.policyManagementUrl=http://this-is-a-non-null-value"
 })
 public class MonitorManagement_ZoneBindingsTest {
+  /**
+   * Provides minimal app context config mainly to avoid picking up Spring Boot configs like
+   * TelemetryCoreEtcdModule.
+   */
+  @Configuration
+  @Import({ObjectMapper.class, MonitorManagement.class,
+      MonitorContentRenderer.class,
+      MonitorContentProperties.class,
+      MetadataUtils.class,
+      DatabaseConfig.class,
+      ServicesProperties.class,
+      ZonesProperties.class,
+      SimpleMeterRegistry.class,
+      ZoneAllocationResolverFactory.class,
+  })
+  public static class TestConfig { }
 
   @MockBean
   MonitorConversionService monitorConversionService;
@@ -137,6 +146,8 @@ public class MonitorManagement_ZoneBindingsTest {
   ZoneManagement zoneManagement;
   @MockBean
   PatchHelper patchHelper;
+  @MockBean
+  ZoneAllocationResolver zoneAllocationResolver;
 
   @Autowired
   ObjectMapper objectMapper;
@@ -155,7 +166,7 @@ public class MonitorManagement_ZoneBindingsTest {
 
   @Autowired
   private MonitorManagement monitorManagement;
-  private PodamFactory podamFactory = new PodamFactoryImpl();
+  private final PodamFactory podamFactory = new PodamFactoryImpl();
 
   @After
   public void tearDown() throws Exception {
@@ -168,17 +179,15 @@ public class MonitorManagement_ZoneBindingsTest {
     final ResolvedZone zone1 = createPrivateZone("t-1", "zone1");
     final ResolvedZone zoneWest = createPublicZone("public/west");
 
-    when(zoneStorage.findLeastLoadedEnvoy(zone1))
-        .thenReturn(CompletableFuture.completedFuture(
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(zone1))
+        .thenReturn(
             Optional.of(
                 new EnvoyResourcePair().setEnvoyId("zone1-e-1").setResourceId("r-e-1"))
-        ));
-    when(zoneStorage.findLeastLoadedEnvoy(zoneWest))
-        .thenReturn(CompletableFuture.completedFuture(
+        );
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(zoneWest))
+        .thenReturn(
             Optional.of(new EnvoyResourcePair().setEnvoyId("zoneWest-e-2").setResourceId("r-e-2"))
-        ));
-    when(zoneStorage.incrementBoundCount(any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(1));
+        );
 
     when(resourceApi.getResourcesWithLabels(any(), any(), eq(LabelSelectorMethod.AND)))
         .thenReturn(List.of(
@@ -213,21 +222,18 @@ public class MonitorManagement_ZoneBindingsTest {
     // VERIFY
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "zone1", "r-1", "zone1-e-1"),
-        new BoundMonitorMatcher(monitor, "public/west", "r-1", "zoneWest-e-2"),
-        new BoundMonitorMatcher(monitor, "zone1", "r-2", "zone1-e-1"),
-        new BoundMonitorMatcher(monitor, "public/west", "r-2", "zoneWest-e-2")
+        new BoundMonitorMatcher(monitor, "zone1", "r-1", "zone1-e-1", "r-e-1"),
+        new BoundMonitorMatcher(monitor, "public/west", "r-1", "zoneWest-e-2", "r-e-2"),
+        new BoundMonitorMatcher(monitor, "zone1", "r-2", "zone1-e-1", "r-e-1"),
+        new BoundMonitorMatcher(monitor, "public/west", "r-2", "zoneWest-e-2", "r-e-2")
     );
 
     assertThat(affectedEnvoys, containsInAnyOrder("zone1-e-1", "zoneWest-e-2"));
 
-    verify(zoneStorage, times(2)).findLeastLoadedEnvoy(zone1);
-    verify(zoneStorage, times(2)).findLeastLoadedEnvoy(zoneWest);
+    verify(zoneAllocationResolver, times(2)).findLeastLoadedEnvoy(zone1);
+    verify(zoneAllocationResolver, times(2)).findLeastLoadedEnvoy(zoneWest);
 
-    verify(zoneStorage, times(2)).incrementBoundCount(zone1, "r-e-1");
-    verify(zoneStorage, times(2)).incrementBoundCount(zoneWest, "r-e-2");
-
-    verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
+    verifyNoMoreInteractions(zoneStorage, monitorEventProducer, zoneAllocationResolver);
   }
 
   @Test
@@ -235,12 +241,10 @@ public class MonitorManagement_ZoneBindingsTest {
     final String tenantId = RandomStringUtils.randomAlphanumeric(10);
     final ResolvedZone zone1 = createPrivateZone(tenantId, "zone1");
 
-    when(zoneStorage.findLeastLoadedEnvoy(any()))
-        .thenReturn(CompletableFuture.completedFuture(
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
+        .thenReturn(
             Optional.empty()
-        ));
-    when(zoneStorage.incrementBoundCount(any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(1));
+        );
 
     Monitor monitor = persistNewMonitor(tenantId, "zone1");
 
@@ -270,18 +274,18 @@ public class MonitorManagement_ZoneBindingsTest {
         .bindMonitor(tenantId, monitor, monitor.getZones());
 
     // VERIFY
-    verify(zoneStorage).findLeastLoadedEnvoy(zone1);
+    verify(zoneAllocationResolver).findLeastLoadedEnvoy(zone1);
 
     // Verify the envoy ID was NOT be set for this
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "zone1", "r-1", null)
+        new BoundMonitorMatcher(monitor, "zone1", "r-1", null, null)
     );
 
     assertThat(affectedEnvoys, hasSize(0));
 
     // ...and no MonitorBoundEvent was sent
-    verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
+    verifyNoMoreInteractions(zoneStorage, monitorEventProducer, zoneAllocationResolver);
   }
 
   @Test
@@ -289,13 +293,13 @@ public class MonitorManagement_ZoneBindingsTest {
     final String tenantId = RandomStringUtils.randomAlphanumeric(10);
     final Monitor monitor = persistNewMonitor(tenantId, "z-1");
     // simulate that three in zone are needing envoys
-    persistBoundMonitor("r-1", "z-1", null, monitor);
-    persistBoundMonitor("r-2", "z-1", null, monitor);
-    persistBoundMonitor("r-3", "z-1", null, monitor);
+    persistBoundMonitor("r-1", "z-1", null, "poller-0", monitor);
+    persistBoundMonitor("r-2", "z-1", null, "poller-0", monitor);
+    persistBoundMonitor("r-3", "z-1", null, "poller-0", monitor);
 
-    when(zoneStorage.findLeastLoadedEnvoy(any()))
-        .thenReturn(CompletableFuture.completedFuture(
-            Optional.of(new EnvoyResourcePair().setEnvoyId("e-1").setResourceId("r-e-1"))));
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
+        .thenReturn(
+            Optional.of(new EnvoyResourcePair().setEnvoyId("e-1").setResourceId("r-e-1")));
 
     // EXECUTE
 
@@ -303,13 +307,8 @@ public class MonitorManagement_ZoneBindingsTest {
 
     // VERIFY
 
-    verify(zoneStorage, times(3)).findLeastLoadedEnvoy(
+    verify(zoneAllocationResolver, times(3)).findLeastLoadedEnvoy(
         createPrivateZone(tenantId, "z-1")
-    );
-
-    verify(zoneStorage, times(3)).incrementBoundCount(
-        createPrivateZone(tenantId, "z-1"),
-        "r-e-1"
     );
 
     // two assignments to same envoy, but verify only one event
@@ -318,12 +317,12 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "z-1", "r-1", "e-1"),
-        new BoundMonitorMatcher(monitor, "z-1", "r-2", "e-1"),
-        new BoundMonitorMatcher(monitor, "z-1", "r-3", "e-1")
+        new BoundMonitorMatcher(monitor, "z-1", "r-1", "e-1", "r-e-1"),
+        new BoundMonitorMatcher(monitor, "z-1", "r-2", "e-1", "r-e-1"),
+        new BoundMonitorMatcher(monitor, "z-1", "r-3", "e-1", "r-e-1")
     );
 
-    verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
+    verifyNoMoreInteractions(zoneStorage, monitorEventProducer, zoneAllocationResolver);
   }
 
   @Test
@@ -332,13 +331,13 @@ public class MonitorManagement_ZoneBindingsTest {
     final Monitor monitor = persistNewMonitor(
         tenantId, "public/west");
     // simulate that three in zone are needing envoys
-    persistBoundMonitor("r-1", "public/west", null, monitor);
-    persistBoundMonitor("r-2", "public/west", null, monitor);
-    persistBoundMonitor("r-3", "public/west", null, monitor);
+    persistBoundMonitor("r-1", "public/west", null, "poller-0", monitor);
+    persistBoundMonitor("r-2", "public/west", null, "poller-0", monitor);
+    persistBoundMonitor("r-3", "public/west", null, "poller-0", monitor);
 
-    when(zoneStorage.findLeastLoadedEnvoy(any()))
-        .thenReturn(CompletableFuture.completedFuture(
-            Optional.of(new EnvoyResourcePair().setEnvoyId("e-1").setResourceId("r-e-1"))));
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
+        .thenReturn(
+            Optional.of(new EnvoyResourcePair().setEnvoyId("e-1").setResourceId("r-e-1")));
 
     // EXECUTE
 
@@ -349,13 +348,8 @@ public class MonitorManagement_ZoneBindingsTest {
 
     // VERIFY
 
-    verify(zoneStorage, times(3)).findLeastLoadedEnvoy(
+    verify(zoneAllocationResolver, times(3)).findLeastLoadedEnvoy(
         createPublicZone("public/west")
-    );
-
-    verify(zoneStorage, times(3)).incrementBoundCount(
-        createPublicZone("public/west"),
-        "r-e-1"
     );
 
     // two assignments to same envoy, but verify only one event
@@ -364,81 +358,73 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "public/west", "r-1", "e-1"),
-        new BoundMonitorMatcher(monitor, "public/west", "r-2", "e-1"),
-        new BoundMonitorMatcher(monitor, "public/west", "r-3", "e-1")
+        new BoundMonitorMatcher(monitor, "public/west", "r-1", "e-1", "r-e-1"),
+        new BoundMonitorMatcher(monitor, "public/west", "r-2", "e-1", "r-e-1"),
+        new BoundMonitorMatcher(monitor, "public/west", "r-3", "e-1", "r-e-1")
     );
 
-    verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
+    verifyNoMoreInteractions(zoneStorage, monitorEventProducer, zoneAllocationResolver);
   }
 
   @Test
   public void testHandleZoneResourceChanged_privateZone() {
     final String tenantId = RandomStringUtils.randomAlphanumeric(10);
     final Monitor monitor = persistNewMonitor(tenantId, "z-1");
-    persistBoundMonitor("r-1", "z-1", "e-1", monitor);
-    persistBoundMonitor("r-2", "z-1", "e-1", monitor);
-    persistBoundMonitor("r-3", "z-1", "e-1", monitor);
+    persistBoundMonitor("r-1", "z-1", "e-1", "poller-0", monitor);
+    persistBoundMonitor("r-2", "z-1", "e-1", "poller-0", monitor);
+    persistBoundMonitor("r-3", "z-1", "e-1", "poller-0", monitor);
 
     // EXECUTE
 
     monitorManagement.handleEnvoyResourceChangedInZone(
-        tenantId, "z-1", "r-1", "e-1", "e-2");
+        tenantId, "z-1", "poller-new", "e-1", "e-new");
 
     // VERIFY
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "z-1", "r-1", "e-2"),
-        new BoundMonitorMatcher(monitor, "z-1", "r-2", "e-2"),
-        new BoundMonitorMatcher(monitor, "z-1", "r-3", "e-2")
-    );
-
-    verify(zoneStorage).changeBoundCount(
-        createPrivateZone(tenantId, "z-1"),
-        "r-1",
-        3
+        new BoundMonitorMatcher(monitor, "z-1", "r-1", "e-new", "poller-new"),
+        new BoundMonitorMatcher(monitor, "z-1", "r-2", "e-new", "poller-new"),
+        new BoundMonitorMatcher(monitor, "z-1", "r-3", "e-new", "poller-new")
     );
 
     verify(monitorEventProducer).sendMonitorEvent(new MonitorBoundEvent()
-        .setEnvoyId("e-2"));
+        .setEnvoyId("e-new"));
+    // NOTE: e-1 doesn't get notified since handleEnvoyResourceChangedInZone knows/assumes that one went away
 
-    verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
+    verifyNoMoreInteractions(zoneStorage, monitorEventProducer, zoneAllocationResolver);
   }
 
   @Test
   public void testHandleZoneResourceChanged_publicZone() {
     final String tenantId = RandomStringUtils.randomAlphanumeric(10);
     final Monitor monitor = persistNewMonitor(tenantId, "public/1");
-    persistBoundMonitor("r-1", "public/1", "e-1", monitor);
-    persistBoundMonitor("r-2", "public/1", "e-1", monitor);
-    persistBoundMonitor("r-3", "public/1", "e-1", monitor);
+    persistBoundMonitor("r-1", "public/1", "e-1", "poller-0", monitor);
+    persistBoundMonitor("r-2", "public/1", "e-1", "poller-0", monitor);
+    persistBoundMonitor("r-3", "public/1", "e-1", "poller-0", monitor);
 
     // EXECUTE
 
     // The main thing being tested is that a null zone tenant ID...
     monitorManagement.handleEnvoyResourceChangedInZone(
-        null, "public/1", "r-1", "e-1", "e-2");
+        null, "public/1", "poller-1", "e-1", "e-2");
 
     // VERIFY
-
-    verify(zoneStorage).changeBoundCount(
-        createPublicZone("public/1"),
-        "r-1",
-        3
-    );
 
     verify(monitorEventProducer).sendMonitorEvent(new MonitorBoundEvent()
         .setEnvoyId("e-2"));
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "public/1", "r-1", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-2", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-3", "e-2")
+        new BoundMonitorMatcher(
+            monitor, "public/1", "r-1", "e-2", "poller-1"),
+        new BoundMonitorMatcher(
+            monitor, "public/1", "r-2", "e-2", "poller-1"),
+        new BoundMonitorMatcher(
+            monitor, "public/1", "r-3", "e-2", "poller-1")
     );
 
-    verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
+    verifyNoMoreInteractions(zoneStorage, monitorEventProducer, zoneAllocationResolver);
   }
 
   /**
@@ -450,22 +436,22 @@ public class MonitorManagement_ZoneBindingsTest {
     final String tenantId = RandomStringUtils.randomAlphanumeric(10);
     final Monitor monitor = persistNewMonitor(tenantId, "public/1");
     // set up bound monitors that were previously bound to this envoy
-    persistBoundMonitor("r-1", "public/1", "e-1", monitor);
-    persistBoundMonitor("r-2", "public/1", "e-1", monitor);
-    persistBoundMonitor("r-3", "public/1", "e-1", monitor);
+    persistBoundMonitor("r-1", "public/1", "e-1", "poller-0", monitor);
+    persistBoundMonitor("r-2", "public/1", "e-1", "poller-0", monitor);
+    persistBoundMonitor("r-3", "public/1", "e-1", "poller-0", monitor);
 
     // set up bound monitors that have never been assigned to an envoy
     // using 4 to make clear where the numbers in the asserts below came from
-    persistBoundMonitor("r-4", "public/1", null, monitor);
-    persistBoundMonitor("r-5", "public/1", null, monitor);
-    persistBoundMonitor("r-6", "public/1", null, monitor);
-    persistBoundMonitor("r-7", "public/1", null, monitor);
+    persistBoundMonitor("r-4", "public/1", null, null, monitor);
+    persistBoundMonitor("r-5", "public/1", null, null, monitor);
+    persistBoundMonitor("r-6", "public/1", null, null, monitor);
+    persistBoundMonitor("r-7", "public/1", null, null, monitor);
 
-    when(zoneStorage.findLeastLoadedEnvoy(any()))
-        .thenReturn(CompletableFuture.completedFuture(
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
+        .thenReturn(
             Optional.of(new EnvoyResourcePair()
                 .setEnvoyId("e-2")
-                .setResourceId("poller-1"))));
+                .setResourceId("poller-1")));
 
     // EXECUTE
 
@@ -476,26 +462,25 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "public/1", "r-1", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-2", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-3", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-4", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-5", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-6", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-7", "e-2")
-    );
-
-    verify(zoneStorage).changeBoundCount(
-        createPublicZone("public/1"),
-        "poller-1",
-        3
+        new BoundMonitorMatcher(
+            monitor, "public/1", "r-1", "e-2", "poller-1"),
+        new BoundMonitorMatcher(
+            monitor, "public/1", "r-2", "e-2", "poller-1"),
+        new BoundMonitorMatcher(
+            monitor, "public/1", "r-3", "e-2", "poller-1"),
+        new BoundMonitorMatcher(
+            monitor, "public/1", "r-4", "e-2", "poller-1"),
+        new BoundMonitorMatcher(
+            monitor, "public/1", "r-5", "e-2", "poller-1"),
+        new BoundMonitorMatcher(
+            monitor, "public/1", "r-6", "e-2", "poller-1"),
+        new BoundMonitorMatcher(
+            monitor, "public/1", "r-7", "e-2", "poller-1")
     );
 
     // then verify that it picks up the other unbound monitors
-    verify(zoneStorage, times(4)).findLeastLoadedEnvoy(
+    verify(zoneAllocationResolver, times(4)).findLeastLoadedEnvoy(
         createPublicZone("public/1"));
-    verify(zoneStorage, times(4)).incrementBoundCount(
-        createPublicZone("public/1"), "poller-1");
 
     // one event for preexisting and one for unassigned monitors
     verify(monitorEventProducer, times(2)).sendMonitorEvent(
@@ -503,7 +488,7 @@ public class MonitorManagement_ZoneBindingsTest {
             .setEnvoyId("e-2")
     );
 
-    verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
+    verifyNoMoreInteractions(zoneStorage, monitorEventProducer, zoneAllocationResolver);
   }
 
   @Test
@@ -512,7 +497,7 @@ public class MonitorManagement_ZoneBindingsTest {
     rawCounts.put(new EnvoyResourcePair().setResourceId("r-1").setEnvoyId("e-1"), 5);
     rawCounts.put(new EnvoyResourcePair().setResourceId("r-2").setEnvoyId("e-2"), 6);
 
-    when(zoneStorage.getZoneBindingCounts(any()))
+    when(zoneAllocationResolver.getZoneBindingCounts(any()))
         .thenReturn(CompletableFuture.completedFuture(rawCounts));
 
     // EXECUTE
@@ -522,19 +507,18 @@ public class MonitorManagement_ZoneBindingsTest {
 
     // VERIFY
 
-    assertThat(counts, hasSize(2));
     assertThat(counts, containsInAnyOrder(
         new ZoneAssignmentCount().setResourceId("r-1").setEnvoyId("e-1").setAssignments(5),
         new ZoneAssignmentCount().setResourceId("r-2").setEnvoyId("e-2").setAssignments(6)
 
     ));
 
-    verify(zoneStorage).getZoneBindingCounts(
+    verify(zoneAllocationResolver).getZoneBindingCounts(
         ResolvedZone.createPrivateZone("t-1", "z-1")
     );
 
     verifyNoMoreInteractions(envoyResourceManagement,
-        zoneStorage, monitorEventProducer, resourceApi
+        zoneStorage, monitorEventProducer, resourceApi, zoneAllocationResolver
     );
   }
 
@@ -547,13 +531,13 @@ public class MonitorManagement_ZoneBindingsTest {
     final Monitor monitor = persistNewMonitor(tenantId, "z-1");
     Map<EnvoyResourcePair, Integer> counts = persistBindingsToRebalance(monitor, "z-1");
 
-    when(zoneStorage.getZoneBindingCounts(any()))
+    when(zoneAllocationResolver.getZoneBindingCounts(any()))
         .thenReturn(CompletableFuture.completedFuture(counts));
 
-    when(zoneStorage.findLeastLoadedEnvoy(any()))
-        .thenReturn(CompletableFuture.completedFuture(Optional.of(
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
+        .thenReturn(Optional.of(
             new EnvoyResourcePair().setResourceId("r-least").setEnvoyId("e-least")
-        )));
+        ));
 
     // EXECUTE
 
@@ -562,7 +546,7 @@ public class MonitorManagement_ZoneBindingsTest {
     // VERIFY
 
     final ResolvedZone zone = createPrivateZone(tenantId, "z-1");
-    verify(zoneStorage).getZoneBindingCounts(zone);
+    verify(zoneAllocationResolver).getZoneBindingCounts(zone);
 
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent().setEnvoyId("e-3")
@@ -571,13 +555,10 @@ public class MonitorManagement_ZoneBindingsTest {
         new MonitorBoundEvent().setEnvoyId("e-least")
     );
 
-    verify(zoneStorage, times(2)).findLeastLoadedEnvoy(zone);
-
-    verify(zoneStorage).changeBoundCount(zone, "poller-3", -2);
-    verify(zoneStorage, times(2)).incrementBoundCount(zone, "r-least");
+    verify(zoneAllocationResolver, times(2)).findLeastLoadedEnvoy(zone);
 
     verifyNoMoreInteractions(envoyResourceManagement,
-        zoneStorage, monitorEventProducer, resourceApi
+        zoneStorage, monitorEventProducer, resourceApi, zoneAllocationResolver
     );
   }
 
@@ -591,13 +572,13 @@ public class MonitorManagement_ZoneBindingsTest {
     Map<EnvoyResourcePair, Integer> counts = persistBindingsToRebalance(
         monitor, "public/west");
 
-    when(zoneStorage.getZoneBindingCounts(any()))
+    when(zoneAllocationResolver.getZoneBindingCounts(any()))
         .thenReturn(CompletableFuture.completedFuture(counts));
 
-    when(zoneStorage.findLeastLoadedEnvoy(any()))
-        .thenReturn(CompletableFuture.completedFuture(Optional.of(
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
+        .thenReturn(Optional.of(
             new EnvoyResourcePair().setResourceId("r-least").setEnvoyId("e-least")
-        )));
+        ));
 
     // EXECUTE
 
@@ -609,7 +590,7 @@ public class MonitorManagement_ZoneBindingsTest {
     assertThat(reassigned, equalTo(2));
 
     final ResolvedZone zone = createPublicZone("public/west");
-    verify(zoneStorage).getZoneBindingCounts(zone);
+    verify(zoneAllocationResolver).getZoneBindingCounts(zone);
 
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent().setEnvoyId("e-3")
@@ -618,13 +599,10 @@ public class MonitorManagement_ZoneBindingsTest {
         new MonitorBoundEvent().setEnvoyId("e-least")
     );
 
-    verify(zoneStorage, times(2)).findLeastLoadedEnvoy(zone);
-
-    verify(zoneStorage).changeBoundCount(zone, "poller-3", -2);
-    verify(zoneStorage, times(2)).incrementBoundCount(zone, "r-least");
+    verify(zoneAllocationResolver, times(2)).findLeastLoadedEnvoy(zone);
 
     verifyNoMoreInteractions(envoyResourceManagement,
-        zoneStorage, monitorEventProducer, resourceApi
+        zoneStorage, monitorEventProducer, resourceApi, zoneAllocationResolver
     );
   }
 
@@ -639,13 +617,13 @@ public class MonitorManagement_ZoneBindingsTest {
     final Map<EnvoyResourcePair, Integer> counts = persistBindingsToRebalance(
         monitor, "public/west");
 
-    when(zoneStorage.getZoneBindingCounts(any()))
+    when(zoneAllocationResolver.getZoneBindingCounts(any()))
         .thenReturn(CompletableFuture.completedFuture(counts));
 
-    when(zoneStorage.findLeastLoadedEnvoy(any()))
-        .thenReturn(CompletableFuture.completedFuture(Optional.of(
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
+        .thenReturn(Optional.of(
             new EnvoyResourcePair().setResourceId("r-least").setEnvoyId("e-least")
-        )));
+        ));
 
     // EXECUTE
 
@@ -657,7 +635,7 @@ public class MonitorManagement_ZoneBindingsTest {
     assertThat(reassigned, equalTo(3));
 
     final ResolvedZone zone = createPublicZone("public/west");
-    verify(zoneStorage).getZoneBindingCounts(zone);
+    verify(zoneAllocationResolver).getZoneBindingCounts(zone);
 
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent().setEnvoyId("e-3")
@@ -666,18 +644,16 @@ public class MonitorManagement_ZoneBindingsTest {
         new MonitorBoundEvent().setEnvoyId("e-least")
     );
 
-    verify(zoneStorage, times(3)).findLeastLoadedEnvoy(zone);
-
-    verify(zoneStorage).changeBoundCount(zone, "poller-3", -3);
-    verify(zoneStorage, times(3)).incrementBoundCount(zone, "r-least");
+    verify(zoneAllocationResolver, times(3)).findLeastLoadedEnvoy(zone);
 
     verifyNoMoreInteractions(
-        envoyResourceManagement, zoneStorage, monitorEventProducer, resourceApi);
+        envoyResourceManagement, zoneStorage, monitorEventProducer, resourceApi,
+        zoneAllocationResolver);
   }
 
   @Test
   public void testRebalanceZone_emptyZone() {
-    when(zoneStorage.getZoneBindingCounts(any()))
+    when(zoneAllocationResolver.getZoneBindingCounts(any()))
         .thenReturn(CompletableFuture.completedFuture(
             Collections.emptyMap()
         ));
@@ -691,10 +667,10 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertThat(reassigned, equalTo(0));
 
-    verify(zoneStorage).getZoneBindingCounts(ResolvedZone.createPrivateZone("t-1", "z-1"));
+    verify(zoneAllocationResolver).getZoneBindingCounts(ResolvedZone.createPrivateZone("t-1", "z-1"));
 
     verifyNoMoreInteractions(envoyResourceManagement,
-        zoneStorage, monitorEventProducer, resourceApi
+        zoneStorage, monitorEventProducer, resourceApi, zoneAllocationResolver
     );
   }
 
@@ -703,11 +679,7 @@ public class MonitorManagement_ZoneBindingsTest {
     final String tenantId = RandomStringUtils.randomAlphanumeric(10);
     final Monitor monitor = persistNewMonitor(tenantId, "z-1");
 
-    persistBoundMonitor("r-1", "z-1", "e-goner", monitor);
-
-    when(zoneStorage.getEnvoyIdToResourceIdMap(any()))
-        .thenReturn(
-            CompletableFuture.completedFuture(Collections.singletonMap("e-goner", "r-gone")));
+    persistBoundMonitor("r-1", "z-1", "e-goner", "poller-0", monitor);
 
     // EXECUTE
 
@@ -721,18 +693,12 @@ public class MonitorManagement_ZoneBindingsTest {
     // assert no bindings remain for given monitor
     assertBindings(monitor.getId());
 
-    verify(zoneStorage).decrementBoundCount(
-        ResolvedZone.createPrivateZone(tenantId, "z-1"),
-        "r-gone"
-    );
-    verify(zoneStorage).getEnvoyIdToResourceIdMap(ResolvedZone.createPrivateZone(tenantId, "z-1"));
-
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent()
             .setEnvoyId("e-goner")
     );
 
-    verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
+    verifyNoMoreInteractions(zoneStorage, monitorEventProducer, zoneAllocationResolver);
   }
 
   @Test
@@ -741,11 +707,7 @@ public class MonitorManagement_ZoneBindingsTest {
     final String tenantId = RandomStringUtils.randomAlphanumeric(10);
     final Monitor monitor = persistNewMonitor(tenantId, zoneName);
 
-    persistBoundMonitor("r-1", zoneName, "e-goner", monitor);
-
-    when(zoneStorage.getEnvoyIdToResourceIdMap(any()))
-        .thenReturn(
-            CompletableFuture.completedFuture(Collections.singletonMap("e-goner", "r-gone")));
+    persistBoundMonitor("r-1", zoneName, "e-goner", "poller-0", monitor);
 
     // EXECUTE
 
@@ -759,18 +721,12 @@ public class MonitorManagement_ZoneBindingsTest {
     // assert no bindings remain for given monitor
     assertBindings(monitor.getId());
 
-    verify(zoneStorage).decrementBoundCount(
-        ResolvedZone.createPublicZone(zoneName),
-        "r-gone"
-    );
-    verify(zoneStorage).getEnvoyIdToResourceIdMap(ResolvedZone.createPublicZone(zoneName));
-
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent()
             .setEnvoyId("e-goner")
     );
 
-    verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
+    verifyNoMoreInteractions(zoneStorage, monitorEventProducer, zoneAllocationResolver);
   }
 
   @Test
@@ -779,12 +735,8 @@ public class MonitorManagement_ZoneBindingsTest {
     final Monitor monitor1 = persistNewMonitor(tenantId, "z-1");
     final Monitor monitor2 = persistNewMonitor(tenantId, "z-1");
 
-    persistBoundMonitor("r-0", "z-1", "e-1", monitor1);
-    persistBoundMonitor("r-0", "z-1", "e-2", monitor2);
-
-    when(zoneStorage.getEnvoyIdToResourceIdMap(any()))
-        .thenReturn(CompletableFuture.completedFuture(Collections.singletonMap("e-1", "r-e-1")))
-        .thenReturn(CompletableFuture.completedFuture(Collections.singletonMap("e-2", "r-e-2")));
+    persistBoundMonitor("r-0", "z-1", "e-1", "poller-0", monitor1);
+    persistBoundMonitor("r-0", "z-1", "e-2", "poller-0", monitor2);
 
     // EXECUTE
 
@@ -795,16 +747,12 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertThat(affectedEnvoys, contains("e-1"));
 
-    final ResolvedZone resolvedZone = createPrivateZone(tenantId, "z-1");
-    verify(zoneStorage).decrementBoundCount(resolvedZone, "r-e-1");
-    verify(zoneStorage).getEnvoyIdToResourceIdMap(resolvedZone);
-
     assertBindings(
         monitor2.getId(),
-        new BoundMonitorMatcher(monitor2, "z-1", "r-0", "e-2")
+        new BoundMonitorMatcher(monitor2, "z-1", "r-0", "e-2", "poller-0")
     );
 
-    verifyNoMoreInteractions(zoneStorage);
+    verifyNoMoreInteractions(zoneStorage, zoneAllocationResolver);
   }
 
   @Test
@@ -817,18 +765,16 @@ public class MonitorManagement_ZoneBindingsTest {
                 .setResourceId("r-1")
         ));
 
-    EnvoyResourcePair pair = new EnvoyResourcePair().setEnvoyId("e-new").setResourceId("r-new-1");
-
-    when(zoneStorage.findLeastLoadedEnvoy(any()))
-        .thenReturn(CompletableFuture.completedFuture(Optional.of(pair)));
-    when(zoneStorage.incrementBoundCount(any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(1));
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
+        .thenReturn(Optional.of(
+            new EnvoyResourcePair().setEnvoyId("e-new").setResourceId("poller-new")
+        ));
 
     final Monitor monitor = persistNewMonitor(
         tenantId, Map.of("os", "linux"), List.of("z-1", "z-2"));
 
-    persistBoundMonitor("r-1", "z-1", "e-existing", monitor);
-    persistBoundMonitor("r-1", "z-2", "e-existing", monitor);
+    persistBoundMonitor("r-1", "z-1", "e-z-1-existing", "poller-z-1-0", monitor);
+    persistBoundMonitor("r-1", "z-2", "e-z-2-existing", "poller-z-2-0", monitor);
 
     List<Zone> zones = List.of(
         new Zone().setName("z-1"),
@@ -838,10 +784,6 @@ public class MonitorManagement_ZoneBindingsTest {
 
     when(zoneManagement.getAvailableZonesForTenant(any(), any()))
         .thenReturn(new PageImpl<>(zones, Pageable.unpaged(), zones.size()));
-
-    when(zoneStorage.getEnvoyIdToResourceIdMap(any()))
-        .thenReturn(
-            CompletableFuture.completedFuture(Collections.singletonMap("e-existing", "r-exist")));
 
     // EXECUTE
 
@@ -863,19 +805,16 @@ public class MonitorManagement_ZoneBindingsTest {
     );
 
     final ResolvedZone resolvedZ3 = createPrivateZone(tenantId, "z-3");
-    verify(zoneStorage).findLeastLoadedEnvoy(resolvedZ3);
-    verify(zoneStorage).incrementBoundCount(resolvedZ3, "r-new-1");
-    verify(zoneStorage).decrementBoundCount(createPrivateZone(tenantId, "z-1"), "r-exist");
-    verify(zoneStorage).getEnvoyIdToResourceIdMap(createPrivateZone(tenantId, "z-1"));
+    verify(zoneAllocationResolver).findLeastLoadedEnvoy(resolvedZ3);
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "z-2", "r-1", "e-existing"),
-        new BoundMonitorMatcher(monitor, "z-3", "r-1", "e-new")
+        new BoundMonitorMatcher(monitor, "z-2", "r-1", "e-z-2-existing", "poller-z-2-0"),
+        new BoundMonitorMatcher(monitor, "z-3", "r-1", "e-new", "poller-new")
     );
 
     verify(monitorEventProducer).sendMonitorEvent(
-        new MonitorBoundEvent().setEnvoyId("e-existing")
+        new MonitorBoundEvent().setEnvoyId("e-z-1-existing")
     );
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent().setEnvoyId("e-new")
@@ -884,17 +823,8 @@ public class MonitorManagement_ZoneBindingsTest {
     verify(zoneManagement).getAvailableZonesForTenant(tenantId, Pageable.unpaged());
 
     verifyNoMoreInteractions(envoyResourceManagement, resourceApi,
-        zoneStorage, monitorEventProducer, zoneManagement
+        zoneStorage, monitorEventProducer, zoneManagement, zoneAllocationResolver
     );
-  }
-
-  private void assertBindings(UUID monitorId, BoundMonitorMatcher... matchers) {
-    final List<BoundMonitor> results = boundMonitorRepository
-        .findAllByMonitor_Id(monitorId);
-
-    assertThat(results, hasSize(matchers.length));
-
-    assertThat(results, containsInAnyOrder(matchers));
   }
 
   @Test
@@ -928,7 +858,7 @@ public class MonitorManagement_ZoneBindingsTest {
     verify(zoneManagement).getAvailableZonesForTenant(tenantId, Pageable.unpaged());
 
     verifyNoMoreInteractions(envoyResourceManagement, resourceApi,
-        zoneStorage, monitorEventProducer, zoneManagement
+        zoneStorage, monitorEventProducer, zoneManagement, zoneAllocationResolver
     );
   }
 
@@ -969,8 +899,8 @@ public class MonitorManagement_ZoneBindingsTest {
     final String resourceId0 = resources.get(0).getResourceId();
     final String resourceId1 = resources.get(1).getResourceId();
 
-    persistBoundMonitor(resourceId0, originalZoneForResource, oldEnvoy1, monitor);
-    persistBoundMonitor(resourceId1, originalZoneForResource, oldEnvoy2, monitor);
+    persistBoundMonitor(resourceId0, originalZoneForResource, oldEnvoy1, "poller-0", monitor);
+    persistBoundMonitor(resourceId1, originalZoneForResource, oldEnvoy2, "poller-0", monitor);
 
     // DISCOVERY OPERATIONS
 
@@ -978,23 +908,12 @@ public class MonitorManagement_ZoneBindingsTest {
         .thenReturn(Optional.of(resources.get(0)))
         .thenReturn(Optional.of(resources.get(1)));
 
-    // UNBIND OPERATIONS
-
-    when(zoneStorage.getEnvoyIdToResourceIdMap(any()))
-        .thenReturn(CompletableFuture
-            .completedFuture(Collections.singletonMap(oldEnvoy1, "resourceValueDoesntMatter")))
-        .thenReturn(CompletableFuture
-            .completedFuture(Collections.singletonMap(oldEnvoy2, "resourceValueDoesntMatter")));
-
     // BIND OPERATIONS
 
-    when(zoneStorage.findLeastLoadedEnvoy(any()))
-        .thenReturn(CompletableFuture.completedFuture(
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
+        .thenReturn(
             Optional.of(
-                new EnvoyResourcePair().setEnvoyId(newEnvoy).setResourceId("new-envoy-resource"))));
-
-    when(zoneStorage.incrementBoundCount(any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(1));
+                new EnvoyResourcePair().setEnvoyId(newEnvoy).setResourceId("new-envoy-resource")));
 
     ResourceInfo info = new ResourceInfo();
     when(envoyResourceManagement.getOne(any(), any()))
@@ -1018,16 +937,15 @@ public class MonitorManagement_ZoneBindingsTest {
 
     // verify bind operations / each operation is performed once per resource
     ResolvedZone newResolvedZone = ResolvedZone.createPublicZone("public/newZone");
-    verify(zoneStorage, times(2)).findLeastLoadedEnvoy(newResolvedZone);
-    verify(zoneStorage, times(2)).incrementBoundCount(newResolvedZone, "new-envoy-resource");
+    verify(zoneAllocationResolver, times(2)).findLeastLoadedEnvoy(newResolvedZone);
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "public/newZone", resourceId0, newEnvoy),
-        new BoundMonitorMatcher(monitor, "public/newZone", resourceId1, newEnvoy)
+        new BoundMonitorMatcher(monitor, "public/newZone", resourceId0, newEnvoy, "new-envoy-resource"),
+        new BoundMonitorMatcher(monitor, "public/newZone", resourceId1, newEnvoy, "new-envoy-resource")
     );
 
-    verifyNoMoreInteractions(resourceRepository);
+    verifyNoMoreInteractions(resourceRepository, zoneAllocationResolver);
   }
 
   /**
@@ -1072,9 +990,9 @@ public class MonitorManagement_ZoneBindingsTest {
     final String resourceId1 = resources.get(1).getResourceId();
     List<BoundMonitor> originalBoundMonitors = List.of(
         persistBoundMonitor(
-            resourceId0, originalZones.get(0), oldEnvoy1, monitor),
+            resourceId0, originalZones.get(0), oldEnvoy1, "poller-0", monitor),
         persistBoundMonitor(
-            resourceId1, originalZones.get(0), oldEnvoy2, monitor)
+            resourceId1, originalZones.get(0), oldEnvoy2, "poller-0", monitor)
     );
 
     // DISCOVERY OPERATIONS
@@ -1090,23 +1008,13 @@ public class MonitorManagement_ZoneBindingsTest {
         .getDefaultMonitoringZones(resources.get(1).getMetadata().get(REGION_METADATA), true))
         .thenReturn(newZones2);
 
-    // UNBIND OPERATIONS
-
-    when(zoneStorage.getEnvoyIdToResourceIdMap(any()))
-        .thenReturn(CompletableFuture
-            .completedFuture(Collections.singletonMap(oldEnvoy1, "resourceValueDoesntMatter")))
-        .thenReturn(CompletableFuture
-            .completedFuture(Collections.singletonMap(oldEnvoy2, "resourceValueDoesntMatter")));
-
     // BIND OPERATIONS
 
-    when(zoneStorage.findLeastLoadedEnvoy(any()))
-        .thenReturn(CompletableFuture.completedFuture(
+    when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
+        .thenReturn(
             Optional.of(
-                new EnvoyResourcePair().setEnvoyId(newEnvoy).setResourceId("new-envoy-resource"))));
+                new EnvoyResourcePair().setEnvoyId(newEnvoy).setResourceId("new-envoy-resource")));
 
-    when(zoneStorage.incrementBoundCount(any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(1));
     ResourceInfo info = new ResourceInfo();
     when(envoyResourceManagement.getOne(any(), any()))
         .thenReturn(CompletableFuture.completedFuture(info));
@@ -1129,20 +1037,25 @@ public class MonitorManagement_ZoneBindingsTest {
     verify(policyApi).getDefaultMonitoringZones("testRegion1", true);
     verify(policyApi).getDefaultMonitoringZones("testRegion2", true);
 
+    verify(zoneAllocationResolver).findLeastLoadedEnvoy(resolveZone(null, newZones1.get(0)));
+    verify(zoneAllocationResolver).findLeastLoadedEnvoy(resolveZone(null, newZones1.get(1)));
+    verify(zoneAllocationResolver).findLeastLoadedEnvoy(resolveZone(null, newZones2.get(0)));
+    verify(zoneAllocationResolver).findLeastLoadedEnvoy(resolveZone(null, newZones2.get(1)));
+
     Set<String> allNewZones = new HashSet<>();
     allNewZones.addAll(newZones1);
     allNewZones.addAll(newZones2);
     
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, newZones1.get(0), resourceId0, newEnvoy),
-        new BoundMonitorMatcher(monitor, newZones1.get(1), resourceId0, newEnvoy),
-        new BoundMonitorMatcher(monitor, newZones2.get(0), resourceId1, newEnvoy),
-        new BoundMonitorMatcher(monitor, newZones2.get(1), resourceId1, newEnvoy)
+        new BoundMonitorMatcher(monitor, newZones1.get(0), resourceId0, newEnvoy, "new-envoy-resource"),
+        new BoundMonitorMatcher(monitor, newZones1.get(1), resourceId0, newEnvoy, "new-envoy-resource"),
+        new BoundMonitorMatcher(monitor, newZones2.get(0), resourceId1, newEnvoy, "new-envoy-resource"),
+        new BoundMonitorMatcher(monitor, newZones2.get(1), resourceId1, newEnvoy, "new-envoy-resource")
     );
 
     verifyNoMoreInteractions(envoyResourceManagement, resourceApi,
-        monitorEventProducer, zoneManagement
+        monitorEventProducer, zoneManagement, zoneAllocationResolver
     );
   }
 
@@ -1158,15 +1071,11 @@ public class MonitorManagement_ZoneBindingsTest {
     Monitor monitor = persistNewMonitor(tenantId, "public/z-1");
 
     BoundMonitor orphanedBoundMonitor =
-        persistBoundMonitor(resourceId, "public/z-1", "e-1", monitor);
+        persistBoundMonitor(resourceId, "public/z-1", "e-1", "poller-0", monitor);
 
     // return no resource for an orphaned bound monitor
     when(resourceRepository.findByTenantIdAndResourceId(anyString(), anyString()))
         .thenReturn(Optional.empty());
-
-    when(zoneStorage.getEnvoyIdToResourceIdMap(any()))
-        .thenReturn(CompletableFuture
-            .completedFuture(Collections.singletonMap("e-1", "resourceValueDoesntMatter")));
 
     // EXECUTE
 
@@ -1180,13 +1089,11 @@ public class MonitorManagement_ZoneBindingsTest {
     verify(resourceRepository).findByTenantIdAndResourceId(tenantId, resourceId);
 
     final ResolvedZone resolvedZone = createPublicZone("public/z-1");
-    verify(zoneStorage).getEnvoyIdToResourceIdMap(resolvedZone);
-    verify(zoneStorage).decrementBoundCount(resolvedZone, "resourceValueDoesntMatter");
 
     // assert no bindings remain
     assertBindings(monitor.getId());
 
-    verifyNoMoreInteractions(zoneStorage, resourceRepository);
+    verifyNoMoreInteractions(zoneStorage, resourceRepository, zoneAllocationResolver);
   }
 
   private Monitor persistNewMonitor(String tenantId, String zoneName) {
@@ -1226,6 +1133,7 @@ public class MonitorManagement_ZoneBindingsTest {
                     .setMonitor(monitor)
                     .setTenantId(monitor.getTenantId())
                     .setEnvoyId(pollerEnvoyId)
+                    .setPollerResourceId(pollerResourceId)
                     .setZoneName(zoneName)
                     .setResourceId(String.format("r-%d", i))
             )
@@ -1235,13 +1143,14 @@ public class MonitorManagement_ZoneBindingsTest {
 
   private BoundMonitor persistBoundMonitor(String resourceId, String zoneName,
                                            String pollerEnvoyId,
-                                           Monitor monitor) {
+                                           String pollerResourceId, Monitor monitor) {
     return boundMonitorRepository.save(
         new BoundMonitor()
             .setTenantId(monitor.getTenantId())
             .setResourceId(resourceId)
             .setZoneName(zoneName)
             .setEnvoyId(pollerEnvoyId)
+            .setPollerResourceId(pollerResourceId)
             .setMonitor(monitor)
             .setRenderedContent("{}")
     );
@@ -1264,6 +1173,13 @@ public class MonitorManagement_ZoneBindingsTest {
     counts.put(new EnvoyResourcePair().setResourceId("poller-4").setEnvoyId("e-4"), 2);
     persistBoundMonitors(2, zoneName, "e-4", "poller-4", monitor);
     return counts;
+  }
+
+  private void assertBindings(UUID monitorId, BoundMonitorMatcher... matchers) {
+    final List<BoundMonitor> results = boundMonitorRepository
+        .findAllByMonitor_Id(monitorId);
+
+    assertThat(results, containsInAnyOrder(matchers));
   }
 
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
@@ -213,10 +213,10 @@ public class MonitorManagement_ZoneBindingsTest {
     // VERIFY
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "zone1", "r-1", "zone1-e-1"),
-        new BoundMonitorMatcher(monitor, "public/west", "r-1", "zoneWest-e-2"),
-        new BoundMonitorMatcher(monitor, "zone1", "r-2", "zone1-e-1"),
-        new BoundMonitorMatcher(monitor, "public/west", "r-2", "zoneWest-e-2")
+        new BoundMonitorMatcher("t-1", "zone1", "r-1", "zone1-e-1"),
+        new BoundMonitorMatcher("t-1", "public/west", "r-1", "zoneWest-e-2"),
+        new BoundMonitorMatcher("t-1", "zone1", "r-2", "zone1-e-1"),
+        new BoundMonitorMatcher("t-1", "public/west", "r-2", "zoneWest-e-2")
     );
 
     assertThat(affectedEnvoys, containsInAnyOrder("zone1-e-1", "zoneWest-e-2"));
@@ -275,7 +275,7 @@ public class MonitorManagement_ZoneBindingsTest {
     // Verify the envoy ID was NOT be set for this
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "zone1", "r-1", null)
+        new BoundMonitorMatcher(tenantId, "zone1", "r-1", null)
     );
 
     assertThat(affectedEnvoys, hasSize(0));
@@ -318,9 +318,9 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "z-1", "r-1", "e-1"),
-        new BoundMonitorMatcher(monitor, "z-1", "r-2", "e-1"),
-        new BoundMonitorMatcher(monitor, "z-1", "r-3", "e-1")
+        new BoundMonitorMatcher(tenantId, "z-1", "r-1", "e-1"),
+        new BoundMonitorMatcher(tenantId, "z-1", "r-2", "e-1"),
+        new BoundMonitorMatcher(tenantId, "z-1", "r-3", "e-1")
     );
 
     verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
@@ -364,9 +364,9 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "public/west", "r-1", "e-1"),
-        new BoundMonitorMatcher(monitor, "public/west", "r-2", "e-1"),
-        new BoundMonitorMatcher(monitor, "public/west", "r-3", "e-1")
+        new BoundMonitorMatcher(tenantId, "public/west", "r-1", "e-1"),
+        new BoundMonitorMatcher(tenantId, "public/west", "r-2", "e-1"),
+        new BoundMonitorMatcher(tenantId, "public/west", "r-3", "e-1")
     );
 
     verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
@@ -389,9 +389,9 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "z-1", "r-1", "e-2"),
-        new BoundMonitorMatcher(monitor, "z-1", "r-2", "e-2"),
-        new BoundMonitorMatcher(monitor, "z-1", "r-3", "e-2")
+        new BoundMonitorMatcher(tenantId, "z-1", "r-1", "e-2"),
+        new BoundMonitorMatcher(tenantId, "z-1", "r-2", "e-2"),
+        new BoundMonitorMatcher(tenantId, "z-1", "r-3", "e-2")
     );
 
     verify(zoneStorage).changeBoundCount(
@@ -433,9 +433,9 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "public/1", "r-1", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-2", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-3", "e-2")
+        new BoundMonitorMatcher(tenantId, "public/1", "r-1", "e-2"),
+        new BoundMonitorMatcher(tenantId, "public/1", "r-2", "e-2"),
+        new BoundMonitorMatcher(tenantId, "public/1", "r-3", "e-2")
     );
 
     verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
@@ -476,13 +476,13 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "public/1", "r-1", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-2", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-3", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-4", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-5", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-6", "e-2"),
-        new BoundMonitorMatcher(monitor, "public/1", "r-7", "e-2")
+        new BoundMonitorMatcher(tenantId, "public/1", "r-1", "e-2"),
+        new BoundMonitorMatcher(tenantId, "public/1", "r-2", "e-2"),
+        new BoundMonitorMatcher(tenantId, "public/1", "r-3", "e-2"),
+        new BoundMonitorMatcher(tenantId, "public/1", "r-4", "e-2"),
+        new BoundMonitorMatcher(tenantId, "public/1", "r-5", "e-2"),
+        new BoundMonitorMatcher(tenantId, "public/1", "r-6", "e-2"),
+        new BoundMonitorMatcher(tenantId, "public/1", "r-7", "e-2")
     );
 
     verify(zoneStorage).changeBoundCount(
@@ -801,7 +801,7 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor2.getId(),
-        new BoundMonitorMatcher(monitor2, "z-1", "r-0", "e-2")
+        new BoundMonitorMatcher(tenantId, "z-1", "r-0", "e-2")
     );
 
     verifyNoMoreInteractions(zoneStorage);
@@ -870,8 +870,8 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "z-2", "r-1", "e-existing"),
-        new BoundMonitorMatcher(monitor, "z-3", "r-1", "e-new")
+        new BoundMonitorMatcher(tenantId, "z-2", "r-1", "e-existing"),
+        new BoundMonitorMatcher(tenantId, "z-3", "r-1", "e-new")
     );
 
     verify(monitorEventProducer).sendMonitorEvent(
@@ -1023,8 +1023,8 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, "public/newZone", resourceId0, newEnvoy),
-        new BoundMonitorMatcher(monitor, "public/newZone", resourceId1, newEnvoy)
+        new BoundMonitorMatcher(tenantId, "public/newZone", resourceId0, newEnvoy),
+        new BoundMonitorMatcher(tenantId, "public/newZone", resourceId1, newEnvoy)
     );
 
     verifyNoMoreInteractions(resourceRepository);
@@ -1135,10 +1135,10 @@ public class MonitorManagement_ZoneBindingsTest {
     
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(monitor, newZones1.get(0), resourceId0, newEnvoy),
-        new BoundMonitorMatcher(monitor, newZones1.get(1), resourceId0, newEnvoy),
-        new BoundMonitorMatcher(monitor, newZones2.get(0), resourceId1, newEnvoy),
-        new BoundMonitorMatcher(monitor, newZones2.get(1), resourceId1, newEnvoy)
+        new BoundMonitorMatcher(tenantId, newZones1.get(0), resourceId0, newEnvoy),
+        new BoundMonitorMatcher(tenantId, newZones1.get(1), resourceId0, newEnvoy),
+        new BoundMonitorMatcher(tenantId, newZones2.get(0), resourceId1, newEnvoy),
+        new BoundMonitorMatcher(tenantId, newZones2.get(1), resourceId1, newEnvoy)
     );
 
     verifyNoMoreInteractions(envoyResourceManagement, resourceApi,
@@ -1226,6 +1226,7 @@ public class MonitorManagement_ZoneBindingsTest {
                     .setMonitor(monitor)
                     .setTenantId(monitor.getTenantId())
                     .setEnvoyId(pollerEnvoyId)
+                    .setPollerResourceId(pollerResourceId)
                     .setZoneName(zoneName)
                     .setResourceId(String.format("r-%d", i))
             )

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
@@ -213,10 +213,10 @@ public class MonitorManagement_ZoneBindingsTest {
     // VERIFY
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher("t-1", "zone1", "r-1", "zone1-e-1"),
-        new BoundMonitorMatcher("t-1", "public/west", "r-1", "zoneWest-e-2"),
-        new BoundMonitorMatcher("t-1", "zone1", "r-2", "zone1-e-1"),
-        new BoundMonitorMatcher("t-1", "public/west", "r-2", "zoneWest-e-2")
+        new BoundMonitorMatcher(monitor, "zone1", "r-1", "zone1-e-1"),
+        new BoundMonitorMatcher(monitor, "public/west", "r-1", "zoneWest-e-2"),
+        new BoundMonitorMatcher(monitor, "zone1", "r-2", "zone1-e-1"),
+        new BoundMonitorMatcher(monitor, "public/west", "r-2", "zoneWest-e-2")
     );
 
     assertThat(affectedEnvoys, containsInAnyOrder("zone1-e-1", "zoneWest-e-2"));
@@ -275,7 +275,7 @@ public class MonitorManagement_ZoneBindingsTest {
     // Verify the envoy ID was NOT be set for this
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(tenantId, "zone1", "r-1", null)
+        new BoundMonitorMatcher(monitor, "zone1", "r-1", null)
     );
 
     assertThat(affectedEnvoys, hasSize(0));
@@ -318,9 +318,9 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(tenantId, "z-1", "r-1", "e-1"),
-        new BoundMonitorMatcher(tenantId, "z-1", "r-2", "e-1"),
-        new BoundMonitorMatcher(tenantId, "z-1", "r-3", "e-1")
+        new BoundMonitorMatcher(monitor, "z-1", "r-1", "e-1"),
+        new BoundMonitorMatcher(monitor, "z-1", "r-2", "e-1"),
+        new BoundMonitorMatcher(monitor, "z-1", "r-3", "e-1")
     );
 
     verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
@@ -364,9 +364,9 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(tenantId, "public/west", "r-1", "e-1"),
-        new BoundMonitorMatcher(tenantId, "public/west", "r-2", "e-1"),
-        new BoundMonitorMatcher(tenantId, "public/west", "r-3", "e-1")
+        new BoundMonitorMatcher(monitor, "public/west", "r-1", "e-1"),
+        new BoundMonitorMatcher(monitor, "public/west", "r-2", "e-1"),
+        new BoundMonitorMatcher(monitor, "public/west", "r-3", "e-1")
     );
 
     verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
@@ -389,9 +389,9 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(tenantId, "z-1", "r-1", "e-2"),
-        new BoundMonitorMatcher(tenantId, "z-1", "r-2", "e-2"),
-        new BoundMonitorMatcher(tenantId, "z-1", "r-3", "e-2")
+        new BoundMonitorMatcher(monitor, "z-1", "r-1", "e-2"),
+        new BoundMonitorMatcher(monitor, "z-1", "r-2", "e-2"),
+        new BoundMonitorMatcher(monitor, "z-1", "r-3", "e-2")
     );
 
     verify(zoneStorage).changeBoundCount(
@@ -433,9 +433,9 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(tenantId, "public/1", "r-1", "e-2"),
-        new BoundMonitorMatcher(tenantId, "public/1", "r-2", "e-2"),
-        new BoundMonitorMatcher(tenantId, "public/1", "r-3", "e-2")
+        new BoundMonitorMatcher(monitor, "public/1", "r-1", "e-2"),
+        new BoundMonitorMatcher(monitor, "public/1", "r-2", "e-2"),
+        new BoundMonitorMatcher(monitor, "public/1", "r-3", "e-2")
     );
 
     verifyNoMoreInteractions(zoneStorage, monitorEventProducer);
@@ -476,13 +476,13 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(tenantId, "public/1", "r-1", "e-2"),
-        new BoundMonitorMatcher(tenantId, "public/1", "r-2", "e-2"),
-        new BoundMonitorMatcher(tenantId, "public/1", "r-3", "e-2"),
-        new BoundMonitorMatcher(tenantId, "public/1", "r-4", "e-2"),
-        new BoundMonitorMatcher(tenantId, "public/1", "r-5", "e-2"),
-        new BoundMonitorMatcher(tenantId, "public/1", "r-6", "e-2"),
-        new BoundMonitorMatcher(tenantId, "public/1", "r-7", "e-2")
+        new BoundMonitorMatcher(monitor, "public/1", "r-1", "e-2"),
+        new BoundMonitorMatcher(monitor, "public/1", "r-2", "e-2"),
+        new BoundMonitorMatcher(monitor, "public/1", "r-3", "e-2"),
+        new BoundMonitorMatcher(monitor, "public/1", "r-4", "e-2"),
+        new BoundMonitorMatcher(monitor, "public/1", "r-5", "e-2"),
+        new BoundMonitorMatcher(monitor, "public/1", "r-6", "e-2"),
+        new BoundMonitorMatcher(monitor, "public/1", "r-7", "e-2")
     );
 
     verify(zoneStorage).changeBoundCount(
@@ -801,7 +801,7 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor2.getId(),
-        new BoundMonitorMatcher(tenantId, "z-1", "r-0", "e-2")
+        new BoundMonitorMatcher(monitor2, "z-1", "r-0", "e-2")
     );
 
     verifyNoMoreInteractions(zoneStorage);
@@ -870,8 +870,8 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(tenantId, "z-2", "r-1", "e-existing"),
-        new BoundMonitorMatcher(tenantId, "z-3", "r-1", "e-new")
+        new BoundMonitorMatcher(monitor, "z-2", "r-1", "e-existing"),
+        new BoundMonitorMatcher(monitor, "z-3", "r-1", "e-new")
     );
 
     verify(monitorEventProducer).sendMonitorEvent(
@@ -1023,8 +1023,8 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(tenantId, "public/newZone", resourceId0, newEnvoy),
-        new BoundMonitorMatcher(tenantId, "public/newZone", resourceId1, newEnvoy)
+        new BoundMonitorMatcher(monitor, "public/newZone", resourceId0, newEnvoy),
+        new BoundMonitorMatcher(monitor, "public/newZone", resourceId1, newEnvoy)
     );
 
     verifyNoMoreInteractions(resourceRepository);
@@ -1135,10 +1135,10 @@ public class MonitorManagement_ZoneBindingsTest {
     
     assertBindings(
         monitor.getId(),
-        new BoundMonitorMatcher(tenantId, newZones1.get(0), resourceId0, newEnvoy),
-        new BoundMonitorMatcher(tenantId, newZones1.get(1), resourceId0, newEnvoy),
-        new BoundMonitorMatcher(tenantId, newZones2.get(0), resourceId1, newEnvoy),
-        new BoundMonitorMatcher(tenantId, newZones2.get(1), resourceId1, newEnvoy)
+        new BoundMonitorMatcher(monitor, newZones1.get(0), resourceId0, newEnvoy),
+        new BoundMonitorMatcher(monitor, newZones1.get(1), resourceId0, newEnvoy),
+        new BoundMonitorMatcher(monitor, newZones2.get(0), resourceId1, newEnvoy),
+        new BoundMonitorMatcher(monitor, newZones2.get(1), resourceId1, newEnvoy)
     );
 
     verifyNoMoreInteractions(envoyResourceManagement, resourceApi,

--- a/src/test/java/com/rackspace/salus/monitor_management/services/TestMonitorServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/TestMonitorServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.monitor_management.services;
 
+import static com.rackspace.salus.telemetry.etcd.types.ResolvedZone.resolveZone;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -38,6 +39,7 @@ import com.rackspace.salus.monitor_management.web.model.telegraf.Ping;
 import com.rackspace.salus.policy.manage.web.client.PolicyApi;
 import com.rackspace.salus.telemetry.entities.Resource;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
+import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
 import com.rackspace.salus.telemetry.messaging.TestMonitorRequestEvent;
 import com.rackspace.salus.telemetry.messaging.TestMonitorResultsEvent;
 import com.rackspace.salus.telemetry.model.AgentType;
@@ -377,8 +379,8 @@ public class TestMonitorServiceTest {
     when(monitorManagement.determineMonitoringZones(any(), (String) any()))
         .then(invocationOnMock -> invocationOnMock.getArgument(0));
 
-    when(monitorManagement.findLeastLoadedEnvoyInZone(any(), any()))
-        .thenReturn("e-1");
+    when(monitorManagement.findLeastLoadedEnvoyInZone(any()))
+        .thenReturn(Optional.of(new EnvoyResourcePair().setEnvoyId("e-1")));
 
     when(monitorContentRenderer.render(any(), any()))
         .thenReturn("rendered-1");
@@ -448,7 +450,7 @@ public class TestMonitorServiceTest {
     }));
 
     verify(monitorManagement).determineMonitoringZones(monitoringZones, null);
-    verify(monitorManagement).findLeastLoadedEnvoyInZone("t-1", "z-1");
+    verify(monitorManagement).findLeastLoadedEnvoyInZone(resolveZone("t-1", "z-1"));
 
     verifyNoMoreInteractions(
         monitorConversionService, monitorContentRenderer, resourceRepository,
@@ -558,8 +560,8 @@ public class TestMonitorServiceTest {
         .then(invocationOnMock -> invocationOnMock.getArgument(0));
 
     //noinspection ConstantConditions
-    when(monitorManagement.findLeastLoadedEnvoyInZone(any(), any()))
-        .thenReturn(envoyId);
+    when(monitorManagement.findLeastLoadedEnvoyInZone(any()))
+        .thenReturn(Optional.empty());
 
     // EXECUTE
 
@@ -590,7 +592,7 @@ public class TestMonitorServiceTest {
     verify(resourceRepository).findByTenantIdAndResourceId("t-1", "r-1");
 
     verify(monitorManagement).determineMonitoringZones(monitoringZones, null);
-    verify(monitorManagement).findLeastLoadedEnvoyInZone("t-1", "z-1");
+    verify(monitorManagement).findLeastLoadedEnvoyInZone(resolveZone("t-1", "z-1"));
 
     verifyNoMoreInteractions(
         monitorConversionService, monitorContentRenderer, resourceRepository,

--- a/src/test/java/com/rackspace/salus/monitor_management/services/TestMonitorServiceTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/TestMonitorServiceTest.java
@@ -539,7 +539,6 @@ public class TestMonitorServiceTest {
   public void testPerformTestMonitorOnResource_remote_noEnvoyInZone()
       throws InterruptedException, ExecutionException, TimeoutException {
     final List<String> monitoringZones = List.of("z-1");
-    final String envoyId = null;
 
     MonitorCU monitorCU = new MonitorCU()
         .setAgentType(AgentType.TELEGRAF)

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolverTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolverTest.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.monitor_management.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
+
+import com.rackspace.salus.monitor_management.config.DatabaseConfig;
+import com.rackspace.salus.telemetry.entities.BoundMonitor;
+import com.rackspace.salus.telemetry.entities.Monitor;
+import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
+import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
+import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
+import com.rackspace.salus.telemetry.model.AgentType;
+import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
+import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@EnableTestContainersDatabase
+@DataJpaTest(showSql = false)
+public class ZoneAllocationResolverTest {
+
+  /**
+   * Provides minimal app context config mainly to avoid picking up Spring Boot configs like
+   * TelemetryCoreEtcdModule.
+   */
+  @Configuration
+  @Import({
+      DatabaseConfig.class,
+      ZoneAllocationResolver.class,
+  })
+  public static class TestConfig { }
+
+  @MockBean
+  ZoneStorage zoneStorage;
+
+  @Autowired
+  ZoneAllocationResolver zoneAllocationResolver;
+
+  @Autowired
+  MonitorRepository monitorRepository;
+
+  @Autowired
+  BoundMonitorRepository boundMonitorRepository;
+
+  @After
+  public void tearDown() throws Exception {
+    boundMonitorRepository.deleteAll();
+    monitorRepository.deleteAll();
+  }
+
+  @Test
+  public void testFindLeastLoadedEnvoy_noneActive_noneBound() {
+    final String tenantId = randomAlphanumeric(10);
+    final ResolvedZone zone = ResolvedZone.resolveZone(tenantId, randomAlphanumeric(5));
+
+    when(zoneStorage.getActivePollerResourceIdsInZone(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of()));
+
+    when(zoneStorage.getResourceIdToEnvoyIdMap(any()))
+        .thenReturn(CompletableFuture.completedFuture(Map.of()));
+
+    // EXECUTE
+
+    final Optional<EnvoyResourcePair> result = zoneAllocationResolver
+        .findLeastLoadedEnvoy(zone);
+
+    // VERIFY
+
+    assertThat(result).isEmpty();
+
+    verify(zoneStorage).getActivePollerResourceIdsInZone(zone);
+    verify(zoneStorage).getResourceIdToEnvoyIdMap(zone);
+
+    verifyNoMoreInteractions(zoneStorage);
+  }
+
+  @Test
+  public void testFindLeastLoadedEnvoy_oneEmpty_noneBound() {
+    final String tenantId = randomAlphanumeric(10);
+    final ResolvedZone zone = ResolvedZone.resolveZone(tenantId, randomAlphanumeric(5));
+
+    when(zoneStorage.getActivePollerResourceIdsInZone(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of("poller-1")));
+
+    when(zoneStorage.getResourceIdToEnvoyIdMap(any()))
+        .thenReturn(CompletableFuture.completedFuture(Map.of("poller-1", "e-1")));
+
+    // EXECUTE
+
+    final Optional<EnvoyResourcePair> result = zoneAllocationResolver.findLeastLoadedEnvoy(zone);
+
+    // VERIFY
+
+    assertThat(result).isNotEmpty();
+    assertThat(result).get()
+        .isEqualTo(new EnvoyResourcePair().setResourceId("poller-1").setEnvoyId("e-1"));
+
+    verify(zoneStorage).getActivePollerResourceIdsInZone(zone);
+    verify(zoneStorage).getResourceIdToEnvoyIdMap(zone);
+
+    verifyNoMoreInteractions(zoneStorage);
+  }
+
+  @Test
+  public void testFindLeastLoadedEnvoy_someEmpty_someBound() {
+    final String tenantId = randomAlphanumeric(10);
+    final ResolvedZone zone = ResolvedZone.resolveZone(tenantId, randomAlphanumeric(5));
+
+    when(zoneStorage.getActivePollerResourceIdsInZone(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of("poller-1", "poller-2", "poller-3")));
+
+    when(zoneStorage.getResourceIdToEnvoyIdMap(any()))
+        .thenReturn(CompletableFuture.completedFuture(Map.of(
+            "poller-1", "e-1",
+            "poller-2", "e-2",
+            "poller-3", "e-3"
+        )));
+
+    final Monitor monitor = persistNewMonitor(tenantId, Map.of(), List.of(zone.getName()));
+    persistBoundMonitors(2, zone.getName(), "e-1", "poller-1", monitor);
+    // poller-2 will be the empty one
+    persistBoundMonitors(1, zone.getName(), "e-3", "poller-3", monitor);
+
+    // EXECUTE
+
+    final Optional<EnvoyResourcePair> result = zoneAllocationResolver.findLeastLoadedEnvoy(zone);
+
+    // VERIFY
+
+    assertThat(result).isNotEmpty();
+    assertThat(result).get()
+        .isEqualTo(new EnvoyResourcePair().setResourceId("poller-2").setEnvoyId("e-2"));
+
+    verify(zoneStorage).getActivePollerResourceIdsInZone(zone);
+    verify(zoneStorage).getResourceIdToEnvoyIdMap(zone);
+
+    verifyNoMoreInteractions(zoneStorage);
+  }
+
+  @Test
+  public void testFindLeastLoadedEnvoy_noneEmpty_someBound() {
+    final String tenantId = randomAlphanumeric(10);
+    final ResolvedZone zone = ResolvedZone.resolveZone(tenantId, randomAlphanumeric(5));
+
+    when(zoneStorage.getActivePollerResourceIdsInZone(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of("poller-1", "poller-2", "poller-3")));
+
+    when(zoneStorage.getResourceIdToEnvoyIdMap(any()))
+        .thenReturn(CompletableFuture.completedFuture(Map.of(
+            "poller-1", "e-1",
+            "poller-2", "e-2",
+            "poller-3", "e-3"
+        )));
+
+    final Monitor monitor = persistNewMonitor(tenantId, Map.of(), List.of(zone.getName()));
+    persistBoundMonitors(2, zone.getName(), "e-1", "poller-1", monitor);
+    persistBoundMonitors(3, zone.getName(), "e-2", "poller-2", monitor);
+    persistBoundMonitors(1, zone.getName(), "e-3", "poller-3", monitor);
+
+    // EXECUTE
+
+    final Optional<EnvoyResourcePair> result = zoneAllocationResolver.findLeastLoadedEnvoy(zone);
+
+    // VERIFY
+
+    assertThat(result).isNotEmpty();
+    assertThat(result).get()
+        .isEqualTo(new EnvoyResourcePair().setResourceId("poller-3").setEnvoyId("e-3"));
+
+    verify(zoneStorage).getActivePollerResourceIdsInZone(zone);
+    verify(zoneStorage).getResourceIdToEnvoyIdMap(zone);
+
+    verifyNoMoreInteractions(zoneStorage);
+  }
+
+  @Test
+  public void testFindLeastLoadedEnvoy_tracksRepeatedCalls() {
+    final String tenantId = randomAlphanumeric(10);
+    final ResolvedZone zone = ResolvedZone.resolveZone(tenantId, randomAlphanumeric(5));
+
+    when(zoneStorage.getActivePollerResourceIdsInZone(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of("poller-1", "poller-2", "poller-3")));
+
+    when(zoneStorage.getResourceIdToEnvoyIdMap(any()))
+        .thenReturn(CompletableFuture.completedFuture(Map.of(
+            "poller-1", "e-1",
+            "poller-2", "e-2",
+            "poller-3", "e-3"
+        )));
+
+    final Monitor monitor = persistNewMonitor(tenantId, Map.of(), List.of(zone.getName()));
+    persistBoundMonitors(2, zone.getName(), "e-1", "poller-1", monitor);
+    // poller-2 will start out as empty one
+    persistBoundMonitors(1, zone.getName(), "e-3", "poller-3", monitor);
+
+    // EXECUTE/ASSERT
+
+    /*
+    Expected pollerResourceCounts progression:
+    {poller-1=2, poller-2=0, poller-3=1}
+    {poller-1=2, poller-2=1, poller-3=1}
+    {poller-1=2, poller-2=2, poller-3=1}
+    {poller-1=2, poller-2=2, poller-3=2}
+     */
+
+    // scope variables for each sub-case
+    {
+      final Optional<EnvoyResourcePair> result = zoneAllocationResolver.findLeastLoadedEnvoy(zone);
+      assertThat(result).isNotEmpty();
+      assertThat(result).get()
+          .isEqualTo(new EnvoyResourcePair().setResourceId("poller-2").setEnvoyId("e-2"));
+    }
+    {
+      final Optional<EnvoyResourcePair> result = zoneAllocationResolver.findLeastLoadedEnvoy(zone);
+      assertThat(result).isNotEmpty();
+      assertThat(result).get()
+          .isEqualTo(new EnvoyResourcePair().setResourceId("poller-2").setEnvoyId("e-2"));
+    }
+    {
+      final Optional<EnvoyResourcePair> result = zoneAllocationResolver.findLeastLoadedEnvoy(zone);
+      assertThat(result).isNotEmpty();
+      assertThat(result).get()
+          .isEqualTo(new EnvoyResourcePair().setResourceId("poller-3").setEnvoyId("e-3"));
+    }
+    {
+      final Optional<EnvoyResourcePair> result = zoneAllocationResolver.findLeastLoadedEnvoy(zone);
+      assertThat(result).isNotEmpty();
+      assertThat(result).get()
+          .isEqualTo(new EnvoyResourcePair().setResourceId("poller-1").setEnvoyId("e-1"));
+    }
+
+    // but these are still only called once
+    verify(zoneStorage).getActivePollerResourceIdsInZone(zone);
+    verify(zoneStorage).getResourceIdToEnvoyIdMap(zone);
+
+    verifyNoMoreInteractions(zoneStorage);
+  }
+
+  @Test
+  public void testFindLeastLoadedEnvoy_twoZones() {
+    final String tenantId = randomAlphanumeric(10);
+    final ResolvedZone zone1 = ResolvedZone.resolveZone(tenantId, randomAlphanumeric(5));
+    final ResolvedZone zone2 = ResolvedZone.resolveZone(tenantId, randomAlphanumeric(5));
+
+    when(zoneStorage.getActivePollerResourceIdsInZone(zone1))
+        .thenReturn(CompletableFuture.completedFuture(List.of("poller-1-1", "poller-1-2")));
+    when(zoneStorage.getActivePollerResourceIdsInZone(zone2))
+        .thenReturn(CompletableFuture.completedFuture(List.of("poller-2-1", "poller-2-2")));
+
+    when(zoneStorage.getResourceIdToEnvoyIdMap(zone1))
+        .thenReturn(CompletableFuture.completedFuture(Map.of(
+            "poller-1-1", "e-1-1",
+            "poller-1-2", "e-1-2"
+        )));
+    when(zoneStorage.getResourceIdToEnvoyIdMap(zone2))
+        .thenReturn(CompletableFuture.completedFuture(Map.of(
+            "poller-2-1", "e-2-1",
+            "poller-2-2", "e-2-2"
+        )));
+
+    final Monitor monitor = persistNewMonitor(tenantId, Map.of(),
+        List.of(zone1.getName(), zone2.getName()));
+    persistBoundMonitors(2, zone1.getName(), "e-1-1", "poller-1-1", monitor);
+    // zone1, poller-2 will start out as empty one
+
+    // zone2 ,poller-1 will start out as empty one
+    persistBoundMonitors(2, zone2.getName(), "e-2-2", "poller-2-2", monitor);
+
+    // EXECUTE
+
+    // scope variables for each sub-case
+    { // zone1
+      final Optional<EnvoyResourcePair> result = zoneAllocationResolver.findLeastLoadedEnvoy(zone1);
+      assertThat(result).isNotEmpty();
+      assertThat(result).get()
+          .isEqualTo(new EnvoyResourcePair().setResourceId("poller-1-2").setEnvoyId("e-1-2"));
+    }
+    { // zone2
+      final Optional<EnvoyResourcePair> result = zoneAllocationResolver.findLeastLoadedEnvoy(zone2);
+      assertThat(result).isNotEmpty();
+      assertThat(result).get()
+          .isEqualTo(new EnvoyResourcePair().setResourceId("poller-2-1").setEnvoyId("e-2-1"));
+    }
+
+    // VERIFY
+
+    // once for each zone
+    verify(zoneStorage).getActivePollerResourceIdsInZone(zone1);
+    verify(zoneStorage).getActivePollerResourceIdsInZone(zone2);
+    verify(zoneStorage).getResourceIdToEnvoyIdMap(zone1);
+    verify(zoneStorage).getResourceIdToEnvoyIdMap(zone2);
+
+    verifyNoMoreInteractions(zoneStorage);
+  }
+
+  @Test
+  public void testGetZoneBindingCounts() {
+    final String tenantId = randomAlphanumeric(10);
+    final ResolvedZone zone = ResolvedZone.resolveZone(tenantId, randomAlphanumeric(5));
+
+    when(zoneStorage.getActivePollerResourceIdsInZone(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of("poller-1", "poller-2", "poller-3")));
+
+    when(zoneStorage.getResourceIdToEnvoyIdMap(any()))
+        .thenReturn(CompletableFuture.completedFuture(Map.of(
+            "poller-1", "e-1",
+            "poller-2", "e-2",
+            "poller-3", "e-3"
+        )));
+
+    final Monitor monitor = persistNewMonitor(tenantId, Map.of(), List.of(zone.getName()));
+    persistBoundMonitors(2, zone.getName(), "e-1", "poller-1", monitor);
+    // poller-2 is empty one
+    persistBoundMonitors(1, zone.getName(), "e-3", "poller-3", monitor);
+
+    // EXECUTE
+
+    final Map<EnvoyResourcePair, Integer> result = zoneAllocationResolver
+        .getZoneBindingCounts(zone)
+        .join();
+
+    // VERIFY
+
+    assertThat(result).isEqualTo(Map.of(
+       new EnvoyResourcePair().setEnvoyId("e-1").setResourceId("poller-1"), 2,
+       new EnvoyResourcePair().setEnvoyId("e-2").setResourceId("poller-2"), 0,
+       new EnvoyResourcePair().setEnvoyId("e-3").setResourceId("poller-3"), 1
+    ));
+
+    verify(zoneStorage).getActivePollerResourceIdsInZone(zone);
+    verify(zoneStorage).getResourceIdToEnvoyIdMap(zone);
+
+    verifyNoMoreInteractions(zoneStorage);
+  }
+
+
+  private void persistBoundMonitors(int count, String zoneName,
+                                    String pollerEnvoyId,
+                                    String pollerResourceId,
+                                    Monitor monitor) {
+    IntStream.range(0, count)
+        .mapToObj(i ->
+            boundMonitorRepository.save(
+                new BoundMonitor()
+                    .setMonitor(monitor)
+                    .setTenantId(monitor.getTenantId())
+                    .setEnvoyId(pollerEnvoyId)
+                    .setPollerResourceId(pollerResourceId)
+                    .setZoneName(zoneName)
+                    .setResourceId(randomAlphanumeric(5))
+            )
+        )
+        .collect(Collectors.toList());
+  }
+
+  private Monitor persistNewMonitor(
+      String tenantId, Map<String, String> labelSelector, List<String> zones) {
+    return monitorRepository.save(
+        new Monitor()
+            .setTenantId(tenantId)
+            .setAgentType(AgentType.TELEGRAF)
+            .setSelectorScope(ConfigSelectorScope.REMOTE)
+            .setLabelSelector(labelSelector)
+            .setLabelSelectorMethod(LabelSelectorMethod.AND)
+            .setAgentType(AgentType.TELEGRAF)
+            .setMonitorType(MonitorType.ping)
+            .setZones(zones)
+            .setInterval(Duration.ofSeconds(60))
+            .setContent("{}")
+    );
+  }
+
+}

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOJsonTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/BoundMonitorDTOJsonTest.java
@@ -110,6 +110,7 @@ public class BoundMonitorDTOJsonTest {
         .setAgentType(AgentType.TELEGRAF)
         .setRenderedContent("{}")
         .setEnvoyId("e-1")
+        .setPollerResourceId("poller-1")
         .setInterval(Duration.ofSeconds(30))
         .setCreatedTimestamp(DEFAULT_TIMESTAMP)
         .setUpdatedTimestamp(DEFAULT_TIMESTAMP);

--- a/src/test/resources/BoundMonitorDTOJsonTest/testAllPopulated.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testAllPopulated.json
@@ -9,6 +9,7 @@
   "agentType": "TELEGRAF",
   "renderedContent": "{}",
   "envoyId": "e-1",
+  "pollerResourceId": "poller-1",
   "zoneName": "z-1",
   "interval": "PT30S",
   "createdTimestamp": "1970-01-02T03:46:40Z",

--- a/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nonNullEnvoy.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nonNullEnvoy.json
@@ -9,6 +9,7 @@
   "agentType": "TELEGRAF",
   "renderedContent": "{}",
   "envoyId": "e-1",
+  "pollerResourceId": null,
   "interval": "PT30S",
   "createdTimestamp": "1970-01-02T03:46:40Z",
   "updatedTimestamp": "1970-01-02T03:46:40Z"

--- a/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nullEnvoy.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nullEnvoy.json
@@ -9,6 +9,7 @@
   "agentType": "TELEGRAF",
   "renderedContent": "{}",
   "envoyId": null,
+  "pollerResourceId": null,
   "interval": "PT30S",
   "createdTimestamp": "1970-01-02T03:46:40Z",
   "updatedTimestamp": "1970-01-02T03:46:40Z"


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-358

# What

Rather than use a brittle, DIY counter in etcd, we'll instead use etcd to simply retrieve a list of the active poller's per remote monitoring zone and use the `BoundMonitor` table as the single source of truth for bindings per envoy-poller.

The motivation to make this change was observing my local system having troubles binding a new monitor to the 1000 resources I had left over from envoy-ambassador stress testing. The `ZoneStorage` code was getting itself into a tight loop of operations like the following with numerous collisions trying to increment the binding count:

```
2020-08-28 13:22:10.821 DEBUG [salus-telemetry-monitor-management,,,] 78771 --- [         etcd22] c.r.s.t.etcd.services.ZoneStorage        : Putting new bound count=894 for resource=development:0 in zone=ResolvedZone(name=dev, tenantId=aaaaaa)
2020-08-28 13:22:10.821 DEBUG [salus-telemetry-monitor-management,,,] 78771 --- [         etcd27] c.r.s.t.etcd.services.ZoneStorage        : Changing bound count of resource=development:0 in zone=ResolvedZone(name=dev, tenantId=aaaaaa) by amount=-1
2020-08-28 13:22:10.827 DEBUG [salus-telemetry-monitor-management,,,] 78771 --- [         etcd30] c.r.s.t.etcd.services.ZoneStorage        : Re-trying incrementing bound count of resource=development:0 in zone=ResolvedZone(name=dev, tenantId=aaaaaa) due to collision
```

# How

[The first commit](https://github.com/racker/salus-telemetry-monitor-management/commit/965b6cace8a3923034b6ae8cd0b5087b74410d47) only a refactoring to consolidate onto a single method of `MonitorManagement` for locating a least-loaded envoy-poller.

The second, big commit includes a new `ZoneAllocationResolver` component, which is allocated and re-used before each iterative operation done in monitor management. For example, if a monitor is about to get bound to 10,000 tenant resources, then a single instance of `ZoneAllocationResolver` is utilized for that. Each subsequent operation gets a fresh instance of that component though.

As you'll see in the javadoc, the `ZoneAllocationResolver` uses a minimal, cheap query into etcd to zero out the known, active envoy-pollers. Then it uses the new named queries on `BoundMonitor` to retrieve an aggregate count of bound monitors per envoy-poller resourceid for a requested zone.

The solution should scale to handle large numbers of tenant resources. The etcd query is small and constant. The `BoundMonitor` monitor table becomes the single source of truth and the remaining "expensive" operation is done within SQL, optimized by new indices, and the snapshot of those counts is used in-memory for any size of monitor-resource-zone binding operation.

# How to test

Updated existing unit tests of remote monitor binding to confirm the `pollerResourceId` was set as expected.

Added a new unit class for the new `ZoneAllocationResolver`.

# Depends on

- https://github.com/racker/salus-telemetry-model/pull/151
- https://github.com/racker/salus-telemetry-etcd-adapter/pull/67