### PR TITLE
Switched getResultStream to getResultList in ZoneAllocationResolver

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolver.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolver.java
@@ -163,8 +163,9 @@ public class ZoneAllocationResolver {
           }
 
           // Merge bindings counts into the active poller mappings
+
           query
-              .getResultStream()
+              .getResultList()
               .forEach(tuple -> {
                 pollerResourceLoading.put(
                     // resourceId


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-358

# What

During smoke testing in dev cluster (and locally) I found that the `getStreamResult()` did not work within the etcd CompletableFuture thread of `ZoneAllocationResolver`

It would throw an exception:

```
org.hibernate.exception.GenericJDBCException: could not advance using next()
--
at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:47)
at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:113)
at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:99)
at org.hibernate.internal.ScrollableResultsImpl.convert(ScrollableResultsImpl.java:70)
at org.hibernate.internal.ScrollableResultsImpl.next(ScrollableResultsImpl.java:105)
at org.hibernate.query.internal.ScrollableResultsIterator.hasNext(ScrollableResultsIterator.java:33)
at java.base/java.util.Iterator.forEachRemaining(Iterator.java:132)
at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
at org.hibernate.query.spi.StreamDecorator.forEach(StreamDecorator.java:155)
at com.rackspace.salus.monitor_management.services.ZoneAllocationResolver.lambda$retrievePollerResourceCounts$7(ZoneAllocationResolver.java:168)

Caused by: java.sql.SQLException: Operation not allowed after ResultSet closed
--
at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)
at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:89)
at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:63)
at com.mysql.cj.jdbc.result.ResultSetImpl.checkClosed(ResultSetImpl.java:445)
at com.mysql.cj.jdbc.result.ResultSetImpl.next(ResultSetImpl.java:1726)
at com.zaxxer.hikari.pool.HikariProxyResultSet.next(HikariProxyResultSet.java)
at org.hibernate.internal.ScrollableResultsImpl.next(ScrollableResultsImpl.java:100)
... 34 common frames omitted

```

# How

There might have been other ways to fix it, but switching to a `getResultList()` and then iterating via a stream of that fixed it.

# How to test

Not able to test via unit tests, but confirmed the fix in local environment.