### PR TITLE
Use default zone policy if custom region has no default zones

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -301,6 +301,12 @@ public class MetadataUtils {
       region = MetadataPolicy.DEFAULT_ZONE;
     }
     log.debug("Querying policy api for monitoring zones for region={}", region);
-    return policyApi.getDefaultMonitoringZones(region, useCache);
+    List<String> zones = policyApi.getDefaultMonitoringZones(region, useCache);
+
+    if (!region.equals(MetadataPolicy.DEFAULT_ZONE) && zones.isEmpty()) {
+      // if the custom region didn't have any default zones, retry using the default zone policy
+      zones = policyApi.getDefaultMonitoringZones(MetadataPolicy.DEFAULT_ZONE, useCache);
+    }
+    return zones;
   }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/utils/MetadataUtils.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Component;
@@ -303,7 +304,7 @@ public class MetadataUtils {
     log.debug("Querying policy api for monitoring zones for region={}", region);
     List<String> zones = policyApi.getDefaultMonitoringZones(region, useCache);
 
-    if (!region.equals(MetadataPolicy.DEFAULT_ZONE) && zones.isEmpty()) {
+    if (!Objects.equals(region, MetadataPolicy.DEFAULT_ZONE) && zones.isEmpty()) {
       // if the custom region didn't have any default zones, retry using the default zone policy
       zones = policyApi.getDefaultMonitoringZones(MetadataPolicy.DEFAULT_ZONE, useCache);
     }


### PR DESCRIPTION
## What

This was discovered during QE testing.

If a custom region like `{'metadata': {'region': 'my_region'}}` is set on a resource and there are no policies configured with `monitoring_zone_my_region` then any remote monitor without a zone set will fail to bind.

Instead, if the region does not have a policy configured the default zone policy should be used instead.

## How to test

The `invalidRegion` is the most important one.  This is the corrected behavior.
