### PR TITLE
Fix tests to use lowercase enum values

### DIFF
--- a/src/test/resources/BoundMonitorDTOJsonTest/testAllPopulated.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testAllPopulated.json
@@ -5,7 +5,7 @@
   "monitorSummary": {},
   "tenantId": "t-1",
   "resourceId": "r-1",
-  "selectorScope": "REMOTE",
+  "selectorScope": "remote",
   "agentType": "TELEGRAF",
   "renderedContent": "{}",
   "envoyId": "e-1",

--- a/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nonNullEnvoy.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nonNullEnvoy.json
@@ -5,7 +5,7 @@
   "monitorSummary": {},
   "tenantId": "t-1",
   "resourceId": "r-1",
-  "selectorScope": "LOCAL",
+  "selectorScope": "local",
   "agentType": "TELEGRAF",
   "renderedContent": "{}",
   "envoyId": "e-1",

--- a/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nullEnvoy.json
+++ b/src/test/resources/BoundMonitorDTOJsonTest/testEmptyZone_nullEnvoy.json
@@ -5,7 +5,7 @@
   "monitorSummary": {},
   "tenantId": "t-1",
   "resourceId": "r-1",
-  "selectorScope": "LOCAL",
+  "selectorScope": "local",
   "agentType": "TELEGRAF",
   "renderedContent": "{}",
   "envoyId": null,

--- a/src/test/resources/MonitorTranslationApiControllerTest/create_req.json
+++ b/src/test/resources/MonitorTranslationApiControllerTest/create_req.json
@@ -4,7 +4,7 @@
   "agentType": "TELEGRAF",
   "agentVersions": ">= 1.12.0",
   "monitorType": "cpu",
-  "selectorScope": "LOCAL",
+  "selectorScope": "local",
   "translatorSpec": {
     "type": "renameFieldKey",
     "from": "from-field",

--- a/src/test/resources/MonitorTranslationApiControllerTest/create_resp.json
+++ b/src/test/resources/MonitorTranslationApiControllerTest/create_resp.json
@@ -5,7 +5,7 @@
   "agentType": "TELEGRAF",
   "agentVersions": ">= 1.12.0",
   "monitorType": "cpu",
-  "selectorScope": "LOCAL",
+  "selectorScope": "local",
   "translatorSpec": {
     "type": "renameFieldKey",
     "from": "from-field",

--- a/src/test/resources/MonitorTranslationApiControllerTest/getAll_resp.json
+++ b/src/test/resources/MonitorTranslationApiControllerTest/getAll_resp.json
@@ -7,7 +7,7 @@
       "agentType": "TELEGRAF",
       "agentVersions": ">= 1.12.0",
       "monitorType": "cpu",
-      "selectorScope": "LOCAL",
+      "selectorScope": "local",
       "translatorSpec": {
         "type": "renameFieldKey",
         "from": "from-field",
@@ -21,7 +21,7 @@
       "agentType": "TELEGRAF",
       "agentVersions": "< 1.12.0",
       "monitorType": "http",
-      "selectorScope": "REMOTE",
+      "selectorScope": "remote",
       "translatorSpec": {
         "type": "renameFieldKey",
         "from": "from-field",

--- a/src/test/resources/MonitorTranslationApiControllerTest/getById_resp.json
+++ b/src/test/resources/MonitorTranslationApiControllerTest/getById_resp.json
@@ -5,7 +5,7 @@
   "agentType": "TELEGRAF",
   "agentVersions": ">= 1.12.0",
   "monitorType": "cpu",
-  "selectorScope": "LOCAL",
+  "selectorScope": "local",
   "translatorSpec": {
     "type": "renameFieldKey",
     "from": "from-field",


### PR DESCRIPTION
Follows on from https://github.com/racker/salus-telemetry-model/pull/168

Makes fields in API requests/responses more consistent.

## TODO

I think AgentType is the only one left as uppercase so maybe that should be changed too, but I'm less concerned about it for now.