### PR TITLE
made deeper response message from JDBC error in REST Response.

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/controller/RestExceptionHandler.java
@@ -75,7 +75,7 @@ public class RestExceptionHandler extends
         monitorManagementErrorCounter.tags(MetricTags.URI_METRIC_TAG,request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE).toString(),
             MetricTags.EXCEPTION_METRIC_TAG,e.getClass().getSimpleName()).register(meterRegistry).increment();
         if (e instanceof DataIntegrityViolationException) {
-            return respondWith(request, HttpStatus.BAD_REQUEST, e.getMessage());
+            return respondWith(request, HttpStatus.BAD_REQUEST, ((DataIntegrityViolationException) e).getRootCause().getMessage());
         } else {
             return respondWith(request, HttpStatus.SERVICE_UNAVAILABLE, ResponseMessages.jdbcExceptionMessage);
         }


### PR DESCRIPTION
# Resolves

[SALUS-1067](https://jira.rax.io/browse/SALUS-1067)

# What

made deeper response message from JDBC error in REST Response.

# How

Used getRootCause().getMessage to get original throwable message
