### PR TITLE
Added handling for such in effect policies whose monitor is not found while deleting cloned monitor

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1490,32 +1490,32 @@ public class MonitorManagement {
     List<MonitorPolicyDTO> effectivePolicies = policyApi.getEffectiveMonitorPoliciesForTenant(tenantId, false);
 
     // if the old policy had been overriding another one using the same monitorId, find the other one
-      List<UUID>  newPolicyIds = effectivePolicies.stream()
-            .filter(p -> event.getMonitorId() != null)
-            .filter(p -> p.getMonitorId().equals(monitorId))
-            .map(PolicyDTO::getId)
-            .collect(Collectors.toList());
+    List<UUID>  newPolicyIds = effectivePolicies.stream()
+        .filter(p -> event.getMonitorId() != null)
+        .filter(p -> p.getMonitorId().equals(monitorId))
+        .map(PolicyDTO::getId)
+        .collect(Collectors.toList());
 
-      if (newPolicyIds.isEmpty()) {
-        log.debug("Removing cloned policy monitor={} for event={}", clonedMonitor.getId(), event);
-        unbindAndRemoveMonitor(clonedMonitor);
-        return;
-      }
+    if (newPolicyIds.isEmpty()) {
+      log.debug("Removing cloned policy monitor={} for event={}", clonedMonitor.getId(), event);
+      unbindAndRemoveMonitor(clonedMonitor);
+      return;
+    }
 
-      if (newPolicyIds.size() > 1) {
-        log.error(
-            "More than one effective policy configured to use the same monitorId={} for tenant={}",
-            monitorId, tenantId);
-        policyIntegrityErrors
-            .tags(MetricTags.OPERATION_METRIC_TAG, "handleMonitorPolicyEvent", "reason",
-                "tooManyClones")
-            .register(meterRegistry).increment();
-      }
-      UUID newPolicyId = newPolicyIds.get(0);
-      log.debug("Updating cloned policy monitor={} with new policyId={}", clonedMonitor,
-          newPolicyId);
-      clonedMonitor.setPolicyId(newPolicyId);
-      monitorRepository.save(clonedMonitor);
+    if (newPolicyIds.size() > 1) {
+      log.error(
+          "More than one effective policy configured to use the same monitorId={} for tenant={}",
+          monitorId, tenantId);
+      policyIntegrityErrors
+          .tags(MetricTags.OPERATION_METRIC_TAG, "handleMonitorPolicyEvent", "reason",
+              "tooManyClones")
+          .register(meterRegistry).increment();
+    }
+    UUID newPolicyId = newPolicyIds.get(0);
+    log.debug("Updating cloned policy monitor={} with new policyId={}", clonedMonitor,
+        newPolicyId);
+    clonedMonitor.setPolicyId(newPolicyId);
+    monitorRepository.save(clonedMonitor);
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1491,8 +1491,7 @@ public class MonitorManagement {
 
     // if the old policy had been overriding another one using the same monitorId, find the other one
     List<UUID>  newPolicyIds = effectivePolicies.stream()
-        .filter(p -> event.getMonitorId() != null)
-        .filter(p -> p.getMonitorId().equals(monitorId))
+        .filter(p -> Objects.equals(p.getMonitorId(), monitorId))
         .map(PolicyDTO::getId)
         .collect(Collectors.toList());
 

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1488,27 +1488,36 @@ public class MonitorManagement {
     List<MonitorPolicyDTO> effectivePolicies = policyApi.getEffectiveMonitorPoliciesForTenant(tenantId, false);
 
     // if the old policy had been overriding another one using the same monitorId, find the other one
-    List<UUID> newPolicyIds = effectivePolicies.stream()
-        .filter(p -> p.getMonitorId().equals(monitorId))
-        .map(PolicyDTO::getId)
-        .collect(Collectors.toList());
+    try {
+      List<UUID> newPolicyIds = effectivePolicies.stream()
+          .filter(p -> p.getMonitorId().equals(monitorId))
+          .map(PolicyDTO::getId)
+          .collect(Collectors.toList());
 
-    if (newPolicyIds.isEmpty()) {
-      log.debug("Removing cloned policy monitor={} for event={}", clonedMonitor.getId(), event);
-      unbindAndRemoveMonitor(clonedMonitor);
-      return;
-    }
+      if (newPolicyIds.isEmpty()) {
+        log.debug("Removing cloned policy monitor={} for event={}", clonedMonitor.getId(), event);
+        unbindAndRemoveMonitor(clonedMonitor);
+        return;
+      }
 
-    if (newPolicyIds.size() > 1) {
-      log.error("More than one effective policy configured to use the same monitorId={} for tenant={}",
-          monitorId, tenantId);
-      policyIntegrityErrors.tags(MetricTags.OPERATION_METRIC_TAG, "handleMonitorPolicyEvent", "reason", "tooManyClones")
-          .register(meterRegistry).increment();
+      if (newPolicyIds.size() > 1) {
+        log.error(
+            "More than one effective policy configured to use the same monitorId={} for tenant={}",
+            monitorId, tenantId);
+        policyIntegrityErrors
+            .tags(MetricTags.OPERATION_METRIC_TAG, "handleMonitorPolicyEvent", "reason",
+                "tooManyClones")
+            .register(meterRegistry).increment();
+      }
+      UUID newPolicyId = newPolicyIds.get(0);
+      log.debug("Updating cloned policy monitor={} with new policyId={}", clonedMonitor,
+          newPolicyId);
+      clonedMonitor.setPolicyId(newPolicyId);
+      monitorRepository.save(clonedMonitor);
+    } catch(Exception e)  {
+      log.error("error occurred while processing policy removal event for policy monitor={} and cloned monitor={}",
+          monitorId, clonedMonitor.getId());
     }
-    UUID newPolicyId = newPolicyIds.get(0);
-    log.debug("Updating cloned policy monitor={} with new policyId={}", clonedMonitor, newPolicyId);
-    clonedMonitor.setPolicyId(newPolicyId);
-    monitorRepository.save(clonedMonitor);
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -1490,19 +1490,11 @@ public class MonitorManagement {
     List<MonitorPolicyDTO> effectivePolicies = policyApi.getEffectiveMonitorPoliciesForTenant(tenantId, false);
 
     // if the old policy had been overriding another one using the same monitorId, find the other one
-    try {
-      List<UUID> newPolicyIds = null;
-      //if policy is in effect and monitor not found
-      try {
-        newPolicyIds = effectivePolicies.stream()
+      List<UUID>  newPolicyIds = effectivePolicies.stream()
+            .filter(p -> event.getMonitorId() != null)
             .filter(p -> p.getMonitorId().equals(monitorId))
             .map(PolicyDTO::getId)
             .collect(Collectors.toList());
-      } catch(NullPointerException e)  {
-        log.debug("Removing cloned policy monitor={} for event={}", clonedMonitor.getId(), event);
-        unbindAndRemoveMonitor(clonedMonitor);
-        return;
-      }
 
       if (newPolicyIds.isEmpty()) {
         log.debug("Removing cloned policy monitor={} for event={}", clonedMonitor.getId(), event);
@@ -1524,13 +1516,6 @@ public class MonitorManagement {
           newPolicyId);
       clonedMonitor.setPolicyId(newPolicyId);
       monitorRepository.save(clonedMonitor);
-    } catch(Exception e)  {
-      log.error("error occurred while processing policy removal event for policy monitor={} and cloned monitor={}",
-          monitorId, clonedMonitor.getId());
-      policyRemvalErrors.tags(MetricTags.OPERATION_METRIC_TAG, "handleMonitorPolicyRemovalEvent","reason",
-          e.getClass().getSimpleName())
-          .register(meterRegistry).increment();
-    }
   }
 
   /**

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
@@ -968,28 +968,30 @@ public class MonitorManagementPolicyTest {
 
   /**
    * Receive a remove monitor policy event and process it for a tenant
-   * that was previously using the policy but the monitor is not found
-   *
+   * that was previously using the policy which is not in effect and
+   * having a null monitor id
    */
   @Test
-  public void testHandleMonitorPolicyEvent_removePolicy_null_monitor_id() {
+  public void testHandleMonitorPolicyEvent_removePolicy_null_monitor_id_for_unrelated_policy() {
     String tenantId = RandomStringUtils.randomAlphanumeric(10);
     UUID policyId = UUID.randomUUID();
     UUID policyMonitorId = currentMonitor.getId();
+    UUID anotherPolicyId = UUID.randomUUID();
 
     // store a monitor for the tenant that is tied to the policy in the event
     Monitor clonedMonitor = createMonitorForPolicyForTenant(tenantId, policyId);
 
-    List<MonitorPolicyDTO> list = List.of((MonitorPolicyDTO) new MonitorPolicyDTO()
+    List<MonitorPolicyDTO> list = List.of(
+        (MonitorPolicyDTO) new MonitorPolicyDTO()
+        .setMonitorId(policyMonitorId)
+        .setId(policyId),
+        (MonitorPolicyDTO) new MonitorPolicyDTO()
         .setMonitorId(null)
-        .setId(policyId));
+        .setId(anotherPolicyId));
 
     when(policyApi.getEffectiveMonitorPoliciesForTenant(anyString(), anyBoolean())).thenReturn(list);
 
     PageRequest pageRequest = PageRequest.of(0, 1000);
-
-    when(boundMonitorRepository.findAllByTenantIdAndMonitor_IdIn(tenantId, List.of(clonedMonitor.getId()), pageRequest))
-        .thenReturn(Page.empty());
 
     MonitorPolicyEvent event = (MonitorPolicyEvent) new MonitorPolicyEvent()
         .setMonitorId(policyMonitorId)
@@ -998,10 +1000,10 @@ public class MonitorManagementPolicyTest {
     monitorManagement.handleMonitorPolicyEvent(event);
 
     // policy monitor no longer exists on tenant
-    assertTrue(monitorRepository.findByTenantIdAndPolicyId(tenantId, policyId).isEmpty());
+    assertTrue(monitorRepository.findByTenantIdAndPolicyId(tenantId, policyId).isPresent());
+    assertTrue(monitorRepository.findByTenantIdAndPolicyId(tenantId, anotherPolicyId).isEmpty());
 
     verify(policyApi).getEffectiveMonitorPoliciesForTenant(tenantId, false);
-    verify(boundMonitorRepository).findAllByTenantIdAndMonitor_IdIn(tenantId, List.of(clonedMonitor.getId()), pageRequest);
     verifyNoMoreInteractions(boundMonitorRepository, policyApi, monitorEventProducer);
   }
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementPolicyTest.java
@@ -62,6 +62,7 @@ import com.rackspace.salus.telemetry.entities.Zone;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
+import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
 import com.rackspace.salus.telemetry.messaging.MonitorPolicyEvent;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
@@ -706,7 +707,7 @@ public class MonitorManagementPolicyTest {
     // handle initial lookup to see if policy exists
     when(monitorPolicyRepository.findById(any()))
         .thenReturn(Optional.of((MonitorPolicy) new MonitorPolicy()
-            .setMonitorId(UUID.randomUUID())
+            .setMonitorId(policyMonitorId)
             .setName(RandomStringUtils.randomAlphabetic(5))
             .setId(policyId)
             .setScope(PolicyScope.GLOBAL)));
@@ -967,12 +968,15 @@ public class MonitorManagementPolicyTest {
   }
 
   /**
-   * Receive a remove monitor policy event and process it for a tenant
-   * that was previously using the policy but the monitor is not found
+   * Process a MonitorPolicyEvent that contains outdated details.
    *
+   * Receives a policy event for a policy that has since been updated to be an opt-out policy.
+   *
+   * The service should ignore the specific values in the kafka event and instead rely
+   * on what is stored in the database.
    */
   @Test
-  public void testHandleMonitorPolicyEvent_removePolicy_null_monitor_id() {
+  public void testHandleMonitorPolicyEvent_lateProcessing() {
     String tenantId = RandomStringUtils.randomAlphanumeric(10);
     UUID policyId = UUID.randomUUID();
     UUID policyMonitorId = currentMonitor.getId();
@@ -984,12 +988,24 @@ public class MonitorManagementPolicyTest {
         .setMonitorId(null)
         .setId(policyId));
 
-    when(policyApi.getEffectiveMonitorPoliciesForTenant(anyString(), anyBoolean())).thenReturn(list);
+    // return the opt-out policy from the db
+    when(monitorPolicyRepository.findById(any()))
+        .thenReturn(Optional.of(new MonitorPolicy().setMonitorId(null)));
+
+    // this returns empty since we exclude null policies
+    when(policyApi.getEffectiveMonitorPolicyIdsForTenant(anyString(), anyBoolean(), anyBoolean()))
+        .thenReturn(Collections.emptyList());
 
     PageRequest pageRequest = PageRequest.of(0, 1000);
 
-    when(boundMonitorRepository.findAllByTenantIdAndMonitor_IdIn(tenantId, List.of(clonedMonitor.getId()), pageRequest))
-        .thenReturn(Page.empty());
+    // return the bound monitors associated to the cloned monitor
+    BoundMonitor b = new BoundMonitor()
+        .setMonitor(clonedMonitor)
+        .setResourceId("r-1")
+        .setEnvoyId("e-1");
+    when(boundMonitorRepository.findAllByTenantIdAndMonitor_IdIn(anyString(), any(), any()))
+        .thenReturn(new PageImpl<>(Collections.singletonList(b)))
+        .thenReturn(Page.empty()); // this page is returned after the first is removed
 
     MonitorPolicyEvent event = (MonitorPolicyEvent) new MonitorPolicyEvent()
         .setMonitorId(policyMonitorId)
@@ -997,21 +1013,27 @@ public class MonitorManagementPolicyTest {
         .setPolicyId(policyId);
     monitorManagement.handleMonitorPolicyEvent(event);
 
-    // policy monitor no longer exists on tenant
+    // despite the event containing a monitorId, the cloned monitor should be removed
+    // due to the policy having a null monitorId in the db
     assertTrue(monitorRepository.findByTenantIdAndPolicyId(tenantId, policyId).isEmpty());
 
-    verify(policyApi).getEffectiveMonitorPoliciesForTenant(tenantId, false);
-    verify(boundMonitorRepository).findAllByTenantIdAndMonitor_IdIn(tenantId, List.of(clonedMonitor.getId()), pageRequest);
-    verifyNoMoreInteractions(boundMonitorRepository, policyApi, monitorEventProducer);
+    verify(policyApi).getEffectiveMonitorPolicyIdsForTenant(tenantId, false, false);
+    verify(monitorPolicyRepository).findById(policyId);
+    verify(boundMonitorRepository).deleteAll(Collections.singletonList(b));
+    verify(boundMonitorRepository, times(2)).findAllByTenantIdAndMonitor_IdIn(tenantId, List.of(clonedMonitor.getId()), pageRequest);
+    verify(monitorEventProducer).sendMonitorEvent(new MonitorBoundEvent().setEnvoyId("e-1"));
+    verifyNoMoreInteractions(boundMonitorRepository, monitorPolicyRepository, policyApi, monitorEventProducer);
   }
 
   /**
-   * Receive a remove monitor policy event and process it for a tenant
-   * that was previously using an effective policy which is not in effect and
-   * having a null monitor id against it
+   * Receive a remove monitor policy event for a tenant whose only remaining policy
+   * is an opt-out policy.
+   *
+   * The null monitorId in the opt-out policy should not cause any problems and the newly
+   * removed policy should trigger the previously stored monitor to be deleted.
    */
   @Test
-  public void testHandleMonitorPolicyEvent_removePolicy_null_monitor_id_for_unrelated_policy() {
+  public void testHandleMonitorPolicyEvent_removePolicy_unrelatedOptOutHasNoEffect() {
     String tenantId = RandomStringUtils.randomAlphanumeric(10);
     UUID policyId = UUID.randomUUID();
     UUID policyMonitorId = currentMonitor.getId();
@@ -1020,17 +1042,17 @@ public class MonitorManagementPolicyTest {
     // store a monitor for the tenant that is tied to the policy in the event
     Monitor clonedMonitor = createMonitorForPolicyForTenant(tenantId, policyId);
 
+    // only return the separate opt-out policy
+    // the policy related to the stored monitor has been deleted so will not be returned
     List<MonitorPolicyDTO> list = List.of(
-        (MonitorPolicyDTO) new MonitorPolicyDTO()
-        .setMonitorId(policyMonitorId)
-        .setId(policyId),
         (MonitorPolicyDTO) new MonitorPolicyDTO()
         .setMonitorId(null)
         .setId(anotherPolicyId));
 
-    when(policyApi.getEffectiveMonitorPoliciesForTenant(anyString(), anyBoolean())).thenReturn(list);
-
-    PageRequest pageRequest = PageRequest.of(0, 1000);
+    when(policyApi.getEffectiveMonitorPoliciesForTenant(anyString(), anyBoolean()))
+        .thenReturn(list);
+    when(boundMonitorRepository.findAllByTenantIdAndMonitor_IdIn(anyString(), any(), any()))
+        .thenReturn(Page.empty());
 
     MonitorPolicyEvent event = (MonitorPolicyEvent) new MonitorPolicyEvent()
         .setMonitorId(policyMonitorId)
@@ -1038,11 +1060,14 @@ public class MonitorManagementPolicyTest {
         .setPolicyId(policyId);
     monitorManagement.handleMonitorPolicyEvent(event);
 
-    // policy monitor no longer exists on tenant
-    assertTrue(monitorRepository.findByTenantIdAndPolicyId(tenantId, policyId).isPresent());
+    // no monitors exist for the newly removed policy or the still existing opt-out policy
+    assertTrue(monitorRepository.findById(clonedMonitor.getId()).isEmpty());
+    assertTrue(monitorRepository.findByTenantIdAndPolicyId(tenantId, policyId).isEmpty());
     assertTrue(monitorRepository.findByTenantIdAndPolicyId(tenantId, anotherPolicyId).isEmpty());
 
     verify(policyApi).getEffectiveMonitorPoliciesForTenant(tenantId, false);
+    PageRequest pageRequest = PageRequest.of(0,1000);
+    verify(boundMonitorRepository).findAllByTenantIdAndMonitor_IdIn(tenantId, List.of(clonedMonitor.getId()), pageRequest);
     verifyNoMoreInteractions(boundMonitorRepository, policyApi, monitorEventProducer);
   }
 


### PR DESCRIPTION
# Resolves

[SALUS-1024](https://jira.rax.io/browse/SALUS-1024)

# What

Added handling for such in effect policies whose monitor is not found while deleting cloned monitor

