### PR TITLE
Send MonitorChangeEvents on all write operations

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorEventProducer.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorEventProducer.java
@@ -1,8 +1,11 @@
 package com.rackspace.salus.monitor_management.services;
 
+import static com.rackspace.salus.telemetry.messaging.KafkaMessageKeyBuilder.buildMessageKey;
+
 import com.rackspace.salus.common.errors.RuntimeKafkaException;
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
+import com.rackspace.salus.telemetry.messaging.MonitorChangeEvent;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,23 +17,35 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class MonitorEventProducer {
 
-    private final KafkaTemplate<String,Object> kafkaTemplate;
-    private final KafkaTopicProperties properties;
+  private final KafkaTemplate<String, Object> kafkaTemplate;
+  private final KafkaTopicProperties properties;
 
-    @Autowired
-    public MonitorEventProducer(KafkaTemplate<String,Object> kafkaTemplate, KafkaTopicProperties properties) {
-        this.kafkaTemplate = kafkaTemplate;
-        this.properties= properties;
+  @Autowired
+  public MonitorEventProducer(KafkaTemplate<String, Object> kafkaTemplate,
+      KafkaTopicProperties properties) {
+    this.kafkaTemplate = kafkaTemplate;
+    this.properties = properties;
+  }
+
+  public void sendMonitorEvent(MonitorBoundEvent event) {
+    final String topic = properties.getMonitors();
+
+    log.debug("Sending monitorBoundEvent={} on topic={}", event, topic);
+    try {
+      kafkaTemplate.send(topic, buildMessageKey(event), event).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeKafkaException(e);
     }
+  }
 
-    public void sendMonitorEvent(MonitorBoundEvent event) {
-        final String topic = properties.getMonitors();
+  public void sendMonitorChangeEvent(MonitorChangeEvent event) {
+    final String topic = properties.getMonitorChanges();
 
-        log.debug("Sending monitorBoundEvent={} on topic={}", event, topic);
-        try {
-            kafkaTemplate.send(topic, event.getEnvoyId(), event).get();
-        } catch (InterruptedException|ExecutionException e) {
-            throw new RuntimeKafkaException(e);
-        }
+    log.debug("Sending monitorChangeEvent={} on topic={}", event, topic);
+    try {
+      kafkaTemplate.send(topic, buildMessageKey(event), event).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeKafkaException(e);
     }
+  }
 }

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -56,6 +56,7 @@ import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.messaging.MetadataPolicyEvent;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
+import com.rackspace.salus.telemetry.messaging.MonitorChangeEvent;
 import com.rackspace.salus.telemetry.messaging.MonitorPolicyEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.messaging.TenantPolicyChangeEvent;
@@ -308,6 +309,7 @@ public class MonitorManagement {
 
     final Set<String> affectedEnvoys = bindMonitor(tenantId, monitor, monitor.getZones());
     sendMonitorBoundEvents(affectedEnvoys);
+    sendMonitorChangeEvent(monitor);
     createMonitorSuccess.tags(MetricTags.OPERATION_METRIC_TAG, MetricTagValues.CREATE_OPERATION,MetricTags.OBJECT_TYPE_METRIC_TAG,"monitor").register(meterRegistry).increment();
     return monitor;
   }
@@ -374,6 +376,7 @@ public class MonitorManagement {
         clonedMonitor, affectedEnvoys.size(), newTenant);
 
     sendMonitorBoundEvents(affectedEnvoys);
+    sendMonitorChangeEvent(clonedMonitor);
     createMonitorSuccess.tags(MetricTags.OPERATION_METRIC_TAG,"clone",MetricTags.OBJECT_TYPE_METRIC_TAG,"monitor").register(meterRegistry).increment();
     return clonedMonitor;
   }
@@ -622,6 +625,17 @@ public class MonitorManagement {
         .forEach(monitorEventProducer::sendMonitorEvent);
   }
 
+  /**
+   * Sends monitor change events for a particular monitor.
+   * @param monitor The monitor that has been modified.
+   */
+  void sendMonitorChangeEvent(Monitor monitor) {
+    monitorEventProducer.sendMonitorChangeEvent(
+        new MonitorChangeEvent()
+            .setTenantId(monitor.getTenantId())
+            .setMonitorId(monitor.getId()));
+  }
+
   BoundMonitor bindAgentMonitor(Monitor monitor, ResourceDTO resource, String envoyId)
       throws InvalidTemplateException {
     return new BoundMonitor()
@@ -815,6 +829,7 @@ public class MonitorManagement {
     monitor = monitorRepository.save(monitor);
 
     sendMonitorBoundEvents(affectedEnvoys);
+    sendMonitorChangeEvent(monitor);
     createMonitorSuccess.tags(MetricTags.OPERATION_METRIC_TAG, MetricTagValues.UPDATE_OPERATION,MetricTags.OBJECT_TYPE_METRIC_TAG,"monitor").register(meterRegistry).increment();
     return monitor;
   }
@@ -1361,6 +1376,7 @@ public class MonitorManagement {
     }
 
     unbindAndRemoveMonitor(monitor);
+    sendMonitorChangeEvent(monitor);
     createMonitorSuccess.tags(MetricTags.OPERATION_METRIC_TAG, MetricTagValues.REMOVE_OPERATION,MetricTags.OBJECT_TYPE_METRIC_TAG,"monitor").register(meterRegistry).increment();
   }
 
@@ -2305,9 +2321,9 @@ public class MonitorManagement {
 
   @Async
   public CompletableFuture<Void> removeAllTenantMonitors(String tenantId, boolean sendEvents) {
-    if(sendEvents) {
+    if (sendEvents) {
       getMonitors(tenantId, Pageable.unpaged()).forEach(monitor -> removeMonitor(tenantId, monitor.getId()));
-    }else {
+    } else {
       unbindByTenantAndMonitorId(tenantId,
           getMonitors(tenantId, Pageable.unpaged()).get()
               .map(Monitor::getId)

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagementExcludeResourceIdsTest.java
@@ -40,6 +40,7 @@ import com.rackspace.salus.telemetry.entities.Resource;
 import com.rackspace.salus.telemetry.etcd.services.EnvoyResourceManagement;
 import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
+import com.rackspace.salus.telemetry.messaging.MonitorChangeEvent;
 import com.rackspace.salus.telemetry.messaging.ResourceEvent;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
@@ -322,6 +323,12 @@ public class MonitorManagementExcludeResourceIdsTest {
     verify(envoyResourceManagement).getOne("t-1", "r-exclude-include");
     verify(envoyResourceManagement, never()).getOne("t-1", "r-exclude-exclude");
 
+    // once for create and once for update
+    verify(monitorEventProducer, times(2)).sendMonitorChangeEvent(
+        new MonitorChangeEvent()
+            .setTenantId(original.getTenantId())
+            .setMonitorId(original.getId()));
+
     verifyNoMoreInteractions(resourceApi, envoyResourceManagement, monitorEventProducer);
   }
 
@@ -426,6 +433,12 @@ public class MonitorManagementExcludeResourceIdsTest {
 
     verify(envoyResourceManagement).getOne("t-1", "r-absent-include");
     verify(envoyResourceManagement, never()).getOne("t-1", "r-absent-exclude");
+
+    // once for create and once for update
+    verify(monitorEventProducer, times(2)).sendMonitorChangeEvent(
+        new MonitorChangeEvent()
+            .setTenantId(original.getTenantId())
+            .setMonitorId(original.getId()));
 
     verifyNoMoreInteractions(resourceApi, envoyResourceManagement, monitorEventProducer);
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_MetadataPolicyTest.java
@@ -60,6 +60,7 @@ import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
 import com.rackspace.salus.telemetry.messaging.MetadataPolicyEvent;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
+import com.rackspace.salus.telemetry.messaging.MonitorChangeEvent;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
@@ -344,6 +345,11 @@ public class MonitorManagement_MetadataPolicyTest {
         new MonitorBoundEvent().setEnvoyId("e-new")
     );
 
+    verify(monitorEventProducer).sendMonitorChangeEvent(
+        new MonitorChangeEvent()
+            .setTenantId(monitor.getTenantId())
+            .setMonitorId(monitor.getId()));
+
     verifyNoMoreInteractions(monitorEventProducer);
   }
 
@@ -421,6 +427,11 @@ public class MonitorManagement_MetadataPolicyTest {
         new MonitorBoundEvent().setEnvoyId("e-new")
     );
 
+    verify(monitorEventProducer).sendMonitorChangeEvent(
+        new MonitorChangeEvent()
+            .setTenantId(monitor.getTenantId())
+            .setMonitorId(monitor.getId()));
+
     verifyNoMoreInteractions(monitorEventProducer);
   }
 
@@ -494,6 +505,11 @@ public class MonitorManagement_MetadataPolicyTest {
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent().setEnvoyId("e-new")
     );
+
+    verify(monitorEventProducer).sendMonitorChangeEvent(
+        new MonitorChangeEvent()
+            .setTenantId(monitor.getTenantId())
+            .setMonitorId(monitor.getId()));
 
     verify(zoneManagement).getAvailableZonesForTenant(eq(tenantId), any());
 
@@ -888,6 +904,12 @@ public class MonitorManagement_MetadataPolicyTest {
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent().setEnvoyId("e-new")
     );
+
+    verify(monitorEventProducer).sendMonitorChangeEvent(
+        new MonitorChangeEvent()
+            .setTenantId(clonedMonitor.getTenantId())
+            .setMonitorId(clonedMonitor.getId()));
+
     verifyNoMoreInteractions(boundMonitorRepository, monitorEventProducer);
   }
 

--- a/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/services/MonitorManagement_ZoneBindingsTest.java
@@ -55,6 +55,7 @@ import com.rackspace.salus.telemetry.etcd.services.ZoneStorage;
 import com.rackspace.salus.telemetry.etcd.types.EnvoyResourcePair;
 import com.rackspace.salus.telemetry.etcd.types.ResolvedZone;
 import com.rackspace.salus.telemetry.messaging.MonitorBoundEvent;
+import com.rackspace.salus.telemetry.messaging.MonitorChangeEvent;
 import com.rackspace.salus.telemetry.model.AgentType;
 import com.rackspace.salus.telemetry.model.ConfigSelectorScope;
 import com.rackspace.salus.telemetry.model.LabelSelectorMethod;
@@ -786,8 +787,12 @@ public class MonitorManagement_ZoneBindingsTest {
 
     verify(monitorEventProducer).sendMonitorEvent(
         new MonitorBoundEvent()
-            .setEnvoyId("e-goner")
-    );
+            .setEnvoyId("e-goner"));
+
+    verify(monitorEventProducer).sendMonitorChangeEvent(
+        new MonitorChangeEvent()
+            .setTenantId(monitor.getTenantId())
+            .setMonitorId(monitor.getId()));
 
     verifyNoMoreInteractions(zoneStorage, monitorEventProducer, zoneAllocationResolver);
   }
@@ -816,6 +821,11 @@ public class MonitorManagement_ZoneBindingsTest {
         new MonitorBoundEvent()
             .setEnvoyId("e-goner")
     );
+
+    verify(monitorEventProducer).sendMonitorChangeEvent(
+        new MonitorChangeEvent()
+            .setTenantId(monitor.getTenantId())
+            .setMonitorId(monitor.getId()));
 
     verifyNoMoreInteractions(zoneStorage, monitorEventProducer, zoneAllocationResolver);
   }
@@ -911,6 +921,11 @@ public class MonitorManagement_ZoneBindingsTest {
         new MonitorBoundEvent().setEnvoyId("e-new")
     );
 
+    verify(monitorEventProducer).sendMonitorChangeEvent(
+        new MonitorChangeEvent()
+            .setTenantId(monitor.getTenantId())
+            .setMonitorId(monitor.getId()));
+
     verify(zoneManagement).getAvailableZonesForTenant(tenantId, Pageable.unpaged());
 
     verifyNoMoreInteractions(envoyResourceManagement, resourceApi,
@@ -947,6 +962,11 @@ public class MonitorManagement_ZoneBindingsTest {
     );
 
     verify(zoneManagement).getAvailableZonesForTenant(tenantId, Pageable.unpaged());
+
+    verify(monitorEventProducer).sendMonitorChangeEvent(
+        new MonitorChangeEvent()
+            .setTenantId(monitor.getTenantId())
+            .setMonitorId(monitor.getId()));
 
     verifyNoMoreInteractions(envoyResourceManagement, resourceApi,
         zoneStorage, monitorEventProducer, zoneManagement, zoneAllocationResolver


### PR DESCRIPTION
# What

Send `MonitorChangeEvent`s to kafka for any create, clone, update, delete.

Also formatted MonitorEventProducer.java so you'll want to ignore white space changes.

# How to test

Updated existing tests to additionally check for the new producer operations.

This addition identified some previous tests were incorrect, so I've updated them as well.

# Why

Event-Engine-Processor will read these and clear its own caches whenever a monitor changes.

That service only really needs update/delete events but I've included them in all places to make it consistent with what is needed in the task service.