### PR TITLE
Added apis to get detached but pending timeout pollers

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -2106,6 +2106,13 @@ public class MonitorManagement {
     handleNewEnvoyInZone(zoneTenantId, zoneName);
   }
 
+  /**
+   * Returns the list of ZoneAssignmentCount for a particular zone of a tenant.
+   *
+   * @param zoneTenantId
+   * @param zoneName
+   * @return
+   */
   public CompletableFuture<List<ZoneAssignmentCount>> getZoneAssignmentCounts(
       @Nullable String zoneTenantId, String zoneName) {
 
@@ -2113,23 +2120,24 @@ public class MonitorManagement {
     ZoneAllocationResolver zoneAllocationResolver = zoneAllocationResolverFactory.create();
 
     return zoneAllocationResolver.getActiveZoneBindingCounts(zone)
-        .thenApply(activePollerMap -> getZoneAssignmentPollerCount(activePollerMap, true))
+        .thenApply(activePollerMap -> mapToZoneAssignmentCount(activePollerMap, true))
         .thenCompose(assignmentCounts -> zoneAllocationResolver.getExpiringZoneBindingCounts(zone)
             .thenApply(envoyResourcePairIntegerMap -> {
               assignmentCounts
-                  .addAll(getZoneAssignmentPollerCount(envoyResourcePairIntegerMap, false));
+                  .addAll(mapToZoneAssignmentCount(envoyResourcePairIntegerMap, false));
               return assignmentCounts;
             }));
   }
 
   /**
-   * This method maps the bindingcount map to the ZoneAssignmentCount list.
+   * This method is used to convert the map of EnvoyResourcePair count to list of
+   * ZoneAssignmentCount.
    *
    * @param bindingCounts
    * @param isConnected
    * @return
    */
-  public List<ZoneAssignmentCount> getZoneAssignmentPollerCount(
+  public List<ZoneAssignmentCount> mapToZoneAssignmentCount(
       Map<EnvoyResourcePair, Integer> bindingCounts, boolean isConnected) {
     return bindingCounts.entrySet().stream()
         .map(entry ->

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -2137,7 +2137,7 @@ public class MonitorManagement {
    * @param isConnected
    * @return
    */
-  public List<ZoneAssignmentCount> mapToZoneAssignmentCount(
+  List<ZoneAssignmentCount> mapToZoneAssignmentCount(
       Map<EnvoyResourcePair, Integer> bindingCounts, boolean isConnected) {
     return bindingCounts.entrySet().stream()
         .map(entry ->

--- a/src/main/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolver.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolver.java
@@ -109,7 +109,7 @@ public class ZoneAllocationResolver {
     );
   }
 
-  private CompletableFuture<Map<String, Integer>> getExpiredPollerResourceCounts(ResolvedZone zone) {
+  private CompletableFuture<Map<String, Integer>> getExpiringPollerResourceCounts(ResolvedZone zone) {
     return expiredPollerCountSnapshot.computeIfAbsent(
         zone,
         this::retrieveExpiredPollerResourceCounts
@@ -147,9 +147,9 @@ public class ZoneAllocationResolver {
    * @param zone the zone to retrieve
    * @return mapping of envoy-pollers to bound monitor counts
    */
-  public CompletableFuture<Map<EnvoyResourcePair, Integer>> getExpiredZoneBindingCounts(ResolvedZone zone) {
+  public CompletableFuture<Map<EnvoyResourcePair, Integer>> getExpiringZoneBindingCounts(ResolvedZone zone) {
     // Combine the poller counts by resourceId
-    return getExpiredPollerResourceCounts(zone)
+    return getExpiringPollerResourceCounts(zone)
         .thenCompose(pollerResourceCounts ->
             // ...with the resourceId to envoyId mappings
             getResourceIdToEnvoyIdMap(zone)
@@ -192,7 +192,7 @@ public class ZoneAllocationResolver {
 
   private CompletableFuture<Map<String, Integer>> retrieveExpiredPollerResourceCounts(
       ResolvedZone zone) {
-    return zoneStorage.getExpiredPollerResourceIdsInZone(zone)
+    return zoneStorage.getExpiringPollerResourceIdsInZone(zone)
         .thenApply(expiredPollerResources -> {
           if (!expiredPollerResources.isEmpty()) {
             return getPollerResourcesCounts(zone, expiredPollerResources);

--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/ZoneApiController.java
@@ -142,11 +142,13 @@ public class ZoneApiController {
   @GetMapping("/tenant/{tenantId}/zone-assignment-counts/{name}")
   @ApiOperation(value = "Gets assignment counts of monitors to poller-envoys in the private zone")
   public CompletableFuture<List<ZoneAssignmentCount>> getPrivateZoneAssignmentCounts(
-      @PathVariable String tenantId, @PathVariable @PrivateZoneName Optional<String> name) {
+      @PathVariable String tenantId, @PathVariable @PrivateZoneName String name) {
 
-    String zoneName = name.orElse("");
+    if (!zoneManagement.exists(tenantId, name)) {
+      throw new NotFoundException(String.format("No private zone found named %s", name));
+    }
 
-    return monitorManagement.getZoneAssignmentCounts(tenantId, zoneName);
+    return monitorManagement.getZoneAssignmentCounts(tenantId, name);
   }
 
   @GetMapping("/tenant/{tenantId}/zone-assignment-counts")
@@ -154,7 +156,7 @@ public class ZoneApiController {
   public CompletableFuture<Map<String, List<ZoneAssignmentCount>>> getPrivateZoneAssignmentCountsPerTenant(
       @PathVariable String tenantId) {
 
-    return monitorManagement.getAssignmentCountForTenant(tenantId);
+    return monitorManagement.getZoneAssignmentCountForTenant(tenantId);
   }
 
   @GetMapping("/admin/zone-assignment-counts/**")
@@ -174,7 +176,7 @@ public class ZoneApiController {
   @GetMapping("/admin/zone-assignment-counts")
   @ApiOperation(value = "Gets assignment counts of monitors to poller-envoys for all the public zones")
   public CompletableFuture<Map<String, List<ZoneAssignmentCount>>> getPublicZoneAssignmentCountsPerTenant() {
-    return monitorManagement.getAssignmentCountForTenant(ResolvedZone.PUBLIC);
+    return monitorManagement.getZoneAssignmentCountForTenant(ResolvedZone.PUBLIC);
   }
 
   @PostMapping("/tenant/{tenantId}/zones")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneAssignmentCount.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/ZoneAssignmentCount.java
@@ -23,4 +23,5 @@ public class ZoneAssignmentCount {
   String resourceId;
   String envoyId;
   int assignments;
+  boolean connected;
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
@@ -571,7 +571,7 @@ public class MonitorManagement_ZoneBindingsTest {
     rawCounts.put(new EnvoyResourcePair().setResourceId("r-1").setEnvoyId("e-1"), 5);
     rawCounts.put(new EnvoyResourcePair().setResourceId("r-2").setEnvoyId("e-2"), 6);
 
-    when(zoneAllocationResolver.getZoneBindingCounts(any()))
+    when(zoneAllocationResolver.getActiveZoneBindingCounts(any()))
         .thenReturn(CompletableFuture.completedFuture(rawCounts));
 
     // EXECUTE
@@ -587,7 +587,7 @@ public class MonitorManagement_ZoneBindingsTest {
 
     ));
 
-    verify(zoneAllocationResolver).getZoneBindingCounts(
+    verify(zoneAllocationResolver).getActiveZoneBindingCounts(
         ResolvedZone.createPrivateZone("t-1", "z-1")
     );
 
@@ -605,7 +605,7 @@ public class MonitorManagement_ZoneBindingsTest {
     final Monitor monitor = persistNewMonitor(tenantId, "z-1");
     Map<EnvoyResourcePair, Integer> counts = persistBindingsToRebalance(monitor, "z-1");
 
-    when(zoneAllocationResolver.getZoneBindingCounts(any()))
+    when(zoneAllocationResolver.getActiveZoneBindingCounts(any()))
         .thenReturn(CompletableFuture.completedFuture(counts));
 
     when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
@@ -620,7 +620,7 @@ public class MonitorManagement_ZoneBindingsTest {
     // VERIFY
 
     final ResolvedZone zone = createPrivateZone(tenantId, "z-1");
-    verify(zoneAllocationResolver).getZoneBindingCounts(zone);
+    verify(zoneAllocationResolver).getActiveZoneBindingCounts(zone);
 
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent().setEnvoyId("e-3")
@@ -646,7 +646,7 @@ public class MonitorManagement_ZoneBindingsTest {
     Map<EnvoyResourcePair, Integer> counts = persistBindingsToRebalance(
         monitor, "public/west");
 
-    when(zoneAllocationResolver.getZoneBindingCounts(any()))
+    when(zoneAllocationResolver.getActiveZoneBindingCounts(any()))
         .thenReturn(CompletableFuture.completedFuture(counts));
 
     when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
@@ -664,7 +664,7 @@ public class MonitorManagement_ZoneBindingsTest {
     assertThat(reassigned, equalTo(2));
 
     final ResolvedZone zone = createPublicZone("public/west");
-    verify(zoneAllocationResolver).getZoneBindingCounts(zone);
+    verify(zoneAllocationResolver).getActiveZoneBindingCounts(zone);
 
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent().setEnvoyId("e-3")
@@ -691,7 +691,7 @@ public class MonitorManagement_ZoneBindingsTest {
     final Map<EnvoyResourcePair, Integer> counts = persistBindingsToRebalance(
         monitor, "public/west");
 
-    when(zoneAllocationResolver.getZoneBindingCounts(any()))
+    when(zoneAllocationResolver.getActiveZoneBindingCounts(any()))
         .thenReturn(CompletableFuture.completedFuture(counts));
 
     when(zoneAllocationResolver.findLeastLoadedEnvoy(any()))
@@ -709,7 +709,7 @@ public class MonitorManagement_ZoneBindingsTest {
     assertThat(reassigned, equalTo(3));
 
     final ResolvedZone zone = createPublicZone("public/west");
-    verify(zoneAllocationResolver).getZoneBindingCounts(zone);
+    verify(zoneAllocationResolver).getActiveZoneBindingCounts(zone);
 
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent().setEnvoyId("e-3")
@@ -727,7 +727,7 @@ public class MonitorManagement_ZoneBindingsTest {
 
   @Test
   public void testRebalanceZone_emptyZone() {
-    when(zoneAllocationResolver.getZoneBindingCounts(any()))
+    when(zoneAllocationResolver.getActiveZoneBindingCounts(any()))
         .thenReturn(CompletableFuture.completedFuture(
             Collections.emptyMap()
         ));
@@ -741,7 +741,7 @@ public class MonitorManagement_ZoneBindingsTest {
 
     assertThat(reassigned, equalTo(0));
 
-    verify(zoneAllocationResolver).getZoneBindingCounts(ResolvedZone.createPrivateZone("t-1", "z-1"));
+    verify(zoneAllocationResolver).getActiveZoneBindingCounts(ResolvedZone.createPrivateZone("t-1", "z-1"));
 
     verifyNoMoreInteractions(envoyResourceManagement,
         zoneStorage, monitorEventProducer, resourceApi, zoneAllocationResolver

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
@@ -59,10 +59,12 @@ import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
 import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.ResourceInfo;
 import com.rackspace.salus.telemetry.repositories.BoundMonitorRepository;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import com.rackspace.salus.telemetry.repositories.ResourceRepository;
+import com.rackspace.salus.telemetry.repositories.ZoneRepository;
 import com.rackspace.salus.test.EnableTestContainersDatabase;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
@@ -89,6 +91,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -158,6 +161,8 @@ public class MonitorManagement_ZoneBindingsTest {
   MetadataUtils metadataUtils;
   @Autowired
   ZonesProperties zonesProperties;
+  @MockBean
+  ZoneRepository zoneRepository;
 
   @Autowired
   private MonitorManagement monitorManagement;
@@ -567,12 +572,19 @@ public class MonitorManagement_ZoneBindingsTest {
 
   @Test
   public void testGetZoneAssignmentCounts() {
-    Map<EnvoyResourcePair, Integer> rawCounts = new HashMap<>();
-    rawCounts.put(new EnvoyResourcePair().setResourceId("r-1").setEnvoyId("e-1"), 5);
-    rawCounts.put(new EnvoyResourcePair().setResourceId("r-2").setEnvoyId("e-2"), 6);
+    Map<EnvoyResourcePair, Integer> activeZoneCounts = new HashMap<>();
+    activeZoneCounts.put(new EnvoyResourcePair().setResourceId("r-1").setEnvoyId("e-1"), 5);
+    activeZoneCounts.put(new EnvoyResourcePair().setResourceId("r-2").setEnvoyId("e-2"), 6);
 
     when(zoneAllocationResolver.getActiveZoneBindingCounts(any()))
-        .thenReturn(CompletableFuture.completedFuture(rawCounts));
+        .thenReturn(CompletableFuture.completedFuture(activeZoneCounts));
+
+    Map<EnvoyResourcePair, Integer> expiredZoneCounts = new HashMap<>();
+    expiredZoneCounts.put(new EnvoyResourcePair().setResourceId("r-3").setEnvoyId("e-3"), 5);
+    expiredZoneCounts.put(new EnvoyResourcePair().setResourceId("r-4").setEnvoyId("e-4"), 6);
+
+    when(zoneAllocationResolver.getExpiringZoneBindingCounts(any()))
+        .thenReturn(CompletableFuture.completedFuture(expiredZoneCounts));
 
     // EXECUTE
 
@@ -582,12 +594,17 @@ public class MonitorManagement_ZoneBindingsTest {
     // VERIFY
 
     assertThat(counts, containsInAnyOrder(
-        new ZoneAssignmentCount().setResourceId("r-1").setEnvoyId("e-1").setAssignments(5),
-        new ZoneAssignmentCount().setResourceId("r-2").setEnvoyId("e-2").setAssignments(6)
-
+        new ZoneAssignmentCount().setResourceId("r-1").setEnvoyId("e-1").setAssignments(5).setConnected(true),
+        new ZoneAssignmentCount().setResourceId("r-2").setEnvoyId("e-2").setAssignments(6).setConnected(true),
+        new ZoneAssignmentCount().setResourceId("r-3").setEnvoyId("e-3").setAssignments(5).setConnected(false),
+        new ZoneAssignmentCount().setResourceId("r-4").setEnvoyId("e-4").setAssignments(6).setConnected(false)
     ));
 
     verify(zoneAllocationResolver).getActiveZoneBindingCounts(
+        ResolvedZone.createPrivateZone("t-1", "z-1")
+    );
+
+    verify(zoneAllocationResolver).getExpiringZoneBindingCounts(
         ResolvedZone.createPrivateZone("t-1", "z-1")
     );
 
@@ -1256,4 +1273,77 @@ public class MonitorManagement_ZoneBindingsTest {
     assertThat(results, containsInAnyOrder(matchers));
   }
 
+  @Test
+  public void testGetZoneAssignmentCounts_PerTenant() {
+
+    ResolvedZone resolvedZone1 = ResolvedZone.createPrivateZone("t-1", "z-1");
+    ResolvedZone resolvedZone2 = ResolvedZone.createPrivateZone("t-1", "z-2");
+
+    Map<EnvoyResourcePair, Integer> activeZoneCountsForZone1 = new HashMap<>();
+    activeZoneCountsForZone1.put(new EnvoyResourcePair().setResourceId("r-1").setEnvoyId("e-1"), 5);
+    activeZoneCountsForZone1.put(new EnvoyResourcePair().setResourceId("r-2").setEnvoyId("e-2"), 6);
+
+    Map<EnvoyResourcePair, Integer> activeZoneCountsForZone2 = new HashMap<>();
+    activeZoneCountsForZone2.put(new EnvoyResourcePair().setResourceId("r-3").setEnvoyId("e-3"), 0);
+    activeZoneCountsForZone2.put(new EnvoyResourcePair().setResourceId("r-4").setEnvoyId("e-4"), 1);
+
+    when(zoneRepository.findAllZoneNameForTenant("t-1", Pageable.unpaged()))
+        .thenReturn(new PageImpl<>(List.of("z-1", "z-2")));
+
+    when(zoneAllocationResolver.getActiveZoneBindingCounts(any()))
+        .thenReturn(CompletableFuture.completedFuture(activeZoneCountsForZone1))
+        .thenReturn(CompletableFuture.completedFuture(activeZoneCountsForZone2));
+
+    Map<EnvoyResourcePair, Integer> expiredZoneCountsForZone1 = new HashMap<>();
+    expiredZoneCountsForZone1.put(new EnvoyResourcePair().setResourceId("r-5").setEnvoyId("e-5"), 2);
+    expiredZoneCountsForZone1.put(new EnvoyResourcePair().setResourceId("r-6").setEnvoyId("e-6"), 3);
+
+    Map<EnvoyResourcePair, Integer> expiredZoneCountsForZone2 = new HashMap<>();
+    expiredZoneCountsForZone2.put(new EnvoyResourcePair().setResourceId("r-7").setEnvoyId("e-7"), 4);
+    expiredZoneCountsForZone2.put(new EnvoyResourcePair().setResourceId("r-8").setEnvoyId("e-8"), 5);
+
+    when(zoneAllocationResolver.getExpiringZoneBindingCounts(any()))
+        .thenReturn(CompletableFuture.completedFuture(expiredZoneCountsForZone1))
+        .thenReturn(CompletableFuture.completedFuture(expiredZoneCountsForZone2));
+
+    // EXECUTE
+
+    final Map<String, List<ZoneAssignmentCount>> counts =
+        monitorManagement.getZoneAssignmentCountForTenant("t-1").join();
+
+    // VERIFY
+
+    assertThat(counts.get("z-1"), containsInAnyOrder(
+        new ZoneAssignmentCount().setResourceId("r-1").setEnvoyId("e-1").setAssignments(5).setConnected(true),
+        new ZoneAssignmentCount().setResourceId("r-2").setEnvoyId("e-2").setAssignments(6).setConnected(true),
+        new ZoneAssignmentCount().setResourceId("r-5").setEnvoyId("e-5").setAssignments(2).setConnected(false),
+        new ZoneAssignmentCount().setResourceId("r-6").setEnvoyId("e-6").setAssignments(3).setConnected(false)
+    ));
+
+    assertThat(counts.get("z-2"), containsInAnyOrder(
+        new ZoneAssignmentCount().setResourceId("r-3").setEnvoyId("e-3").setAssignments(0).setConnected(true),
+        new ZoneAssignmentCount().setResourceId("r-4").setEnvoyId("e-4").setAssignments(1).setConnected(true),
+        new ZoneAssignmentCount().setResourceId("r-7").setEnvoyId("e-7").setAssignments(4).setConnected(false),
+        new ZoneAssignmentCount().setResourceId("r-8").setEnvoyId("e-8").setAssignments(5).setConnected(false)
+    ));
+
+    verify(zoneAllocationResolver).getActiveZoneBindingCounts(resolvedZone1);
+    verify(zoneAllocationResolver).getActiveZoneBindingCounts(resolvedZone2);
+
+    verify(zoneAllocationResolver).getExpiringZoneBindingCounts(resolvedZone1);
+    verify(zoneAllocationResolver).getExpiringZoneBindingCounts(resolvedZone2);
+
+    verifyNoMoreInteractions(envoyResourceManagement,
+        zoneStorage, monitorEventProducer, resourceApi, zoneAllocationResolver
+    );
+  }
+
+  @Test
+  public void testGetZoneAssignmentCounts_PerTenant_NotFound() {
+    when(zoneRepository.findAllZoneNameForTenant("t-1", Pageable.unpaged()))
+        .thenReturn(Page.empty());
+    Assertions.assertThatThrownBy(() -> monitorManagement.getZoneAssignmentCountForTenant("t-1").join())
+        .isInstanceOf(NotFoundException.class)
+        .hasMessage("No zones present for tenant t-1");
+  }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolverTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolverTest.java
@@ -409,4 +409,44 @@ public class ZoneAllocationResolverTest {
     );
   }
 
+
+  @Test
+  public void testGetExpiringZoneBindingCounts() {
+    final String tenantId = randomAlphanumeric(10);
+    final ResolvedZone zone = ResolvedZone.resolveZone(tenantId, randomAlphanumeric(5));
+
+    when(zoneStorage.getExpiringPollerResourceIdsInZone(any()))
+        .thenReturn(CompletableFuture.completedFuture(List.of("poller-1", "poller-2", "poller-3")));
+
+    when(zoneStorage.getResourceIdToEnvoyIdMap(any()))
+        .thenReturn(CompletableFuture.completedFuture(Map.of(
+            "poller-1", "e-1",
+            "poller-2", "e-2",
+            "poller-3", "e-3"
+        )));
+
+    final Monitor monitor = persistNewMonitor(tenantId, Map.of(), List.of(zone.getName()));
+    persistBoundMonitors(2, zone.getName(), "e-1", "poller-1", monitor);
+    // poller-2 is empty one
+    persistBoundMonitors(1, zone.getName(), "e-3", "poller-3", monitor);
+
+    // EXECUTE
+
+    final Map<EnvoyResourcePair, Integer> result = zoneAllocationResolver
+        .getExpiringZoneBindingCounts(zone)
+        .join();
+
+    // VERIFY
+
+    assertThat(result).isEqualTo(Map.of(
+        new EnvoyResourcePair().setEnvoyId("e-1").setResourceId("poller-1"), 2,
+        new EnvoyResourcePair().setEnvoyId("e-2").setResourceId("poller-2"), 0,
+        new EnvoyResourcePair().setEnvoyId("e-3").setResourceId("poller-3"), 1
+    ));
+
+    verify(zoneStorage).getExpiringPollerResourceIdsInZone(zone);
+    verify(zoneStorage).getResourceIdToEnvoyIdMap(zone);
+
+    verifyNoMoreInteractions(zoneStorage);
+  }
 }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolverTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/ZoneAllocationResolverTest.java
@@ -355,7 +355,7 @@ public class ZoneAllocationResolverTest {
     // EXECUTE
 
     final Map<EnvoyResourcePair, Integer> result = zoneAllocationResolver
-        .getZoneBindingCounts(zone)
+        .getActiveZoneBindingCounts(zone)
         .join();
 
     // VERIFY

--- a/src/test/resources/ZoneApiControllerTest/privateZoneAssignmentCountPerTenant_valid.json
+++ b/src/test/resources/ZoneApiControllerTest/privateZoneAssignmentCountPerTenant_valid.json
@@ -1,0 +1,19 @@
+{
+  "z-1": [
+    {
+      "resourceId": "r-1",
+      "envoyId": "e-1",
+      "assignments": 3,
+      "connected": true
+    }
+  ],
+  "z-2": [
+    {
+      "resourceId": "r-2",
+      "envoyId": "e-2",
+      "assignments": 1,
+      "connected": false
+    }
+  ],
+  "z-3": []
+}

--- a/src/test/resources/ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json
+++ b/src/test/resources/ZoneApiControllerTest/privateZoneAssignmentCounts_valid.json
@@ -2,6 +2,13 @@
   {
     "resourceId": "r-1",
     "envoyId": "e-1",
-    "assignments": 3
+    "assignments": 3,
+    "connected": true
+  },
+  {
+    "resourceId": "r-2",
+    "envoyId": "e-2",
+    "assignments": 1,
+    "connected": false
   }
 ]

--- a/src/test/resources/ZoneApiControllerTest/publicZoneAssignmentCountPerTenant_valid.json
+++ b/src/test/resources/ZoneApiControllerTest/publicZoneAssignmentCountPerTenant_valid.json
@@ -1,0 +1,19 @@
+{
+  "public/west": [
+    {
+      "resourceId": "r-1",
+      "envoyId": "e-1",
+      "assignments": 3,
+      "connected": true
+    }
+  ],
+  "public/east": [
+    {
+      "resourceId": "r-2",
+      "envoyId": "e-2",
+      "assignments": 1,
+      "connected": false
+    }
+  ],
+  "public/north": []
+}


### PR DESCRIPTION
# Resolves
https://jira.rax.io/browse/SALUS-992

# What
Added apis to get detached but pending timeout pollers

# How
Added 2 new apis for public and admin to get the list of detached but pending timeout pollers.

# How to test
This can be tested via Rest call.