### PR TITLE
Added metadata field to monitors

### DIFF
--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorConversionService.java
@@ -96,6 +96,7 @@ public class MonitorConversionService {
         .setLabelSelectorMethod(monitor.getLabelSelectorMethod())
         .setResourceId(monitor.getResourceId())
         .setExcludedResourceIds(monitor.getExcludedResourceIds())
+        .setMetadata(monitor.getMetadata())
         .setDetails(convertContentToDetails(monitor));
 
     if (StringUtils.isNotBlank(monitor.getResourceId())) {
@@ -114,6 +115,7 @@ public class MonitorConversionService {
         .setLabelSelectorMethod(monitor.getLabelSelectorMethod())
         .setResourceId(monitor.getResourceId())
         .setExcludedResourceIds(monitor.getExcludedResourceIds())
+        .setMetadata(monitor.getMetadata())
         .setInterval(monitor.getInterval())
         .setDetails(convertContentToDetails(monitor))
         .setPolicy(monitor.getPolicyId() != null)

--- a/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/services/MonitorManagement.java
@@ -297,6 +297,7 @@ public class MonitorManagement {
         .setAgentType(newMonitor.getAgentType())
         .setSelectorScope(newMonitor.getSelectorScope())
         .setZones(newMonitor.getZones())
+        .setMetadata(newMonitor.getMetadata())
         .setPluginMetadataFields(newMonitor.getPluginMetadataFields());
 
     if (newMonitor.getLabelSelectorMethod() != null) {
@@ -819,6 +820,13 @@ public class MonitorManagement {
       monitor.setMonitorName(updatedValues.getMonitorName());
     } else if (updatedValues.getMonitorName() != null) {
       monitor.setMonitorName(updatedValues.getMonitorName());
+    }
+
+    // Update the metadata if needed
+    if (patchOperation) {
+      monitor.setMetadata(updatedValues.getMetadata());
+    } else if (updatedValues.getMetadata() != null) {
+      monitor.setMetadata(updatedValues.getMetadata());
     }
 
     // Update any metadata fields on the monitor if required.

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorInput.java
@@ -54,6 +54,8 @@ public class DetailedMonitorInput {
    */
   Set<String> excludedResourceIds;
 
+  Map<String,String> metadata;
+
   Duration interval;
 
   @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\",\"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false,\"reportActive\": false, \"totalcpu\": true}}")

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutput.java
@@ -36,6 +36,7 @@ public class DetailedMonitorOutput {
     LabelSelectorMethod labelSelectorMethod;
     String resourceId;
     Set<String> excludedResourceIds;
+    Map<String,String> metadata;
     Duration interval;
     @ApiModelProperty(value="details", required=true, example="\"details\":{ \"type\": \"local|remote\", \"plugin\":{ \"type\":\"cpu\", \"collectCpuTime\": false, \"percpu\": false, \"reportActive\": false, \"totalcpu\": true} }")
     MonitorDetails details;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorCU.java
@@ -60,6 +60,8 @@ public class MonitorCU implements Serializable {
 
     Set<String> excludedResourceIds;
 
+    Map<String,String> metadata;
+
     String resourceId;
 
     Duration interval;

--- a/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDTO.java
+++ b/src/main/java/com/rackspace/salus/monitor_management/web/model/MonitorDTO.java
@@ -54,6 +54,8 @@ public class MonitorDTO {
 
   Set<String> excludedResourceIds;
 
+  Map<String,String> metadata;
+
   String createdTimestamp;
 
   String updatedTimestamp;
@@ -79,6 +81,7 @@ public class MonitorDTO {
     this.agentType = monitor.getAgentType();
     this.selectorScope = monitor.getSelectorScope();
     this.zones = monitor.getZones();
+    this.metadata = monitor.getMetadata();
     this.createdTimestamp = DateTimeFormatter.ISO_INSTANT.format(monitor.getCreatedTimestamp());
     this.updatedTimestamp = DateTimeFormatter.ISO_INSTANT.format(monitor.getUpdatedTimestamp());
   }

--- a/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
+++ b/src/test/java/com/rackspace/salus/monitor_management/web/model/DetailedMonitorOutputTest.java
@@ -53,6 +53,7 @@ public class DetailedMonitorOutputTest {
         .setId("m-1")
         .setResourceId("r-1")
         .setExcludedResourceIds(Set.of("r-excluded"))
+        .setMetadata(Map.of("metaKey", "metaValue"))
         .setName("name-1")
         .setLabelSelector(
             Map.of("key1", "val1", "key2", "val2")
@@ -81,6 +82,7 @@ public class DetailedMonitorOutputTest {
         .setId("m-1")
         .setResourceId("r-1")
         .setExcludedResourceIds(Set.of("r-excluded"))
+        .setMetadata(Map.of("metaKey", "metaValue"))
         .setName("name-1")
         .setLabelSelector(
             Map.of("key1", "val1", "key2", "val2")

--- a/src/test/resources/DetailedMonitorOutputTest/local.json
+++ b/src/test/resources/DetailedMonitorOutputTest/local.json
@@ -2,6 +2,7 @@
   "id": "m-1",
   "resourceId": "r-1",
   "excludedResourceIds": ["r-excluded"],
+  "metadata": {"metaKey": "metaValue"},
   "name": "name-1",
   "labelSelector": {
     "key1": "val1",

--- a/src/test/resources/DetailedMonitorOutputTest/remote.json
+++ b/src/test/resources/DetailedMonitorOutputTest/remote.json
@@ -2,6 +2,7 @@
   "id": "m-1",
   "resourceId": "r-1",
   "excludedResourceIds": ["r-excluded"],
+  "metadata": {"metaKey": "metaValue"},
   "name": "name-1",
   "labelSelector": {
     "key1": "val1",


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-1104

# What

Needed to convey fields brought over from migrating MaaS checks.

# How

Added a metadata `Map<String,String>` that is a JSON encoded text column.

## How to test

Updated unit tests

# Depends on

- https://github.com/racker/salus-telemetry-model/pull/178